### PR TITLE
Extend TTL for PR containers

### DIFF
--- a/.github/workflows/ghcr-actions.yml
+++ b/.github/workflows/ghcr-actions.yml
@@ -16,13 +16,12 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Delete 'PR' containers older than a week
+      - name: Delete 'PR' containers older than one month
         uses: snok/container-retention-policy@v2.1.2
         with:
           image-names: sensitive-data-archive
-          filter-tags: PR*,sha-*
           skip-tags: v*
-          cut-off: A week ago UTC
+          cut-off: One month ago UTC
           account-type: org
           org-name: ${{ github.repository_owner }}
           keep-at-least: 1


### PR DESCRIPTION
Since it seems to take more that one week for a PR to be reviewed and merged we need to extend the time before old PR containers are cleaned out.