### PR TITLE
[FEGA usecase] merge `finalize` from `sda-pipeline` into `sda`

### DIFF
--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -159,6 +159,31 @@ services:
       - ./sda/config.yaml:/config.yaml
       - shared:/shared
 
+  finalize:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
+    command: [ sda-finalize ]
+    container_name: finalize
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=finalize
+      - BROKER_USER=finalize
+      - BROKER_QUEUE=accession
+      - BROKER_ROUTINGKEY=completed
+      - DB_PASSWORD=finalize
+      - DB_USER=finalize
+    restart: always
+    volumes:
+      - ./sda/config.yaml:/config.yaml
+      - shared:/shared
+
   oidc:
     container_name: oidc
     command:
@@ -193,6 +218,8 @@ services:
     depends_on:
       credentials:
         condition: service_completed_successfully
+      finalize:
+        condition: service_started
       ingest:
         condition: service_started
       s3inbox:

--- a/.github/integration/sda/config.yaml
+++ b/.github/integration/sda/config.yaml
@@ -10,6 +10,15 @@ archive:
   secretKey: "secretKey"
   bucket: "archive"
   region: "us-east-1"
+backup:
+  type: s3
+  url: "http://s3"
+  port: 9000
+  readypath: "/minio/health/ready"
+  accessKey: "access"
+  secretKey: "secretKey"
+  bucket: "backup"
+  region: "us-east-1"
 inbox:
   type: s3
   url: "http://s3"

--- a/.github/integration/tests/sda/30_finalize_test.sh
+++ b/.github/integration/tests/sda/30_finalize_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+cd shared || true
+
+i=1
+while [ $i -le "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ | jq -r '.messages_ready')" ]; do
+    ## get correlation id from upload message
+    MSG=$(
+        curl -s -X POST \
+            -H "content-type:application/json" \
+            -u guest:guest http://rabbitmq:15672/api/queues/sda/verified/get \
+            -d '{"count":1,"encoding":"auto","ackmode":"ack_requeue_false"}'
+    )
+
+    corrid=$(jq -r '.[0].properties.correlation_id' <<< "$MSG")
+    user=$(jq -r '.[0].payload|fromjson|.user' <<< "$MSG")
+    filepath=$(jq -r '.[0].payload|fromjson|.filepath' <<< "$MSG")
+    decrypted_checksums=$(jq -r '.[0].payload|fromjson|.decrypted_checksums|tostring' <<< "$MSG")
+
+    ## publish message to trigger backup
+    properties=$(
+        jq -c -n \
+            --argjson delivery_mode 2 \
+            --arg correlation_id "$corrid" \
+            --arg content_encoding UTF-8 \
+            --arg content_type application/json \
+            '$ARGS.named'
+    )
+
+    accession_payload=$(
+        jq -r -c -n \
+            --arg type accession \
+            --arg user "$user" \
+            --arg filepath "$filepath" \
+            --arg accession_id "EGAF7490000000$i" \
+            --argjson decrypted_checksums "$decrypted_checksums" \
+            '$ARGS.named|@base64'
+    )
+
+    accession_body=$(
+        jq -c -n \
+            --arg vhost sda \
+            --arg name sda \
+            --argjson properties "$properties" \
+            --arg routing_key "accession" \
+            --arg payload_encoding base64 \
+            --arg payload "$accession_payload" \
+            '$ARGS.named'
+    )
+
+    curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -d "$accession_body"
+
+    i=$(( i + 1 ))
+done
+
+echo "waiting for finalize to complete"
+
+until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/completed/ | jq -r '.messages_ready')" -eq 2 ]; do
+    echo "waiting for finalize to complete"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for finalize to complete"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "finalize completed successfully"

