### PR TITLE
Don't delete images with version tags

### DIFF
--- a/.github/workflows/ghcr-actions.yml
+++ b/.github/workflows/ghcr-actions.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           image-names: sensitive-data-archive
           filter-tags: PR*,sha-*
+          skip-tags: v*
           cut-off: A week ago UTC
           account-type: org
           org-name: ${{ github.repository_owner }}


### PR DESCRIPTION
It seems the image deletion action is inclusive rather than exclusive in how it selects the images, so we need to make sure that the images with proper version tags doesn't get deleted.