### PR TITLE
[FEGA usecase] merge `mapper` from `sda-pipeline` into `sda`

### DIFF
--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -184,6 +184,30 @@ services:
       - ./sda/config.yaml:/config.yaml
       - shared:/shared
 
+  mapper:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
+    command: [ sda-mapper ]
+    container_name: mapper
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=mapper
+      - BROKER_USER=mapper
+      - BROKER_QUEUE=mappings
+      - DB_PASSWORD=mapper
+      - DB_USER=mapper
+    restart: always
+    volumes:
+      - ./sda/config.yaml:/config.yaml
+      - shared:/shared
+
   oidc:
     container_name: oidc
     command:
@@ -221,6 +245,8 @@ services:
       finalize:
         condition: service_started
       ingest:
+        condition: service_started
+      mapper:
         condition: service_started
       s3inbox:
         condition: service_started

--- a/.github/integration/tests/sda/40_mapper_test.sh
+++ b/.github/integration/tests/sda/40_mapper_test.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+set -e
+
+cd shared || true
+
+## map files to dataset
+properties=$(
+    jq -c -n \
+        --argjson delivery_mode 2 \
+        --arg content_encoding UTF-8 \
+        --arg content_type application/json \
+        '$ARGS.named'
+)
+
+mappings=$(
+    jq -c -n \
+        '$ARGS.positional' \
+        --args "EGAF74900000001" \
+        --args "EGAF74900000002"
+)
+
+mapping_payload=$(
+    jq -r -c -n \
+        --arg type mapping \
+        --arg dataset_id EGAD74900000101 \
+        --argjson accession_ids "$mappings" \
+        '$ARGS.named|@base64'
+)
+
+mapping_body=$(
+    jq -c -n \
+        --arg vhost test \
+        --arg name sda \
+        --argjson properties "$properties" \
+        --arg routing_key "mappings" \
+        --arg payload_encoding base64 \
+        --arg payload "$mapping_payload" \
+        '$ARGS.named'
+)
+
+curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d "$mapping_body"
+
+# check DB for dataset contents
+RETRY_TIMES=0
+until [ "$(psql -U postgres -h postgres -d sda -At -c "select count(id) from sda.file_dataset where dataset_id = (select id from sda.datasets where stable_id = 'EGAD74900000101')")" -eq 2 ]; do
+    echo "waiting for mapper to complete"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for dataset to be mapped"
+        exit 1
+    fi
+    sleep 2
+done
+
+## check that files has been removed form the inbox
+for file in NA12878.bam.c4gh NA12878_20k_b37.bam.c4gh; do
+    result=$(s3cmd -c direct ls s3://inbox/test_dummy.org/"$file")
+    if [ "$result" != "" ]; then
+        echo "Failed to remove $file from inbox"
+        exit 1
+    fi
+done
+
+until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.file_event_log where file_id = (select id from sda.files where stable_id = 'EGAF74900000002') order by started_at DESC LIMIT 1")" = "ready" ]; do
+    echo "waiting for files be ready"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for files to be ready"
+        exit 1
+    fi
+    sleep 2
+done
+
+until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.dataset_event_log where dataset_id = 'EGAD74900000101' order by event_date DESC LIMIT 1")" = "registered" ]; do
+    echo "waiting for dataset be registered"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for dataset to be registered"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "dataset mapped successfully"
+
+## release dataset
+release_payload=$(
+    jq -r -c -n \
+        --arg type release \
+        --arg dataset_id EGAD74900000101 \
+        '$ARGS.named'
+)
+
+release_body=$(
+    jq -c -n \
+        --arg vhost test \
+        --arg name sda \
+        --argjson properties "$properties" \
+        --arg routing_key "mappings" \
+        --arg payload "$release_payload" \
+        --arg payload_encoding string \
+        '$ARGS.named'
+)
+
+curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d "$release_body"
+
+until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.dataset_event_log where dataset_id = 'EGAD74900000101' order by event_date DESC LIMIT 1")" = "released" ]; do
+    echo "waiting for dataset be released"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for dataset to be released"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "dataset released successfully"
+
+## deprecate dataset
+deprecate_payload=$(
+    jq -r -c -n \
+        --arg type deprecate \
+        --arg dataset_id EGAD74900000101 \
+        '$ARGS.named'
+)
+
+deprecate_body=$(
+    jq -c -n \
+        --arg vhost test \
+        --arg name sda \
+        --argjson properties "$properties" \
+        --arg routing_key "mappings" \
+        --arg payload "$deprecate_payload" \
+        --arg payload_encoding string \
+        '$ARGS.named'
+)
+
+curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d "$deprecate_body"
+
+until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.dataset_event_log where dataset_id = 'EGAD74900000101' order by event_date DESC LIMIT 1")" = "deprecated" ]; do
+    echo "waiting for dataset be deprecated"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for dataset to be deprecated"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "dataset deprecated successfully"

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -1,0 +1,184 @@
+// The mapper service register mapping of accessionIDs
+// (IDs for files) to datasetIDs.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/neicnordic/sensitive-data-archive/internal/broker"
+	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
+	"github.com/neicnordic/sensitive-data-archive/internal/schema"
+	"github.com/neicnordic/sensitive-data-archive/internal/storage"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	forever := make(chan bool)
+	conf, err := config.NewConfig("mapper")
+	if err != nil {
+		log.Fatal(err)
+	}
+	mq, err := broker.NewMQ(conf.Broker)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db, err := database.NewSDAdb(conf.Database)
+	if err != nil {
+		log.Fatal(err)
+	}
+	inbox, err := storage.NewBackend(conf.Inbox)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer mq.Channel.Close()
+	defer mq.Connection.Close()
+	defer db.Close()
+
+	go func() {
+		connError := mq.ConnectionWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
+
+	go func() {
+		connError := mq.ChannelWatcher()
+		log.Error(connError)
+		forever <- false
+	}()
+
+	log.Info("Starting mapper service")
+	var mappings schema.DatasetMapping
+
+	go func() {
+		messages, err := mq.GetMessages(conf.Broker.Queue)
+		if err != nil {
+			log.Fatalf("Failed to get message from mq (error: %v)", err)
+		}
+
+		for delivered := range messages {
+			log.Debugf("received a message: %s", delivered.Body)
+			schemaType, err := schemaFromDatasetOperation(delivered.Body)
+			if err != nil {
+				log.Errorf(err.Error())
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("failed to ack message: %v", err)
+				}
+				if err := mq.SendMessage(delivered.CorrelationId, mq.Conf.Exchange, "error", delivered.Body); err != nil {
+					log.Errorf("failed to send error message: %v", err)
+				}
+
+				continue
+			}
+
+			err = schema.ValidateJSON(fmt.Sprintf("%s/%s.json", conf.Broker.SchemasPath, schemaType), delivered.Body)
+			if err != nil {
+				log.Errorf("validation of incoming message (%s) failed, reason: %v ", schemaType, err)
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("Failed acking canceled work, reason: %v", err)
+				}
+
+				continue
+			}
+
+			// we unmarshal the message in the validation step so this is safe to do
+			_ = json.Unmarshal(delivered.Body, &mappings)
+
+			switch mappings.Type {
+			case "mapping":
+				log.Debug("Mapping type operation, mapping files to dataset")
+				if err := db.MapFilesToDataset(mappings.DatasetID, mappings.AccessionIDs); err != nil {
+					log.Errorf("failed to map files to dataset, reason: %v", err)
+
+					// Nack message so the server gets notified that something is wrong and requeue the message
+					if err := delivered.Nack(false, true); err != nil {
+						log.Errorf("failed to Nack message, reason: (%v)", err)
+					}
+
+					continue
+				}
+
+				for _, aID := range mappings.AccessionIDs {
+					log.Debugf("Mapped file to dataset (corr-id: %s, datasetid: %s, accessionid: %s)", delivered.CorrelationId, mappings.DatasetID, aID)
+					filePath, err := db.GetInboxPath(aID)
+					if err != nil {
+						log.Errorf("failed to get inbox path for file with stable ID: %s", aID)
+					}
+					err = inbox.RemoveFile(filePath)
+					if err != nil {
+						log.Errorf("Remove file from inbox failed, reason: %v", err)
+					}
+				}
+
+				if err := db.UpdateDatasetEvent(mappings.DatasetID, "registered", string(delivered.Body)); err != nil {
+					log.Errorf("failed to set dataset status for dataset: %s", mappings.DatasetID)
+					if err = delivered.Nack(false, false); err != nil {
+						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
+					}
+
+					continue
+				}
+			case "release":
+				log.Debug("Release type operation, marking dataset as released")
+				if err := db.UpdateDatasetEvent(mappings.DatasetID, "released", string(delivered.Body)); err != nil {
+					log.Errorf("failed to set dataset status for dataset: %s", mappings.DatasetID)
+					if err = delivered.Nack(false, false); err != nil {
+						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
+					}
+
+					continue
+				}
+			case "deprecate":
+				log.Debug("Deprecate type operation, marking dataset as deprecated")
+				if err := db.UpdateDatasetEvent(mappings.DatasetID, "deprecated", string(delivered.Body)); err != nil {
+					log.Errorf("failed to set dataset status for dataset: %s", mappings.DatasetID)
+					if err = delivered.Nack(false, false); err != nil {
+						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
+					}
+
+					continue
+				}
+			}
+
+			if err := delivered.Ack(false); err != nil {
+				log.Errorf("failed to Ack message, reason: (%v)", err)
+			}
+		}
+	}()
+
+	<-forever
+}
+
+// schemaFromDatasetOperation returns the operation done with dataset supplied in body of the message
+func schemaFromDatasetOperation(body []byte) (string, error) {
+	message := make(map[string]interface{})
+	err := json.Unmarshal(body, &message)
+	if err != nil {
+		return "", err
+	}
+
+	datasetMessageType, ok := message["type"]
+	if !ok {
+		return "", fmt.Errorf("malformed message, dataset message type is missing")
+	}
+
+	datasetOpsType, ok := datasetMessageType.(string)
+	if !ok {
+		return "", fmt.Errorf("could not cast operation attribute to string")
+	}
+
+	switch datasetOpsType {
+	case "mapping":
+		return "dataset-mapping", nil
+	case "release":
+		return "dataset-release", nil
+	case "deprecate":
+		return "dataset-deprecate", nil
+	default:
+		return "", fmt.Errorf("could not recognize mapping operation")
+	}
+
+}