--- a/sda/cmd/finalize/finalize.go
+++ b/sda/cmd/finalize/finalize.go
@@ -1,0 +1,182 @@
+// The finalize command accepts messages with accessionIDs for
+// ingested files and registers them in the database.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/neicnordic/sensitive-data-archive/internal/broker"
+	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
+	"github.com/neicnordic/sensitive-data-archive/internal/schema"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	forever := make(chan bool)
+	conf, err := config.NewConfig("finalize")
+	if err != nil {
+		log.Fatal(err)
+	}
+	mq, err := broker.NewMQ(conf.Broker)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db, err := database.NewSDAdb(conf.Database)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer mq.Channel.Close()
+	defer mq.Connection.Close()
+	defer db.Close()
+
+	go func() {
+		connError := mq.ConnectionWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
+
+	go func() {
+		connError := mq.ChannelWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
+
+	log.Info("Starting finalize service")
+	var message schema.IngestionAccession
+
+	go func() {
+		messages, err := mq.GetMessages(conf.Broker.Queue)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for delivered := range messages {
+			log.Debugf("Received a message (corr-id: %s, message: %s)", delivered.CorrelationId, delivered.Body)
+			err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-accession.json", conf.Broker.SchemasPath), delivered.Body)
+			if err != nil {
+				log.Errorf("validation of incoming message (ingestion-accession) failed, reason: %v ", err)
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("Failed acking canceled work, reason: %v", err)
+				}
+
+				continue
+			}
+
+			// we unmarshal the message in the validation step so this is safe to do
+			_ = json.Unmarshal(delivered.Body, &message)
+			// If the file has been canceled by the uploader, don't spend time working on it.
+			status, err := db.GetFileStatus(delivered.CorrelationId)
+			if err != nil {
+				log.Errorf("failed to get file status, reason: %v", err)
+			}
+			if status == "disabled" {
+				log.Infof("file with correlation ID: %s is disabled, stopping work", delivered.CorrelationId)
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("Failed acking canceled work, reason: %v", err)
+				}
+
+				continue
+			}
+
+			// Extract the sha256 from the message and use it for the database
+			var checksumSha256 string
+			for _, checksum := range message.DecryptedChecksums {
+				if checksum.Type == "sha256" {
+					checksumSha256 = checksum.Value
+				}
+			}
+
+			accessionIDExists, err := db.CheckAccessionIDExists(message.AccessionID)
+			if err != nil {
+				log.Errorf("CheckAccessionIdExists failed, reason: %v ", err)
+				if err := delivered.Nack(false, true); err != nil {
+					log.Errorf("failed to Nack message, reason: (%v)", err)
+				}
+
+				continue
+			}
+
+			if accessionIDExists {
+				log.Debugf("Seems accession ID already exists (corr-id: %s, accessionid: %s", delivered.CorrelationId, message.AccessionID)
+				// Send the message to an error queue so it can be analyzed.
+				fileError := broker.InfoError{
+					Error:           "There is a conflict regarding the file accessionID",
+					Reason:          "The Accession ID already exists in the database, skipping marking it ready.",
+					OriginalMessage: message,
+				}
+				body, _ := json.Marshal(fileError)
+
+				// Send the message to an error queue so it can be analyzed.
+				if e := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "error", body); e != nil {
+					log.Errorf("failed to publish message, reason: (%v)", err)
+				}
+
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("failed to Ack message, reason: (%v)", err)
+				}
+
+				continue
+
+			}
+
+			fileID, err := db.GetFileID(delivered.CorrelationId)
+			if err != nil {
+				log.Errorf("failed to get ID for file, reason: %v", err)
+				if err := delivered.Nack(false, true); err != nil {
+					log.Errorf("failed to Nack message, reason: (%v)", err)
+				}
+
+				continue
+			}
+
+			if err := db.SetAccessionID(message.AccessionID, message.User, message.FilePath, checksumSha256); err != nil {
+				log.Errorf("Failed to set accessionID for file with corrID: %v, reason: %v", delivered.CorrelationId, err)
+				if err := delivered.Nack(false, true); err != nil {
+					log.Errorf("failed to Nack message, reason: (%v)", err)
+				}
+
+				continue
+			}
+
+			// Mark file as "ready"
+			if err := db.UpdateFileStatus(fileID, "ready", delivered.CorrelationId, "finalize", string(delivered.Body)); err != nil {
+				log.Errorf("set status ready failed, reason: (%v)", err)
+				if err := delivered.Nack(false, true); err != nil {
+					log.Errorf("failed to Nack message, reason: (%v)", err)
+				}
+
+				continue
+			}
+
+			c := schema.IngestionCompletion{
+				User:               message.User,
+				FilePath:           message.FilePath,
+				AccessionID:        message.AccessionID,
+				DecryptedChecksums: message.DecryptedChecksums,
+			}
+			completeMsg, _ := json.Marshal(&c)
+			err = schema.ValidateJSON(fmt.Sprintf("%s/ingestion-completion.json", conf.Broker.SchemasPath), completeMsg)
+			if err != nil {
+				log.Errorf("Validation of outgoing message failed, reason: (%v)", err)
+
+				continue
+			}
+
+			if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingKey, completeMsg); err != nil {
+				// TODO fix resend mechanism
+				log.Errorf("failed to publish message, reason: (%v)", err)
+
+				continue
+			}
+
+			if err := delivered.Ack(false); err != nil {
+				log.Errorf("failed to Ack message, reason: (%v)", err)
+			}
+		}
+	}()
+
+	<-forever
+}

