### PR TITLE
Run test queries against the postgres migration container

### DIFF
--- a/.github/integration/scripts/make_db_credentials.sh
+++ b/.github/integration/scripts/make_db_credentials.sh
@@ -6,5 +6,6 @@ apt-get -o DPkg::Lock::Timeout=60 install -y postgresql-client >/dev/null
 
 for n in download finalize inbox ingest mapper sync verify; do
     echo "creating credentials for: $n"
+    psql -U postgres -h migrate -d sda -c "ALTER ROLE $n LOGIN PASSWORD '$n';"
     psql -U postgres -h postgres -d sda -c "ALTER ROLE $n LOGIN PASSWORD '$n';"
 done

--- a/.github/integration/tests/postgres/10_sanity_check.sh
+++ b/.github/integration/tests/postgres/10_sanity_check.sh
@@ -34,3 +34,5 @@ for u in download finalize inbox ingest mapper sync verify; do
     export PGPASSWORD="$u"
     psql -U "$u" -h postgres -d sda -At -c "SELECT version();" 1>/dev/null
 done
+
+echo "10_sanity_check completed successfully"

--- a/.github/integration/tests/postgres/20_inbox_queries.sh
+++ b/.github/integration/tests/postgres/20_inbox_queries.sh
@@ -16,3 +16,5 @@ for host in migrate postgres; do
         exit 1
     fi
 done
+
+echo "20_inbox_queries completed successfully"

--- a/.github/integration/tests/postgres/20_inbox_queries.sh
+++ b/.github/integration/tests/postgres/20_inbox_queries.sh
@@ -3,14 +3,16 @@ set -eou pipefail
 
 export PGPASSWORD=inbox
 
-fileID=$(psql -U inbox -h postgres -d sda -At -c "SELECT sda.register_file('inbox/test-file.c4gh', 'test-user');")
-if [ -z "$fileID" ]; then
-    echo "register_file failed"
-    exit 1
-fi
+for host in migrate postgres; do
+    fileID=$(psql -U inbox -h "$host" -d sda -At -c "SELECT sda.register_file('inbox/test-file.c4gh', 'test-user');")
+    if [ -z "$fileID" ]; then
+        echo "register_file failed"
+        exit 1
+    fi
 
-resp=$(psql -U inbox -h postgres -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, user_id, message) VALUES('$fileID', 'uploaded', 'test-user', '{\"uploaded\": \"message\"}');")
-if [ "$resp" != "INSERT 0 1" ]; then
-    echo "Mark file as uploaded failed"
-    exit 1
-fi
+    resp=$(psql -U inbox -h "$host" -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, user_id, message) VALUES('$fileID', 'uploaded', 'test-user', '{\"uploaded\": \"message\"}');")
+    if [ "$resp" != "INSERT 0 1" ]; then
+        echo "Mark file as uploaded failed"
+        exit 1
+    fi
+done

--- a/.github/integration/tests/postgres/30_ingest_queries.sh
+++ b/.github/integration/tests/postgres/30_ingest_queries.sh
@@ -5,32 +5,34 @@ export PGPASSWORD=ingest
 user="test-user"
 corrID="33d29907-c565-4a90-98b4-e31b992ab376"
 
-## insert file
-fileID=$(psql -U ingest -h postgres -d sda -At -c "SELECT sda.register_file('inbox/test-file.c4gh', '$user');")
-if [ -z "$fileID" ]; then
-    echo "register_file failed"
-    exit 1
-fi
+for host in migrate postgres; do
+    ## insert file
+    fileID=$(psql -U ingest -h "$host" -d sda -At -c "SELECT sda.register_file('inbox/test-file.c4gh', '$user');")
+    if [ -z "$fileID" ]; then
+        echo "register_file failed"
+        exit 1
+    fi
 
