### PR TITLE
Added missing properties for posix mapper

### DIFF
--- a/charts/sda-svc/templates/mapper-deploy.yaml
+++ b/charts/sda-svc/templates/mapper-deploy.yaml
@@ -191,6 +191,10 @@ spec:
         volumeMounts:
         - name: tls
           mountPath: {{ template "tlsPath" . }}
+        {{- if eq "posix" .Values.global.inbox.storageType }}
+        - name: inbox
+          mountPath: {{ .Values.global.inbox.path | quote }}
+        {{- end }}
       volumes:
         - name: {{ ternary "tls" "tls-certs" (empty .Values.global.pkiPermissions) }}
           projected:
@@ -209,5 +213,16 @@ spec:
             sizeLimit: 10Mi
       {{- end }}
     {{- end }}
+      {{- if eq "posix" .Values.global.inbox.storageType }}
+        - name: inbox
+        {{- if .Values.global.inbox.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.inbox.existingClaim }}
+        {{- else }}
+          nfs:
+            server: {{ required "An inbox NFS server is required" .Values.global.inbox.nfsServer | quote }}
+            path: {{ if .Values.global.inbox.nfsPath }}{{ .Values.global.inbox.nfsPath | quote }}{{ else }}{{ "/" }}{{ end }}
+        {{- end }}
+      {{- end }}
       restartPolicy: Always
 {{- end }}


### PR DESCRIPTION
When running the application in federated and inbox mode as posix, the mapper container is not started.

Log error:
`{"level": "fatal", "msg": "stat /inbox/: no such file or directory", "time": "2023-09-13T09:56:45Z"}`

The error is generated by the following changes to the mapper:
```
  inbox, err := storage.NewBackend(conf.Inbox)
  if err != nil {
           log.Fatal(err)
  }
```