--- a/sda/cmd/finalize/finalize.go
+++ b/sda/cmd/finalize/finalize.go
@@ -81,14 +81,6 @@ func main() {
 				continue
 			}
 
-			// Extract the sha256 from the message and use it for the database
-			var checksumSha256 string
-			for _, checksum := range message.DecryptedChecksums {
-				if checksum.Type == "sha256" {
-					checksumSha256 = checksum.Value
-				}
-			}
-
 			accessionIDExists, err := db.CheckAccessionIDExists(message.AccessionID)
 			if err != nil {
 				log.Errorf("CheckAccessionIdExists failed, reason: %v ", err)
@@ -119,7 +111,6 @@ func main() {
 				}
 
 				continue
-
 			}
 
 			fileID, err := db.GetFileID(delivered.CorrelationId)
@@ -132,7 +123,7 @@ func main() {
 				continue
 			}
 
-			if err := db.SetAccessionID(message.AccessionID, message.User, message.FilePath, checksumSha256); err != nil {
+			if err := db.SetAccessionID(message.AccessionID, fileID); err != nil {
 				log.Errorf("Failed to set accessionID for file with corrID: %v, reason: %v", delivered.CorrelationId, err)
 				if err := delivered.Nack(false, true); err != nil {
 					log.Errorf("failed to Nack message, reason: (%v)", err)

--- a/sda/cmd/finalize/finalize.md
+++ b/sda/cmd/finalize/finalize.md
@@ -1,0 +1,114 @@
+# sda-pipeline: finalize
+
+Handles the so-called _Accession ID (stable ID)_ to filename mappings from Central EGA.
+
+
+## Configuration
+
+There are a number of options that can be set for the finalize service.
+These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
+
+ex.
+```yaml
+log:
+  level: "debug"
+  format: "json"
+```
+They may also be set using environment variables like:
+```bash
+export LOG_LEVEL="debug"
+export LOG_FORMAT="json"
+```
+
+### RabbitMQ broker settings
+
+These settings control how finalize connects to the RabbitMQ message broker.
+
+ - `BROKER_HOST`: hostname of the rabbitmq server
+
+ - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+
+ - `BROKER_QUEUE`: message queue to read messages from (commonly `accessionIDs`)
+
+ - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `backup`)
+
+ - `BROKER_USER`: username to connect to rabbitmq
+
+ - `BROKER_PASSWORD`: password to connect to rabbitmq
+
+ - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+
+### PostgreSQL Database settings:
+
+ - `DB_HOST`: hostname for the postgresql database
+
+ - `DB_PORT`: database port (commonly 5432)
+
+ - `DB_USER`: username for the database
+
+ - `DB_PASSWORD`: password for the database
+
+ - `DB_DATABASE`: database name
+
+ - `DB_SSLMODE`: The TLS encryption policy to use for database connections.
+   Valid options are:
+    - `disable`
+    - `allow`
+    - `prefer`
+    - `require`
+    - `verify-ca`
+    - `verify-full`
+
+   More information is available
+   [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
+
+   Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
+   and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
+
+ - `DB_CLIENTKEY`: key-file for the database client certificate
+
+ - `DB_CLIENTCERT`: database client certificate file
+
+ - `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
+
+### Logging settings:
+
+ - `LOG_FORMAT` can be set to “json” to get logs in json format.
+   All other values result in text logging
+
+ - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
+    - `trace`
+    - `debug`
+    - `info`
+    - `warn` (or `warning`)
+    - `error`
+    - `fatal`
+    - `panic`
+
+## Service Description
+Finalize adds stable, shareable _Accession ID_'s to archive files.
+When running, finalize reads messages from the configured RabbitMQ queue (default "accessionIDs").
+For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
+
+1. The message is validated as valid JSON that matches the "ingestion-accession" schema (defined in sda-common).
+If the message can’t be validated it is discarded with an error message in the logs.
+
+1. if the type of the `DecryptedChecksums` field in the message is `sha256`, the value is stored.
+
+1. A new RabbitMQ "complete" message is created and validated against the "ingestion-completion" schema.
+If the validation fails, an error message is written to the logs.
+
+1. The file accession ID in the message is marked as "ready" in the database.
+On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
+
+1. The complete message is sent to RabbitMQ. On error, a message is written to the logs.
+
+1. The original RabbitMQ message is Ack'ed.
+
+## Communication
+
+ - Finalize reads messages from one rabbitmq queue (default `accessionIDs`).
+
+ - Finalize writes messages to one rabbitmq queue (default `backup`).
+
+ - Finalize assigns the accession ID to a file in the database using the `SetAccessionID` function.

--- a/sda/cmd/finalize/finalize.md
+++ b/sda/cmd/finalize/finalize.md
@@ -2,19 +2,20 @@
 
 Handles the so-called _Accession ID (stable ID)_ to filename mappings from Central EGA.
 
-
 ## Configuration
 
 There are a number of options that can be set for the finalize service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
-
 ex.
+
 ```yaml
 log:
   level: "debug"
   format: "json"
 ```
+
 They may also be set using environment variables like:
+
 ```bash
 export LOG_LEVEL="debug"
 export LOG_FORMAT="json"
@@ -24,40 +25,29 @@ export LOG_FORMAT="json"
 
 These settings control how finalize connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+- `BROKER_HOST`: hostname of the rabbitmq server
+- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly `accessionIDs`)
+- `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `backup`)
+- `BROKER_USER`: username to connect to rabbitmq
+- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+### PostgreSQL Database settings
 
- - `BROKER_QUEUE`: message queue to read messages from (commonly `accessionIDs`)
-
- - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `backup`)
-
- - `BROKER_USER`: username to connect to rabbitmq
-
- - `BROKER_PASSWORD`: password to connect to rabbitmq
-
- - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
-
-### PostgreSQL Database settings:
-
- - `DB_HOST`: hostname for the postgresql database
-
- - `DB_PORT`: database port (commonly 5432)
-
- - `DB_USER`: username for the database
-
- - `DB_PASSWORD`: password for the database
-
- - `DB_DATABASE`: database name
-
- - `DB_SSLMODE`: The TLS encryption policy to use for database connections.
-   Valid options are:
-    - `disable`
-    - `allow`
-    - `prefer`
-    - `require`
-    - `verify-ca`
-    - `verify-full`
+- `DB_HOST`: hostname for the postgresql database
+- `DB_PORT`: database port (commonly 5432)
+- `DB_USER`: username for the database
+- `DB_PASSWORD`: password for the database
+- `DB_DATABASE`: database name
+- `DB_SSLMODE`: The TLS encryption policy to use for database connections.
+ Valid options are:
+  - `disable`
+  - `allow`
+  - `prefer`
+  - `require`
+  - `verify-ca`
+  - `verify-full`
 
    More information is available
    [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
@@ -65,50 +55,81 @@ These settings control how finalize connects to the RabbitMQ message broker.
    Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
    and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
 
- - `DB_CLIENTKEY`: key-file for the database client certificate
+- `DB_CLIENTKEY`: key-file for the database client certificate
+- `DB_CLIENTCERT`: database client certificate file
+- `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
 
- - `DB_CLIENTCERT`: database client certificate file
+### Logging settings
 
- - `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
+- `LOG_FORMAT` can be set to “json” to get logs in json format.
+ All other values result in text logging
 
-### Logging settings:
+- `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn` (or `warning`)
+  - `error`
+  - `fatal`
+  - `panic`
 
- - `LOG_FORMAT` can be set to “json” to get logs in json format.
-   All other values result in text logging
+#### Keyfile settings
 
- - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
-    - `trace`
-    - `debug`
-    - `info`
-    - `warn` (or `warning`)
-    - `error`
-    - `fatal`
-    - `panic`
+These settings control which crypt4gh keyfile is loaded.
+These settings are only needed is `copyheader` is `true`.
+
+- `C4GH_FILEPATH`: path to the crypt4gh keyfile
+- `C4GH_PASSPHRASE`: pass phrase to unlock the keyfile
+- `C4GH_BACKUPPUBKEY`: path to the crypt4gh public key to use for reencrypting file headers.
+
+### Storage settings
+
+Storage backend is defined by the `ARCHIVE_TYPE`, and `BACKUP_TYPE` variables.
+Valid values for these options are `S3` or `POSIX`
+(Defaults to `POSIX` on unknown values).
+
+The value of these variables define what other variables are read.
+The same variables are available for all storage types, differing by prefix (`ARCHIVE_`, or  `BACKUP_`)
+
+if `*_TYPE` is `S3` then the following variables are available:
+
+- `*_URL`: URL to the S3 system
+- `*_ACCESSKEY`: The S3 access and secret key are used to authenticate to S3,
+[more info at AWS](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+- `*_SECRETKEY`: The S3 access and secret key are used to authenticate to S3,
+[more info at AWS](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+- `*_BUCKET`: The S3 bucket to use as the storage root
+- `*_PORT`: S3 connection port (default: `443`)
+- `*_REGION`: S3 region (default: `us-east-1`)
+- `*_CHUNKSIZE`: S3 chunk size for multipart uploads.
+- `*_CACERT`: Certificate Authority (CA) certificate for the storage system, tjhis is only needed if the S3 server has a certificate signed by a private entity
+
+and if `*_TYPE` is `POSIX`:
+
+- `*_LOCATION`: POSIX path to use as storage root
 
 ## Service Description
+
 Finalize adds stable, shareable _Accession ID_'s to archive files.
+If a backup location is configured it will perform backup of a file.
 When running, finalize reads messages from the configured RabbitMQ queue (default "accessionIDs").
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
 
-1. The message is validated as valid JSON that matches the "ingestion-accession" schema (defined in sda-common).
+1. The message is validated as valid JSON that matches the "ingestion-accession" schema.
 If the message can’t be validated it is discarded with an error message in the logs.
-
-1. if the type of the `DecryptedChecksums` field in the message is `sha256`, the value is stored.
-
-1. A new RabbitMQ "complete" message is created and validated against the "ingestion-completion" schema.
-If the validation fails, an error message is written to the logs.
-
-1. The file accession ID in the message is marked as "ready" in the database.
-On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
-
-1. The complete message is sent to RabbitMQ. On error, a message is written to the logs.
-
-1. The original RabbitMQ message is Ack'ed.
+2. If the service is configured to perform backups the file path and file size is fetched from the database.
+   1. The file size on disk is requested from the storage system.
+   2. The database file size is compared against the disk file size.
+   3. A file reader is created for the archive storage file, and a file writer is created for the backup storage file..
+3. The file data is copied from the archive file reader to the backup file writer.
+4. if the type of the `DecryptedChecksums` field in the message is `sha256`, the value is stored.
+5. A new RabbitMQ "complete" message is created and validated against the "ingestion-completion" schema. If the validation fails, an error message is written to the logs.
+6. The file accession ID in the message is marked as "ready" in the database. On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
+7. The complete message is sent to RabbitMQ. On error, a message is written to the logs.
+8. The original RabbitMQ message is Ack'ed.
 
 ## Communication
 
- - Finalize reads messages from one rabbitmq queue (default `accessionIDs`).
-
- - Finalize writes messages to one rabbitmq queue (default `backup`).
-
- - Finalize assigns the accession ID to a file in the database using the `SetAccessionID` function.
+- Finalize reads messages from one rabbitmq queue (default `accessionIDs`).
+- Finalize writes messages to one rabbitmq queue (default `backup`).
+- Finalize assigns the accession ID to a file in the database using the `SetAccessionID` function.

--- a/sda/cmd/finalize/finalize_test.go
+++ b/sda/cmd/finalize/finalize_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}
+
+func (suite *TestSuite) SetupTest() {
+	viper.Set("log.level", "debug")
+}

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -133,40 +133,6 @@ func NewConfig(app string) (*Config, error) {
 			"db.password",
 			"db.database",
 		}
-	case "backup":
-		requiredConfVars = []string{
-			"broker.host",
-			"broker.port",
-			"broker.user",
-			"broker.password",
-			"broker.queue",
-			"broker.routingkey",
-			"db.host",
-			"db.port",
-			"db.user",
-			"db.password",
-			"db.database",
-		}
-
-		switch viper.GetString("archive.type") {
-		case S3:
-			requiredConfVars = append(requiredConfVars, []string{"archive.url", "archive.accesskey", "archive.secretkey", "archive.bucket"}...)
-		case POSIX:
-			requiredConfVars = append(requiredConfVars, []string{"archive.location"}...)
-		default:
-			return nil, fmt.Errorf("archive.type not set")
-		}
-
-		switch viper.GetString("backup.type") {
-		case S3:
-			requiredConfVars = append(requiredConfVars, []string{"backup.url", "backup.accesskey", "backup.secretkey", "backup.bucket"}...)
-		case POSIX:
-			requiredConfVars = append(requiredConfVars, []string{"backup.location"}...)
-		case SFTP:
-			requiredConfVars = append(requiredConfVars, []string{"backup.sftp.host", "backup.sftp.port", "backup.sftp.userName", "backup.sftp.pemKeyPath", "backup.sftp.pemKeyPass"}...)
-		default:
-			return nil, fmt.Errorf("backup.type not set")
-		}
 	case "ingest":
 		requiredConfVars = []string{
 			"broker.host",
@@ -213,8 +179,21 @@ func NewConfig(app string) (*Config, error) {
 			"db.password",
 			"db.database",
 		}
+
+		switch viper.GetString("archive.type") {
+		case S3:
+			requiredConfVars = append(requiredConfVars, []string{"archive.url", "archive.accesskey", "archive.secretkey", "archive.bucket"}...)
+		case POSIX:
+			requiredConfVars = append(requiredConfVars, []string{"archive.location"}...)
+		}
+
+		switch viper.GetString("backup.type") {
+		case S3:
+			requiredConfVars = append(requiredConfVars, []string{"backup.url", "backup.accesskey", "backup.secretkey", "backup.bucket"}...)
+		case POSIX:
+			requiredConfVars = append(requiredConfVars, []string{"backup.location"}...)
+		}
 	case "intercept":
-		// Intercept does not require these extra settings
 		requiredConfVars = []string{
 			"broker.host",
 			"broker.port",
@@ -356,22 +335,12 @@ func NewConfig(app string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-	case "backup":
-		c.configArchive()
-		c.configBackup()
-
-		err := c.configBroker()
-		if err != nil {
-			return nil, err
-		}
-
-		err = c.configDatabase()
-		if err != nil {
-			return nil, err
-		}
-
-		c.configSchemas()
 	case "finalize":
+		if viper.GetString("archive.type") != "" && viper.GetString("backup.type") != "" {
+			c.configArchive()
+			c.configBackup()
+		}
+
 		err := c.configBroker()
 		if err != nil {
 			return nil, err

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
+	"time"
 )
 
 // RegisterFile inserts a file in the database, along with a "registered" log
@@ -287,4 +289,66 @@ func (dbs *SDAdb) getArchived(user, filepath, checksum string) (string, int, err
 	}
 
 	return filePath, fileSize, nil
+}
+
+// CheckAccessionIdExists validates if an accessionID exists in the db
+func (dbs *SDAdb) CheckAccessionIDExists(accessionID string) (bool, error) {
+	var err error
+	var exists bool
+	// 2, 4, 8, 16, 32 seconds between each retry event.
+	for count := 1; count <= RetryTimes; count++ {
+		exists, err = dbs.checkAccessionIDExists(accessionID)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Duration(math.Pow(2, float64(count))) * time.Second)
+	}
+
+	return exists, err
+}
+func (dbs *SDAdb) checkAccessionIDExists(accessionID string) (bool, error) {
+	dbs.checkAndReconnectIfNeeded()
+	db := dbs.DB
+	const checkIDExist = "SELECT COUNT(*) FROM sda.files WHERE stable_id = $1;"
+	var stableIDCount int
+	if err := db.QueryRow(checkIDExist, accessionID).Scan(&stableIDCount); err != nil {
+		return false, err
+	}
+
+	if stableIDCount >= 1 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// SetAccessionID adds a stable id to a file
+// identified by the user submitting it, inbox path and decrypted checksum
+func (dbs *SDAdb) SetAccessionID(accessionID, user, filepath, checksum string) error {
+	var err error
+	// 2, 4, 8, 16, 32 seconds between each retry event.
+	for count := 1; count <= RetryTimes; count++ {
+		err = dbs.setAccessionID(accessionID, user, filepath, checksum)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Duration(math.Pow(2, float64(count))) * time.Second)
+	}
+
+	return err
+}
+func (dbs *SDAdb) setAccessionID(accessionID, user, filepath, checksum string) error {
+	dbs.checkAndReconnectIfNeeded()
+	db := dbs.DB
+	const ready = "UPDATE local_ega.files SET stable_id = $1 WHERE elixir_id = $2 and inbox_path = $3 and decrypted_file_checksum = $4 and status = 'COMPLETED';"
+	result, err := db.Exec(ready, accessionID, user, filepath, checksum)
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected, _ := result.RowsAffected(); rowsAffected == 0 {
+		return errors.New("something went wrong with the query zero rows were changed")
+	}
+
+	return nil
 }

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -324,11 +324,11 @@ func (dbs *SDAdb) checkAccessionIDExists(accessionID string) (bool, error) {
 
 // SetAccessionID adds a stable id to a file
 // identified by the user submitting it, inbox path and decrypted checksum
-func (dbs *SDAdb) SetAccessionID(accessionID, user, filepath, checksum string) error {
+func (dbs *SDAdb) SetAccessionID(accessionID, fileID string) error {
 	var err error
 	// 2, 4, 8, 16, 32 seconds between each retry event.
 	for count := 1; count <= RetryTimes; count++ {
-		err = dbs.setAccessionID(accessionID, user, filepath, checksum)
+		err = dbs.setAccessionID(accessionID, fileID)
 		if err == nil {
 			break
 		}
@@ -337,11 +337,11 @@ func (dbs *SDAdb) SetAccessionID(accessionID, user, filepath, checksum string) e
 
 	return err
 }
-func (dbs *SDAdb) setAccessionID(accessionID, user, filepath, checksum string) error {
+func (dbs *SDAdb) setAccessionID(accessionID, fileID string) error {
 	dbs.checkAndReconnectIfNeeded()
 	db := dbs.DB
-	const ready = "UPDATE local_ega.files SET stable_id = $1 WHERE elixir_id = $2 and inbox_path = $3 and decrypted_file_checksum = $4 and status = 'COMPLETED';"
-	result, err := db.Exec(ready, accessionID, user, filepath, checksum)
+	const setStableID = "UPDATE sda.files SET stable_id = $1 WHERE id = $2;"
+	result, err := db.Exec(setStableID, accessionID, fileID)
 	if err != nil {
 		return err
 	}

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -223,7 +223,7 @@ func (suite *DatabaseTests) TestSetAccessionID() {
 	err = db.MarkCompleted(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as completed", err)
 	stableID := "TEST:000-1234-4567"
-	err = db.SetAccessionID(stableID, "testuser", "/testuser/TestSetAccessionID.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)))
+	err = db.SetAccessionID(stableID, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
 }
 
@@ -242,7 +242,7 @@ func (suite *DatabaseTests) TestCheckAccessionIDExists() {
 	err = db.MarkCompleted(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as completed", err)
 	stableID := "TEST:111-1234-4567"
-	err = db.SetAccessionID(stableID, "testuser", "/testuser/TestCheckAccessionIDExists.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)))
+	err = db.SetAccessionID(stableID, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
 
 	ok, err := db.CheckAccessionIDExists(stableID)

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"crypto/sha256"
-	"fmt"
 	"regexp"
 
 	"github.com/google/uuid"
@@ -202,7 +201,7 @@ func (suite *DatabaseTests) TestGetArchived() {
 	err = db.MarkCompleted(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as completed", err)
 
-	filePath, fileSize, err := db.GetArchived("testuser", "/testuser/TestGetArchived.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)))
+	filePath, fileSize, err := db.GetArchived(fileID)
 	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
 	assert.Equal(suite.T(), 1000, fileSize)
 	assert.Equal(suite.T(), "/tmp/TestGetArchived.c4gh", filePath)

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -207,3 +207,45 @@ func (suite *DatabaseTests) TestGetArchived() {
 	assert.Equal(suite.T(), 1000, fileSize)
 	assert.Equal(suite.T(), "/tmp/TestGetArchived.c4gh", filePath)
 }
+
+func (suite *DatabaseTests) TestSetAccessionID() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	// register a file in the database
+	fileID, err := db.RegisterFile("/testuser/TestSetAccessionID.c4gh", "testuser")
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	decSha := sha256.New()
+	fileInfo := FileInfo{sha256.New(), 1000, "/tmp/TestSetAccessionID.c4gh", decSha, 987}
+	corrID := uuid.New().String()
+	err = db.SetArchived(fileInfo, fileID, corrID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
+	err = db.MarkCompleted(fileInfo, fileID, corrID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as completed", err)
+	stableID := "TEST:000-1234-4567"
+	err = db.SetAccessionID(stableID, "testuser", "/testuser/TestSetAccessionID.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)))
+	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
+}
+
+func (suite *DatabaseTests) TestCheckAccessionIDExists() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	// register a file in the database
+	fileID, err := db.RegisterFile("/testuser/TestCheckAccessionIDExists.c4gh", "testuser")
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	decSha := sha256.New()
+	fileInfo := FileInfo{sha256.New(), 1000, "/tmp/TestCheckAccessionIDExists.c4gh", decSha, 987}
+	corrID := uuid.New().String()
+	err = db.SetArchived(fileInfo, fileID, corrID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
+	err = db.MarkCompleted(fileInfo, fileID, corrID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as completed", err)
+	stableID := "TEST:111-1234-4567"
+	err = db.SetAccessionID(stableID, "testuser", "/testuser/TestCheckAccessionIDExists.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)))
+	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
+
+	ok, err := db.CheckAccessionIDExists(stableID)
+	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
+	assert.True(suite.T(), ok, "CheckAccessionIDExists returned false when true was expected")
+}


### PR DESCRIPTION
* Merge `finalize` into `sda`
* Expands test suite to assign stable ID to a verified file.
* Adds backup functionality to finalize
  * As per the FEGA specification, an archived fie should be `backed up` before it can be considered `completed`
 * Adds check in the integration test that the files have been copied to the backup location. 