### PR TITLE
[s3inbox] set correlation ID when updating file status

### DIFF
--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -182,7 +182,7 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
 			}
 
 			log.Debugf("marking file %v as 'uploaded' in database", p.fileIds[r.URL.Path])
-			err = p.database.UpdateFileEventLog(p.fileIds[r.URL.Path], "uploaded", username, string(jsonMessage))
+			err = p.database.UpdateFileStatus(p.fileIds[r.URL.Path], "uploaded", p.fileIds[r.URL.Path], "inbox", string(jsonMessage))
 			if err != nil {
 				log.Error(err)
 			}


### PR DESCRIPTION
Set the correlation ID when setting the file status to `uploaded`

closes #381 