-resp=$(psql -U ingest -h postgres -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, correlation_id, user_id, message) VALUES('$fileID', 'submitted', '$corrID', '$user', '{}');")
-if [ "$(echo "$resp" | tr -d '\n')" != "INSERT 0 1" ]; then
-    echo "insert file failed"
-    exit 1
-fi
+    resp=$(psql -U ingest -h "$host" -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, correlation_id, user_id, message) VALUES('$fileID', 'submitted', '$corrID', '$user', '{}');")
+    if [ "$(echo "$resp" | tr -d '\n')" != "INSERT 0 1" ]; then
+        echo "insert file failed"
+        exit 1
+    fi
 
-## store header
-resp=$(psql -U ingest -h postgres -d sda -At -c "UPDATE sda.files SET header = '637279707434676801000000010000006c00000000000000' WHERE id = '$fileID';")
-if [ "$resp" != "UPDATE 1" ]; then
-    echo "store header failed"
-    exit 1
-fi
+    ## store header
+    resp=$(psql -U ingest -h "$host" -d sda -At -c "UPDATE sda.files SET header = '637279707434676801000000010000006c00000000000000' WHERE id = '$fileID';")
+    if [ "$resp" != "UPDATE 1" ]; then
+        echo "store header failed"
+        exit 1
+    fi
 
-## set archived
-archive_path=d853c51b-6aed-4243-b427-177f5e588857
-size="2035150"
-checksum="f03775a50feea74c579d459fdbeb27adafd543b87f6692703543a6ebe7daa1ff"
-resp=$(psql -U ingest -h postgres -d sda -At -c "SELECT sda.set_archived('$fileID', '$corrID', '$archive_path', '$size', '$checksum', 'SHA256');")
-if [ "$resp" != "" ]; then
-    echo "mark file archived failed"
-    exit 1
-fi
+    ## set archived
+    archive_path=d853c51b-6aed-4243-b427-177f5e588857
+    size="2035150"
+    checksum="f03775a50feea74c579d459fdbeb27adafd543b87f6692703543a6ebe7daa1ff"
+    resp=$(psql -U ingest -h "$host" -d sda -At -c "SELECT sda.set_archived('$fileID', '$corrID', '$archive_path', '$size', '$checksum', 'SHA256');")
+    if [ "$resp" != "" ]; then
+        echo "mark file archived failed"
+        exit 1
+    fi
+done

--- a/.github/integration/tests/postgres/30_ingest_queries.sh
+++ b/.github/integration/tests/postgres/30_ingest_queries.sh
@@ -36,3 +36,5 @@ for host in migrate postgres; do
         exit 1
     fi
 done
+
+echo "30_ingest_queries completed successfully"

--- a/.github/integration/tests/postgres/40_verify_queries.sh
+++ b/.github/integration/tests/postgres/40_verify_queries.sh
@@ -3,29 +3,32 @@ set -eou pipefail
 
 export PGPASSWORD=verify
 corrID="33d29907-c565-4a90-98b4-e31b992ab376"
-fileID=$(psql -U verify -h postgres -d sda -At -c "SELECT DISTINCT file_id from sda.file_event_log WHERE correlation_id = '$corrID';")
 
-## get file status
-status=$(psql -U verify -h postgres -d sda -At -c "SELECT event from sda.file_event_log WHERE correlation_id = '$corrID' ORDER BY id DESC LIMIT 1;")
-if [ "$status" = "" ]; then
-    echo "get file status failed"
-    exit 1
-fi
+for host in migrate postgres; do
+    fileID=$(psql -U verify -h "$host" -d sda -At -c "SELECT DISTINCT file_id from sda.file_event_log WHERE correlation_id = '$corrID';")
 
-## get file header
-header="637279707434676801000000010000006c00000000000000"
-dbheader=$(psql -U verify -h postgres -d sda -At -c "SELECT header from sda.files WHERE id = '$fileID';")
-if [ "$dbheader" != "$header" ]; then
-    echo "wrong header recieved"
-    exit 1
-fi
+    ## get file status
+    status=$(psql -U verify -h "$host" -d sda -At -c "SELECT event from sda.file_event_log WHERE correlation_id = '$corrID' ORDER BY id DESC LIMIT 1;")
+    if [ "$status" = "" ]; then
+        echo "get file status failed"
+        exit 1
+    fi
 
