### PR TITLE
Fix/return login data in sda auth

### DIFF
--- a/sda-auth/dev-server/docker-compose.yml
+++ b/sda-auth/dev-server/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       - JWTISSUER=http://auth:8080
       - JWTPRIVATEKEY=keys/sign-jwt.key
       - JWTSIGNATUREALG=ES256
+      - INFOTEXT=About Federated EGA
+      - INFOURL=https://ega-archive.org/about/projects-and-funders/federated-ega/
     volumes:
       - ../keys:/keys
       - ../:/sda-auth

--- a/sda-auth/main.go
+++ b/sda-auth/main.go
@@ -150,11 +150,14 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 			}
 
 			s3conf := getS3ConfigMap(token, auth.Config.S3Inbox, username)
-			idStruct := EGAIdentity{User: username, Token: token, ExpDate: expDate}
 			s.SetFlash("ega", s3conf)
 			ctx.ViewData("infoUrl", auth.Config.InfoURL)
 			ctx.ViewData("infoText", auth.Config.InfoText)
-			err = ctx.View("ega.html", idStruct)
+			ctx.ViewData("User", username)
+			ctx.ViewData("Token", token)
+			ctx.ViewData("ExpDate", expDate)
+
+			err = ctx.View("ega.html")
 			if err != nil {
 				log.Error("Failed to parse response: ", err)
 
@@ -294,7 +297,12 @@ func (auth AuthHandler) getElixirLogin(ctx iris.Context) {
 	s.SetFlash("elixir", oidcData.S3Conf)
 	ctx.ViewData("infoUrl", auth.Config.InfoURL)
 	ctx.ViewData("infoText", auth.Config.InfoText)
-	err := ctx.View("elixir.html", oidcData.ElixirID)
+	ctx.ViewData("User", oidcData.ElixirID.User)
+	ctx.ViewData("Passport", oidcData.ElixirID.Passport)
+	ctx.ViewData("Token", oidcData.ElixirID.Token)
+	ctx.ViewData("ExpDate", oidcData.ElixirID.ExpDate)
+
+	err := ctx.View("elixir.html")
 	if err != nil {
 		log.Error("Failed to view login form: ", err)
 


### PR DESCRIPTION
`Context.View` of Iris  overrides any previous `Context.ViewData`  calls, therefore the project info configuration was not read properly in ega and elixir login pages, making the later malfunction.

This PR breaks out all variable passing into individual `ViewData` calls.

Closes #367.