--- a/sda/cmd/mapper/mapper.md
+++ b/sda/cmd/mapper/mapper.md
@@ -1,0 +1,90 @@
+# sda-pipeline: mapper
+
+The mapper service registers mapping of accessionIDs (stable ids for files) to datasetIDs.
+
+## Configuration
+
+There are a number of options that can be set for the mapper service.
+These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
+
+ex.
+
+```yaml
+log:
+  level: "debug"
+  format: "json"
+```
+
+They may also be set using environment variables like:
+
+```bash
+export LOG_LEVEL="debug"
+export LOG_FORMAT="json"
+```
+
+### RabbitMQ broker settings
+
+These settings control how mapper connects to the RabbitMQ message broker.
+
+- `BROKER_HOST`: hostname of the rabbitmq server
+- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly `mapper`)
+- `BROKER_USER`: username to connect to rabbitmq
+- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+
+### PostgreSQL Database settings
+
+- `DB_HOST`: hostname for the postgresql database
+- `DB_PORT`: database port (commonly 5432)
+- `DB_USER`: username for the database
+- `DB_PASSWORD`: password for the database
+- `DB_DATABASE`: database name
+- `DB_SSLMODE`: The TLS encryption policy to use for database connections.  Valid options are:
+  - `disable`
+  - `allow`
+  - `prefer`
+  - `require`
+  - `verify-ca`
+  - `verify-full`
+
+More information is available in the [postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)  
+Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set, and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
+
+- `DB_CLIENTKEY`: key-file for the database client certificate
+- `DB_CLIENTCERT`: database client certificate file
+- `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
+
+### Logging settings
+
+- `LOG_FORMAT` can be set to “json” to get logs in json format. All other values result in text logging
+- `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn` (or `warning`)
+  - `error`
+  - `fatal`
+  - `panic`
+
+## Service Description
+
+The mapper service maps file accessionIDs to datasetIDs.
+
+When running, mapper reads messages from the configured RabbitMQ queue (default: "mappings").  
+For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
+
+1. The message is validated as valid JSON that matches the "dataset-mapping" schema.  
+If the message can’t be validated it is discarded with an error message is logged.
+2. AccessionIDs from the message are mapped to a datasetID (also in the message) in the database.  
+On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
+3. The uploaded files related to each AccessionID is removed from the inbox  
+If this fails an error will be written to the logs.
+4. The RabbitMQ message is Ack'ed.
+
+## Communication
+
+- Mapper reads messages from one rabbitmq queue (default `mappings`).
+- Mapper maps files to datasets in the database using the `MapFilesToDataset` function.
+- Mapper retrieves the inbox filepath from the database for each file using the `GetInboxPath` function.
+- Mapper sets the status of a dataset in the database usig the `UpdateDatasetEvent` function.

--- a/sda/cmd/mapper/mapper_test.go
+++ b/sda/cmd/mapper/mapper_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}
+
+func (suite *TestSuite) SetupTest() {
+	viper.Set("log.level", "debug")
+}

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"regexp"
 
 	"github.com/google/uuid"
@@ -247,4 +248,87 @@ func (suite *DatabaseTests) TestCheckAccessionIDExists() {
 	ok, err := db.CheckAccessionIDExists(stableID)
 	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
 	assert.True(suite.T(), ok, "CheckAccessionIDExists returned false when true was expected")
+}
+
+func (suite *DatabaseTests) TestMapFilesToDataset() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	accessions := []string{}
+	for i := 1; i < 12; i++ {
+		fileID, err := db.RegisterFile(fmt.Sprintf("/testuser/TestMapFilesToDataset-%d.c4gh", i), "testuser")
+		assert.NoError(suite.T(), err, "failed to register file in database")
+
+		err = db.SetAccessionID(fmt.Sprintf("acession-%d", i), fileID)
+		assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
+
+		accessions = append(accessions, fmt.Sprintf("acession-%d", i))
+	}
+
+	diSet := map[string][]string{
+		"dataset1": accessions[0:3],
+		"dataset2": accessions[3:5],
+		"dataset3": accessions[5:8],
+		"dataset4": accessions[8:9],
+	}
+
+	for di, acs := range diSet {
+		err := db.MapFilesToDataset(di, acs)
+		assert.NoError(suite.T(), err, "failed to map file to dataset")
+	}
+}
+
+func (suite *DatabaseTests) TestGetInboxPath() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	accessions := []string{}
+	for i := 0; i < 5; i++ {
+		fileID, err := db.RegisterFile(fmt.Sprintf("/testuser/TestGetInboxPath-00%d.c4gh", i), "testuser")
+		assert.NoError(suite.T(), err, "failed to register file in database")
+
+		err = db.SetAccessionID(fmt.Sprintf("acession-00%d", i), fileID)
+		assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
+
+		accessions = append(accessions, fmt.Sprintf("acession-00%d", i))
+	}
+
+	for _, acc := range accessions {
+		path, err := db.getInboxPath(acc)
+		assert.NoError(suite.T(), err, "getInboxPath failed")
+		assert.Contains(suite.T(), path, "/testuser/TestGetInboxPath")
+	}
+}
+
+func (suite *DatabaseTests) TestUpdateDatasetEvent() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	accessions := []string{}
+	for i := 0; i < 5; i++ {
+		fileID, err := db.RegisterFile(fmt.Sprintf("/testuser/TestGetInboxPath-00%d.c4gh", i), "testuser")
+		assert.NoError(suite.T(), err, "failed to register file in database")
+
+		err = db.SetAccessionID(fmt.Sprintf("acession-00%d", i), fileID)
+		assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
+
+		accessions = append(accessions, fmt.Sprintf("acession-00%d", i))
+	}
+
+	diSet := map[string][]string{"DATASET:TEST-0001": accessions}
+
+	for di, acs := range diSet {
+		err := db.MapFilesToDataset(di, acs)
+		assert.NoError(suite.T(), err, "failed to map file to dataset")
+	}
+
+	dID := "DATASET:TEST-0001"
+	err = db.UpdateDatasetEvent(dID, "registered", "{\"type\": \"mapping\"}")
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	err = db.UpdateDatasetEvent(dID, "released", "{\"type\": \"release\"}")
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	err = db.UpdateDatasetEvent(dID, "deprecated", "{\"type\": \"deprecate\"}")
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
 }

--- a/sda/internal/schema/schema.go
+++ b/sda/internal/schema/schema.go
@@ -36,8 +36,12 @@ func ValidateJSON(reference string, body []byte) error {
 
 func getStructName(path string) interface{} {
 	switch strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)) {
+	case "dataset-deprecate":
+		return new(DatasetDeprecate)
 	case "dataset-mapping":
 		return new(DatasetMapping)
+	case "dataset-release":
+		return new(DatasetRelease)
 	case "inbox-remove":
 		return new(InboxRemove)
 	case "inbox-rename":
@@ -68,10 +72,20 @@ type Checksums struct {
 	Value string `json:"value"`
 }
 
+type DatasetDeprecate struct {
+	Type      string `json:"type"`
+	DatasetID string `json:"dataset_id"`
+}
+
 type DatasetMapping struct {
 	Type         string   `json:"type"`
 	DatasetID    string   `json:"dataset_id"`
 	AccessionIDs []string `json:"accession_ids"`
+}
+
+type DatasetRelease struct {
+	Type      string `json:"type"`
+	DatasetID string `json:"dataset_id"`
 }
 
 type InfoError struct {

--- a/sda/internal/schema/schema_test.go
+++ b/sda/internal/schema/schema_test.go
@@ -25,6 +25,24 @@ func TestDefaultResponse(t *testing.T) {
 	assert.Equal(t, "unknown reference schema", err.Error())
 }
 
+func TestValidateJSONDatasetDeprecate(t *testing.T) {
+	okMsg := DatasetMapping{
+		Type:      "deprecate",
+		DatasetID: "EGAD00123456789",
+	}
+
+	msg, _ := json.Marshal(okMsg)
+	assert.Nil(t, ValidateJSON(fmt.Sprintf("%s/federated/dataset-deprecate.json", schemaPath), msg))
+
+	badMsg := DatasetMapping{
+		Type:      "mapping",
+		DatasetID: "ABCD00123456789",
+	}
+
+	msg, _ = json.Marshal(badMsg)
+	assert.Error(t, ValidateJSON(fmt.Sprintf("%s/federated/dataset-deprecate.json", schemaPath), msg))
+}
+
 func TestValidateJSONDatasetMapping(t *testing.T) {
 	okMsg := DatasetMapping{
 		Type:      "mapping",
@@ -48,6 +66,27 @@ func TestValidateJSONDatasetMapping(t *testing.T) {
 
 	msg, _ = json.Marshal(badMsg)
 	assert.Error(t, ValidateJSON(fmt.Sprintf("%s/federated/dataset-mapping.json", schemaPath), msg))
+}
+
+func TestValidateJSONDatasetRelease(t *testing.T) {
+	okMsg := DatasetMapping{
+		Type:      "release",
+		DatasetID: "EGAD00123456789",
+	}
+
+	msg, _ := json.Marshal(okMsg)
+	assert.Nil(t, ValidateJSON(fmt.Sprintf("%s/federated/dataset-release.json", schemaPath), msg))
+
+	badMsg := DatasetMapping{
+		Type:      "release",
+		DatasetID: "ABCD00123456789",
+		AccessionIDs: []string{
+			"c177c69c-dcc6-4174-8740-919b8f994122",
+		},
+	}
+
+	msg, _ = json.Marshal(badMsg)
+	assert.Error(t, ValidateJSON(fmt.Sprintf("%s/federated/dataset-release.json", schemaPath), msg))
 }
 
 func TestValidateJSONInboxRemove(t *testing.T) {


### PR DESCRIPTION
* Merge `mapper` into `sda
* Expands integration tests with the following:
  * Stable IDs for files mapped to dataset
  * Files removed from inbox
  * Dataset released
  * Dataset deprecated