-## mark file as 'COMPLETED'
-archive_checksum="64e56b0d245b819c116b5f1ad296632019490b57eeaebb419a5317e24a153852"
-decrypted_size="2034254"
-decrypted_checksum="febee6829a05772eea93c647e38bf5cc5bf33d1bcd0ea7d7bdd03225d84d2553"
-resp=$(psql -U verify -h postgres -d sda -At -c "SELECT sda.set_verified('$fileID', '$corrID', '$archive_checksum', 'SHA256', '$decrypted_size', '$decrypted_checksum', 'SHA256')")
-if [ "$resp" != "" ]; then
-    echo "set_verified failed"
-    exit 1
-fi
+    ## get file header
+    header="637279707434676801000000010000006c00000000000000"
+    dbheader=$(psql -U verify -h "$host" -d sda -At -c "SELECT header from sda.files WHERE id = '$fileID';")
+    if [ "$dbheader" != "$header" ]; then
+        echo "wrong header recieved"
+        exit 1
+    fi
+
+    ## mark file as 'COMPLETED'
+    archive_checksum="64e56b0d245b819c116b5f1ad296632019490b57eeaebb419a5317e24a153852"
+    decrypted_size="2034254"
+    decrypted_checksum="febee6829a05772eea93c647e38bf5cc5bf33d1bcd0ea7d7bdd03225d84d2553"
+    resp=$(psql -U verify -h "$host" -d sda -At -c "SELECT sda.set_verified('$fileID', '$corrID', '$archive_checksum', 'SHA256', '$decrypted_size', '$decrypted_checksum', 'SHA256')")
+    if [ "$resp" != "" ]; then
+        echo "set_verified failed"
+        exit 1
+    fi
+done

--- a/.github/integration/tests/postgres/40_verify_queries.sh
+++ b/.github/integration/tests/postgres/40_verify_queries.sh
@@ -32,3 +32,5 @@ for host in migrate postgres; do
         exit 1
     fi
 done
+
+echo "40_verify_queries completed successfully"

--- a/.github/integration/tests/postgres/50_finalize_queries.sh
+++ b/.github/integration/tests/postgres/50_finalize_queries.sh
@@ -15,3 +15,5 @@ for host in migrate postgres; do
         exit 1
     fi
 done
+
+echo "50_finalize_queries completed successfully"

--- a/.github/integration/tests/postgres/50_finalize_queries.sh
+++ b/.github/integration/tests/postgres/50_finalize_queries.sh
@@ -3,13 +3,15 @@ set -eou pipefail
 
 export PGPASSWORD=finalize
 
-## mark file as 'READY'
-accession="urn:uuid:7964e232-8830-4351-8adb-e4ebb71fafed"
-user="test-user"
-inbox_path="inbox/test-file.c4gh"
-decrypted_checksum="febee6829a05772eea93c647e38bf5cc5bf33d1bcd0ea7d7bdd03225d84d2553"
-resp=$(psql -U finalize -h postgres -d sda -At -c "UPDATE local_ega.files SET status = 'READY', stable_id = '$accession' WHERE elixir_id = '$user' and inbox_path = '$inbox_path' and decrypted_file_checksum = '$decrypted_checksum' and status = 'COMPLETED';")
-if [ "$resp" != "UPDATE 1" ]; then
-    echo "mark file ready failed"
-    exit 1
-fi
+for host in migrate postgres; do
+    ## mark file as 'READY'
+    accession="urn:uuid:7964e232-8830-4351-8adb-e4ebb71fafed"
+    user="test-user"
+    inbox_path="inbox/test-file.c4gh"
+    decrypted_checksum="febee6829a05772eea93c647e38bf5cc5bf33d1bcd0ea7d7bdd03225d84d2553"
+    resp=$(psql -U finalize -h "$host" -d sda -At -c "UPDATE local_ega.files SET status = 'READY', stable_id = '$accession' WHERE elixir_id = '$user' and inbox_path = '$inbox_path' and decrypted_file_checksum = '$decrypted_checksum' and status = 'COMPLETED';")
+    if [ "$resp" != "UPDATE 1" ]; then
+        echo "mark file ready failed"
+        exit 1
+    fi
+done

