### PR TITLE
[sda-auth] Make elixir endpoint optional

### DIFF
--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -75,6 +75,7 @@ spec:
           value: {{ .Values.global.log.level | quote }}
       {{- end }}
       {{- if not .Values.global.vaultSecrets }}
+      {{- if and (ne "" .Values.global.oidc.id) (ne "" .Values.global.oidc.secret) }}
         - name: ELIXIR_ID
           valueFrom:
             secretKeyRef:
@@ -85,6 +86,7 @@ spec:
             secretKeyRef:
               name: {{ template "sda.fullname" . }}-auth
               key: oidcSecret
+      {{- end }}
         {{- if or ( eq "federated" .Values.global.schemaType) ( eq "" .Values.global.schemaType) }}
         - name: CEGA_ID
           valueFrom:

--- a/charts/sda-svc/templates/auth-secrets.yaml
+++ b/charts/sda-svc/templates/auth-secrets.yaml
@@ -7,8 +7,10 @@ metadata:
   name: {{ template "sda.fullname" . }}-auth
 type: Opaque
 data:
+  {{- if and (ne "" .Values.global.oidc.id) (ne "" .Values.global.oidc.secret) }}
   oidcID: {{ .Values.global.oidc.id | quote | trimall "\"" | b64enc }}
   oidcSecret: {{ .Values.global.oidc.secret | quote | trimall "\"" | b64enc }}
+  {{- end }}
   {{- if or ( eq "federated" .Values.global.schemaType) ( eq "" .Values.global.schemaType) }}
   cegaID: {{ .Values.global.cega.user | quote | trimall "\"" | b64enc }}
   cegaSecret: {{ .Values.global.cega.password | quote | trimall "\"" | b64enc }}

--- a/sda-auth/README.md
+++ b/sda-auth/README.md
@@ -60,3 +60,7 @@ Using the provided Dockerfile, you may build a Docker image:
 ```bash
 docker build -t neicnordic/sda-auth:mytag <path-to-Dockerfile-folder>
 ```
+
+## Choosing provider login
+
+The `sda-auth` allows for two different type of login providers: `EGA` and `Elixir` (LS-AAI). It is possible, however, to run the `sda-auth` using only one of the parameters. In order to remove the `EGA` option, remove the `CEGA_ID` and `CEGA_SECRET` options for the configuration, while for removing the `Elixir` option, remove the `ELIXIR_ID` and `ELIXIR_SECRET` variables.

--- a/sda-auth/README.md
+++ b/sda-auth/README.md
@@ -63,4 +63,4 @@ docker build -t neicnordic/sda-auth:mytag <path-to-Dockerfile-folder>
 
 ## Choosing provider login
 
-The `sda-auth` allows for two different type of login providers: `EGA` and `Elixir` (LS-AAI). It is possible, however, to run the `sda-auth` using only one of the parameters. In order to remove the `EGA` option, remove the `CEGA_ID` and `CEGA_SECRET` options for the configuration, while for removing the `Elixir` option, remove the `ELIXIR_ID` and `ELIXIR_SECRET` variables.
+The `sda-auth` allows for two different type of login providers: `EGA` and `Elixir` (LS-AAI). It is possible, however, to run the `sda-auth` using only one of the providers. In order to remove the `EGA` option, remove the `CEGA_ID` and `CEGA_SECRET` options for the configuration, while for removing the `Elixir` option, remove the `ELIXIR_ID` and `ELIXIR_SECRET` variables.

--- a/sda-auth/config.go
+++ b/sda-auth/config.go
@@ -120,6 +120,11 @@ func (c *Config) readConfig() error {
 
 	c.Cega = cega
 
+	// Check the either cega or Elixir config exists
+	if (elixir.ID == "" || elixir.Secret == "") && (cega.ID == "" || cega.Secret == "") {
+		return fmt.Errorf("neither cega or elixir login configured")
+	}
+
 	// Read CORS settings
 	cors := CORSConfig{AllowCredentials: false}
 	if viper.IsSet("cors.origins") {

--- a/sda-auth/config_test.go
+++ b/sda-auth/config_test.go
@@ -228,4 +228,27 @@ func (suite *ConfigTests) TestConfig() {
 	// re-read the config
 	_, err = NewConfig()
 	assert.NoError(suite.T(), err)
+
+	// Repeat with Elixir secret but no ID
+	os.Setenv("ELIXIR_ID", "")
+
+	// re-read the config
+	_, err = NewConfig()
+	assert.Equal(suite.T(), err.Error(), "neither cega or elixir login configured")
+
+	// Repeat test without CEGA or Elixir login
+	os.Setenv("ELIXIR_ID", "")
+	os.Setenv("ELIXIR_SECRET", "")
+
+	// re-read the config
+	_, err = NewConfig()
+	assert.Equal(suite.T(), err.Error(), "neither cega or elixir login configured")
+
+	os.Setenv("CEGA_ID", fmt.Sprintf("env_%v", suite.CegaConfig.ID))
+	os.Setenv("CEGA_SECRET", fmt.Sprintf("env_%v", suite.CegaConfig.Secret))
+	os.Setenv("JWTPRIVATEKEY", fmt.Sprintf("%v_env", suite.JwtPrivateKey))
+
+	// re-read the config
+	_, err = NewConfig()
+	assert.NoError(suite.T(), err)
 }

--- a/sda-auth/main.go
+++ b/sda-auth/main.go
@@ -81,8 +81,12 @@ func (auth AuthHandler) getMain(ctx iris.Context) {
 // getLoginOptions returns the available login providers as JSON
 func (auth AuthHandler) getLoginOptions(ctx iris.Context) {
 
-	// Elixir is always available
-	response := []LoginOption{{Name: "Elixir", URL: "/elixir"}}
+	var response []LoginOption
+	// Only add the Elixir option if it has both id and secret
+	if auth.Config.Elixir.ID != "" && auth.Config.Elixir.Secret != "" {
+		response = append(response, LoginOption{Name: "Elixir", URL: "/elixir"})
+	}
+
 	// Only add the CEGA option if it has both id and secret
 	if auth.Config.Cega.ID != "" && auth.Config.Cega.Secret != "" {
 		response = append(response, LoginOption{Name: "EGA", URL: "/ega/login"})
@@ -361,8 +365,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialise OIDC client
-	oauth2Config, provider := getOidcClient(config.Elixir)
+	var oauth2Config oauth2.Config
+	var provider *oidc.Provider
+
+	if config.Elixir.ID != "" && config.Elixir.Secret != "" {
+		// Initialise OIDC client
+		oauth2Config, provider = getOidcClient(config.Elixir)
+	}
 
 	// Create handler struct for the web server
 	authHandler := AuthHandler{


### PR DESCRIPTION
This PR makes the Elixir endpoint of the sda-auth optional. Specifically, if the variables `Elixir_id` or `Elixir_secret` are not set, the sda-auth is running only with the EGA option.

Also, in case neither the EGA nor the Elixir options are set, the service will return an error, letting the user know that it cannot start.


The PR is now deployed on the fega-test namespace