--- a/.github/integration/tests/postgres/60_mapper_queries.sh
+++ b/.github/integration/tests/postgres/60_mapper_queries.sh
@@ -44,3 +44,5 @@ for host in migrate postgres; do
         exit 1
     fi
 done
+
+echo "60_mapper_queries completed successfully"

--- a/.github/integration/tests/postgres/60_mapper_queries.sh
+++ b/.github/integration/tests/postgres/60_mapper_queries.sh
@@ -7,38 +7,40 @@ export PGPASSWORD=mapper
 accession="urn:uuid:7964e232-8830-4351-8adb-e4ebb71fafed"
 dataset="urn:neic:ci-test-dataset"
 
-file_id=$(psql -U mapper -h postgres -d sda -At -c "SELECT id FROM sda.files WHERE stable_id = '$accession';")
-if [ -z "$file_id" ]; then
-    echo "get file_id failed"
-    exit 1
-fi
+for host in migrate postgres; do
+    file_id=$(psql -U mapper -h "$host" -d sda -At -c "SELECT id FROM sda.files WHERE stable_id = '$accession';")
+    if [ -z "$file_id" ]; then
+        echo "get file_id failed"
+        exit 1
+    fi
 
-dataset_id=$(psql -U mapper -h postgres -d sda -At -c "INSERT INTO sda.datasets (stable_id) VALUES ('$dataset') ON CONFLICT DO NOTHING;")
-if [ "$dataset_id" != "INSERT 0 1" ]; then
-    echo "insert dataset failed"
-    exit 1
-fi
+    dataset_id=$(psql -U mapper -h "$host" -d sda -At -c "INSERT INTO sda.datasets (stable_id) VALUES ('$dataset') ON CONFLICT DO NOTHING;")
+    if [ "$dataset_id" != "INSERT 0 1" ]; then
+        echo "insert dataset failed"
+        exit 1
+    fi
 
-resp=$(psql -U mapper -h postgres -d sda -At -c "INSERT INTO sda.file_dataset (file_id, dataset_id) SELECT '$file_id', id FROM sda.datasets WHERE stable_id = '$dataset' ON CONFLICT DO NOTHING;")
-if [ "$resp" != "INSERT 0 1" ]; then
-    echo "map file to dataset failed"
-    exit 1
-fi
+    resp=$(psql -U mapper -h "$host" -d sda -At -c "INSERT INTO sda.file_dataset (file_id, dataset_id) SELECT '$file_id', id FROM sda.datasets WHERE stable_id = '$dataset' ON CONFLICT DO NOTHING;")
+    if [ "$resp" != "INSERT 0 1" ]; then
+        echo "map file to dataset failed"
+        exit 1
+    fi
 
-register=$(psql -U mapper -h postgres -d sda -At -c "INSERT INTO sda.dataset_event_log(dataset_id, event, message) VALUES('$dataset', 'registered', '{\"type\": \"mapping\"}');")
-if [ "$register" != "INSERT 0 1" ]; then
-    echo "update dataset event failed"
-    exit 1
-fi
+    register=$(psql -U mapper -h "$host" -d sda -At -c "INSERT INTO sda.dataset_event_log(dataset_id, event, message) VALUES('$dataset', 'registered', '{\"type\": \"mapping\"}');")
+    if [ "$register" != "INSERT 0 1" ]; then
+        echo "update dataset event failed"
+        exit 1
+    fi
 
-release=$(psql -U mapper -h postgres -d sda -At -c "INSERT INTO sda.dataset_event_log(dataset_id, event, message) VALUES('$dataset', 'released', '{\"type\": \"release\"}');")
-if [ "$release" != "INSERT 0 1" ]; then
-    echo "update dataset event failed"
-    exit 1
-fi
+    release=$(psql -U mapper -h "$host" -d sda -At -c "INSERT INTO sda.dataset_event_log(dataset_id, event, message) VALUES('$dataset', 'released', '{\"type\": \"release\"}');")
+    if [ "$release" != "INSERT 0 1" ]; then
+        echo "update dataset event failed"
+        exit 1
+    fi
 
-deprecate=$(psql -U mapper -h postgres -d sda -At -c "INSERT INTO sda.dataset_event_log(dataset_id, event, message) VALUES('$dataset', 'deprecated', '{\"type\": \"deprecate\"}');")
-if [ "$deprecate" != "INSERT 0 1" ]; then
-    echo "update dataset event failed"
-    exit 1
-fi
+    deprecate=$(psql -U mapper -h "$host" -d sda -At -c "INSERT INTO sda.dataset_event_log(dataset_id, event, message) VALUES('$dataset', 'deprecated', '{\"type\": \"deprecate\"}');")
+    if [ "$deprecate" != "INSERT 0 1" ]; then
+        echo "update dataset event failed"
+        exit 1
+    fi
+done

--- a/.github/integration/tests/postgres/70_download_queries.sh
+++ b/.github/integration/tests/postgres/70_download_queries.sh
@@ -5,31 +5,33 @@ export PGPASSWORD=download
 dataset="urn:neic:ci-test-dataset"
 accession="urn:uuid:7964e232-8830-4351-8adb-e4ebb71fafed"
 
-## get file info
-resp=$(psql -U download -h postgres -d sda -At -c "SELECT a.file_id, dataset_id, display_file_name, file_name, file_size, decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, file_status from local_ega_ebi.file a, local_ega_ebi.file_dataset b WHERE dataset_id = '$dataset' AND a.file_id=b.file_id;")
-if [ "$(echo "$resp" | cut -d '|' -f1)" != "$accession" ]; then
-    echo "get file info failed"
-    exit 1
-fi
+for host in migrate postgres; do
+    ## get file info
+    resp=$(psql -U download -h "$host" -d sda -At -c "SELECT a.file_id, dataset_id, display_file_name, file_name, file_size, decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, file_status from local_ega_ebi.file a, local_ega_ebi.file_dataset b WHERE dataset_id = '$dataset' AND a.file_id=b.file_id;")
+    if [ "$(echo "$resp" | cut -d '|' -f1)" != "$accession" ]; then
+        echo "get file info failed"
+        exit 1
+    fi
 
-## check dataset
-resp=$(psql -U download -h postgres -d sda -At -c "SELECT DISTINCT dataset_id FROM local_ega_ebi.file_dataset WHERE dataset_id = '$dataset'")
-if [ "$resp" != "$dataset" ]; then
-    echo "check dataset failed"
-    exit 1
-fi
+    ## check dataset
+    resp=$(psql -U download -h "$host" -d sda -At -c "SELECT DISTINCT dataset_id FROM local_ega_ebi.file_dataset WHERE dataset_id = '$dataset'")
+    if [ "$resp" != "$dataset" ]; then
+        echo "check dataset failed"
+        exit 1
+    fi
 
-## check file permissions
-resp=$(psql -U download -h postgres -d sda -At -c "SELECT dataset_id FROM local_ega_ebi.file_dataset WHERE file_id = '$accession'")
-if [ "$resp" != "$dataset" ]; then
-    echo "check file permissions failed"
-    exit 1
-fi
+    ## check file permissions
+    resp=$(psql -U download -h "$host" -d sda -At -c "SELECT dataset_id FROM local_ega_ebi.file_dataset WHERE file_id = '$accession'")
+    if [ "$resp" != "$dataset" ]; then
+        echo "check file permissions failed"
+        exit 1
+    fi
 
-## get file
-archive_path=d853c51b-6aed-4243-b427-177f5e588857
-resp=$(psql -U download -h postgres -d sda -At -c "SELECT file_path, archive_file_size, header FROM local_ega_ebi.file WHERE file_id = '$accession'")
-if [ "$(echo "$resp" | cut -d '|' -f1)" != "$archive_path" ]; then
-    echo "get file failed"
-    exit 1
-fi
+    ## get file
+    archive_path=d853c51b-6aed-4243-b427-177f5e588857
+    resp=$(psql -U download -h "$host" -d sda -At -c "SELECT file_path, archive_file_size, header FROM local_ega_ebi.file WHERE file_id = '$accession'")
+    if [ "$(echo "$resp" | cut -d '|' -f1)" != "$archive_path" ]; then
+        echo "get file failed"
+        exit 1
+    fi
+done

--- a/.github/integration/tests/postgres/70_download_queries.sh
+++ b/.github/integration/tests/postgres/70_download_queries.sh
@@ -35,3 +35,5 @@ for host in migrate postgres; do
         exit 1
     fi
 done
+
+echo "70_download_queries completed successfully"

--- a/postgresql/initdb.d/02_functions.sql
+++ b/postgresql/initdb.d/02_functions.sql
@@ -57,10 +57,10 @@ END;
 
 $set_archived$ LANGUAGE plpgsql;
 
-CREATE FUNCTION set_verified(file_uuid UUID, corr_id UUID, archive_checksum TEXT, archive_checksum_type TEXT, descrypted_size BIGINT, decrypted_checksum TEXT, decrypted_checksum_type TEXT)
+CREATE FUNCTION set_verified(file_uuid UUID, corr_id UUID, archive_checksum TEXT, archive_checksum_type TEXT, decrypted_size BIGINT, decrypted_checksum TEXT, decrypted_checksum_type TEXT)
 RETURNS void AS $set_verified$
 BEGIN
-    UPDATE sda.files SET decrypted_file_size = descrypted_size WHERE id = file_uuid;
+    UPDATE sda.files SET decrypted_file_size = decrypted_size WHERE id = file_uuid;
 
     INSERT INTO sda.checksums(file_id, checksum, type, source)
     VALUES(file_uuid, archive_checksum, upper(archive_checksum_type)::sda.checksum_algorithm, upper('ARCHIVED')::sda.checksum_source);

--- a/postgresql/migratedb.d/08.sql
+++ b/postgresql/migratedb.d/08.sql
@@ -32,10 +32,10 @@ BEGIN
 
     $set_archived$ LANGUAGE plpgsql;
 
-    CREATE FUNCTION sda.set_verified(file_uuid UUID, corr_id UUID, archive_checksum TEXT, archive_checksum_type TEXT, decrypted_checksum TEXT, decrypted_checksum_type TEXT, descrypted_size BIGINT)
+    CREATE FUNCTION sda.set_verified(file_uuid UUID, corr_id UUID, archive_checksum TEXT, archive_checksum_type TEXT, decrypted_size BIGINT, decrypted_checksum TEXT, decrypted_checksum_type TEXT)
     RETURNS void AS $set_verified$
     BEGIN
-        UPDATE sda.files SET decrypted_file_size = descrypted_size WHERE id = file_uuid;
+        UPDATE sda.files SET decrypted_file_size = decrypted_size WHERE id = file_uuid;
 
         INSERT INTO sda.checksums(file_id, checksum, type, source)
         VALUES(file_uuid, archive_checksum, upper(archive_checksum_type)::sda.checksum_algorithm, upper('ARCHIVED')::sda.checksum_source);

--- a/postgresql/migratedb.d/09.sql
+++ b/postgresql/migratedb.d/09.sql
@@ -30,6 +30,10 @@ BEGIN
         message    JSONB, -- The rabbitMQ message that initiated the dataset event
         event_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
     );
+
+    -- add new permissions
+    GRANT INSERT ON sda.dataset_event_log TO mapper;
+    GRANT USAGE, SELECT ON SEQUENCE sda.dataset_event_log_id_seq TO mapper;
   ELSE
     RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
   END IF;


### PR DESCRIPTION
* Fixes some of the migration scripts
* Expands the test suite to also run the queries against the container that is configured by running the migration scripts
* Prints exit messages for the test scripts to make it easier to see if it completed successfully