### PR TITLE
Docs/spell check

### DIFF
--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -35,7 +35,6 @@ GRANT USAGE ON SCHEMA sda TO ingest;
 GRANT INSERT ON sda.files TO ingest;
 GRANT SELECT ON sda.files TO ingest;
 GRANT UPDATE ON sda.files TO ingest;
-GRANT UPDATE ON sda.files TO ingest;
 GRANT INSERT ON sda.checksums TO ingest;
 GRANT UPDATE ON sda.checksums TO ingest;
 GRANT SELECT ON sda.checksums TO ingest;
@@ -75,7 +74,6 @@ GRANT UPDATE ON local_ega.files TO verify;
 GRANT SELECT ON local_ega.main_to_files TO verify;
 GRANT SELECT ON local_ega.status_translation TO verify;
 GRANT UPDATE ON local_ega.main TO verify;
-GRANT UPDATE ON sda.files TO verify;
 GRANT INSERT, SELECT, UPDATE ON sda.checksums TO verify;
 GRANT USAGE, SELECT ON SEQUENCE sda.checksums_id_seq TO verify;
 
@@ -97,7 +95,6 @@ GRANT SELECT ON local_ega.main_to_files TO finalize;
 GRANT SELECT ON local_ega.status_translation TO finalize;
 GRANT UPDATE ON local_ega.files TO finalize;
 GRANT SELECT ON local_ega.files TO finalize;
-GRANT UPDATE ON sda.files TO finalize;
 GRANT INSERT, SELECT, UPDATE ON sda.checksums TO finalize;
 GRANT USAGE, SELECT ON SEQUENCE sda.checksums_id_seq TO finalize;
 

--- a/sda-auth/README.md
+++ b/sda-auth/README.md
@@ -42,7 +42,7 @@ The current setup also requires that `127.0.0.1  oidc` is added to `/etc/hosts`,
 This service can be run as a backend only, and in the case where the frontend
 is running somewhere else, CORS is needed.
 
-Recommended cors settings for a given host are:
+Recommended CORS settings for a given host are:
 
 ```txt
 export CORS_ORIGINS="https://<frontend-url>"

--- a/sda-pipeline/cmd/backup/backup.md
+++ b/sda-pipeline/cmd/backup/backup.md
@@ -36,17 +36,17 @@ These settings are only needed is `copyheader` is `true`.
 
 These settings control how backup connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `backup`)
 
  - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `completed`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
  - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
@@ -162,9 +162,9 @@ If the message can’t be validated it is discarded with an error message in the
 
 ## Communication
 
- - Backup reads messages from one rabbitmq queue (default `backup`)
+ - Backup reads messages from one RabbitMQ queue (default `backup`)
 
- - Backup writes messages to one rabbitmq queue (default `completed`)
+ - Backup writes messages to one RabbitMQ queue (default `completed`)
 
  - Backup optionally reads encryption headers from the database and can not be started without a database connection.
    This is done using the `GetArchived`, and `GetHeaderForStableID` functions.

--- a/sda-pipeline/cmd/finalize/finalize.md
+++ b/sda-pipeline/cmd/finalize/finalize.md
@@ -24,17 +24,17 @@ export LOG_FORMAT="json"
 
 These settings control how finalize connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `accessionIDs`)
 
  - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `backup`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
  - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
@@ -107,8 +107,8 @@ On error the service sleeps for up to 5 minutes to allow for database recovery, 
 
 ## Communication
 
- - Finalize reads messages from one rabbitmq queue (default `accessionIDs`).
+ - Finalize reads messages from one RabbitMQ queue (default `accessionIDs`).
 
- - Finalize writes messages to one rabbitmq queue (default `backup`).
+ - Finalize writes messages to one RabbitMQ queue (default `backup`).
 
  - Finalize assigns the accession ID to a file in the database using the `SetAccessionID` function.

--- a/sda-pipeline/cmd/ingest/ingest.md
+++ b/sda-pipeline/cmd/ingest/ingest.md
@@ -31,17 +31,17 @@ These settings control which crypt4gh keyfile is loaded.
 
 These settings control how ingest connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `ingest`)
 
  - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `archived`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
  - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
@@ -159,9 +159,9 @@ This error does not halt ingestion.
 
 ## Communication
 
- - Ingest reads messages from one rabbitmq queue (commonly `ingest`).
+ - Ingest reads messages from one RabbitMQ queue (commonly `ingest`).
 
- - Ingest writes messages to one rabbitmq queue (commonly `archived`).
+ - Ingest writes messages to one RabbitMQ queue (commonly `archived`).
 
  - Ingest inserts file information in the database using three database functions, `InsertFile`, `StoreHeader`, and `SetArchived`.
 

--- a/sda-pipeline/cmd/intercept/intercept.md
+++ b/sda-pipeline/cmd/intercept/intercept.md
@@ -23,15 +23,15 @@ export LOG_FORMAT="json"
 
 These settings control how intercept connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `files`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
 ### PostgreSQL Database settings:
 
@@ -103,6 +103,6 @@ This has no error handling as the resend-mechanism hasn't been finished.
 
 ## Communication
 
- - Intercept reads messages from one rabbitmq queue (default `files`).
+ - Intercept reads messages from one RabbitMQ queue (default `files`).
 
- - Intercept writes messages to three rabbitmq queues, `accessionIDs`, `ingest`, and `mappings`.
+ - Intercept writes messages to three RabbitMQ queues, `accessionIDs`, `ingest`, and `mappings`.

--- a/sda-pipeline/cmd/mapper/mapper.md
+++ b/sda-pipeline/cmd/mapper/mapper.md
@@ -23,15 +23,15 @@ export LOG_FORMAT="json"
 
 These settings control how mapper connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `mapper`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
  - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
@@ -103,6 +103,6 @@ If this fails an error will be written to the logs.
 
 ## Communication
 
- - Mapper reads messages from one rabbitmq queue (default `mappings`).
+ - Mapper reads messages from one RabbitMQ queue (default `mappings`).
 
  - Mapper maps files to datasets in the database using the `MapFilesToDataset` function.

--- a/sda-pipeline/cmd/verify/verify.md
+++ b/sda-pipeline/cmd/verify/verify.md
@@ -30,17 +30,17 @@ These settings control which crypt4gh keyfile is loaded.
 
 These settings control how verify connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `archived`)
 
  - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `verified`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
  - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
@@ -159,9 +159,9 @@ Otherwise the processing continues with verification:
 
 ## Communication
 
- - Verify reads messages from one rabbitmq queue (commonly `archived`).
+ - Verify reads messages from one RabbitMQ queue (commonly `archived`).
 
- - Verify writes messages to one rabbitmq queue (commonly `verified`).
+ - Verify writes messages to one RabbitMQ queue (commonly `verified`).
 
  - Verify gets the file encryption header from the database using `GetHeader`,
    and marks the files as `verified` (`COMPLETED` in db version <= 2.0) using `MarkCompleted`.

--- a/sda/cmd/finalize/finalize.md
+++ b/sda/cmd/finalize/finalize.md
@@ -25,12 +25,12 @@ export LOG_FORMAT="json"
 
 These settings control how finalize connects to the RabbitMQ message broker.
 
-- `BROKER_HOST`: hostname of the rabbitmq server
-- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_HOST`: hostname of the RabbitMQ server
+- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 - `BROKER_QUEUE`: message queue to read messages from (commonly `accessionIDs`)
 - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `backup`)
-- `BROKER_USER`: username to connect to rabbitmq
-- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_USER`: username to connect to RabbitMQ
+- `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings
@@ -120,6 +120,6 @@ For each message, these steps are taken (if not otherwise noted, errors halt pro
 
 ## Communication
 
-- Finalize reads messages from one rabbitmq queue (default `accessionIDs`).
-- Finalize writes messages to one rabbitmq queue (default `backup`).
+- Finalize reads messages from one RabbitMQ queue (default `accessionIDs`).
+- Finalize writes messages to one RabbitMQ queue (default `backup`).
 - Finalize assigns the accession ID to a file in the database using the `SetAccessionID` function.

--- a/sda/cmd/ingest/ingest.md
+++ b/sda/cmd/ingest/ingest.md
@@ -31,17 +31,17 @@ These settings control which crypt4gh keyfile is loaded.
 
 These settings control how ingest connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the rabbitmq server
+ - `BROKER_HOST`: hostname of the RabbitMQ server
 
- - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+ - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 
  - `BROKER_QUEUE`: message queue to read messages from (commonly `ingest`)
 
  - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `archived`)
 
- - `BROKER_USER`: username to connect to rabbitmq
+ - `BROKER_USER`: username to connect to RabbitMQ
 
- - `BROKER_PASSWORD`: password to connect to rabbitmq
+ - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
  - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
@@ -161,9 +161,9 @@ This error does not halt ingestion.
 
 ## Communication
 
- - Ingest reads messages from one rabbitmq queue (commonly `ingest`).
+ - Ingest reads messages from one RabbitMQ queue (commonly `ingest`).
 
- - Ingest writes messages to one rabbitmq queue (commonly `archived`).
+ - Ingest writes messages to one RabbitMQ queue (commonly `archived`).
 
  - Ingest inserts file information in the database using three database functions, `InsertFile`, `StoreHeader`, and `SetArchived`.
 

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -50,7 +50,7 @@ When running, intercept reads messages from the configured RabbitMQ queue (defau
 For each message, these steps are taken:
 
 1. The message type is read from the message `type` field.
-   1. If the message `type` is not known, an eror is logged and the message is Ack'ed.
+   1. If the message `type` is not known, an error is logged and the message is Ack'ed.
 2. The correct queue for the message is decided based on message type.
 3. The message is sent to the queue. This has no error handling as the resend-mechanism hasn't been finished.
 4. The message is Ack'ed.

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -26,11 +26,11 @@ export LOG_FORMAT="json"
 
 These settings control how intercept connects to the RabbitMQ message broker.
 
-- `BROKER_HOST`: hostname of the rabbitmq server
-- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_HOST`: hostname of the RabbitMQ server
+- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 - `BROKER_QUEUE`: message queue to read messages from (commonly `from_cega`)
-- `BROKER_USER`: username to connect to rabbitmq
-- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_USER`: username to connect to RabbitMQ
+- `BROKER_PASSWORD`: password to connect to RabbitMQ
 
 ### Logging settings
 

--- a/sda/cmd/mapper/mapper.md
+++ b/sda/cmd/mapper/mapper.md
@@ -26,11 +26,11 @@ export LOG_FORMAT="json"
 
 These settings control how mapper connects to the RabbitMQ message broker.
 
-- `BROKER_HOST`: hostname of the rabbitmq server
-- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_HOST`: hostname of the RabbitMQ server
+- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 - `BROKER_QUEUE`: message queue to read messages from (commonly `mapper`)
-- `BROKER_USER`: username to connect to rabbitmq
-- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_USER`: username to connect to RabbitMQ
+- `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings
@@ -84,7 +84,7 @@ If this fails an error will be written to the logs.
 
 ## Communication
 
-- Mapper reads messages from one rabbitmq queue (default `mappings`).
+- Mapper reads messages from one RabbitMQ queue (default `mappings`).
 - Mapper maps files to datasets in the database using the `MapFilesToDataset` function.
 - Mapper retrieves the inbox filepath from the database for each file using the `GetInboxPath` function.
 - Mapper sets the status of a dataset in the database using the `UpdateDatasetEvent` function.

--- a/sda/cmd/mapper/mapper.md
+++ b/sda/cmd/mapper/mapper.md
@@ -87,4 +87,4 @@ If this fails an error will be written to the logs.
 - Mapper reads messages from one rabbitmq queue (default `mappings`).
 - Mapper maps files to datasets in the database using the `MapFilesToDataset` function.
 - Mapper retrieves the inbox filepath from the database for each file using the `GetInboxPath` function.
-- Mapper sets the status of a dataset in the database usig the `UpdateDatasetEvent` function.
+- Mapper sets the status of a dataset in the database using the `UpdateDatasetEvent` function.

--- a/sda/cmd/s3inbox/s3inbox.md
+++ b/sda/cmd/s3inbox/s3inbox.md
@@ -35,12 +35,12 @@ These settings control the TLS status and where the service gets the public keys
 
 These settings control how verify connects to the RabbitMQ message broker.
 
-- `BROKER_HOST`: hostname of the rabbitmq server
-- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_HOST`: hostname of the RabbitMQ server
+- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 - `BROKER_QUEUE`: message queue to read messages from (commonly `archived`)
 - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `verified`)
-- `BROKER_USER`: username to connect to rabbitmq
-- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_USER`: username to connect to RabbitMQ
+- `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings
@@ -104,4 +104,4 @@ The s3inbox proxies uploads to an S3 compatible storage backend.
 
 - s3inbox proxies uploads to inbox storage.
 - s3inbox inserts file information in the database using the `RegisterFile` database function and marks it as uploaded in the `file_event_log`
-- s3inbox writes messages to one rabbitmq queue (commonly `inbox`).
+- s3inbox writes messages to one RabbitMQ queue (commonly `inbox`).

--- a/sda/cmd/verify/verify.md
+++ b/sda/cmd/verify/verify.md
@@ -33,12 +33,12 @@ These settings control which crypt4gh keyfile is loaded.
 
 These settings control how verify connects to the RabbitMQ message broker.
 
-- `BROKER_HOST`: hostname of the rabbitmq server
-- `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
+- `BROKER_HOST`: hostname of the RabbitMQ server
+- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
 - `BROKER_QUEUE`: message queue to read messages from (commonly `archived`)
 - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `verified`)
-- `BROKER_USER`: username to connect to rabbitmq
-- `BROKER_PASSWORD`: password to connect to rabbitmq
+- `BROKER_USER`: username to connect to RabbitMQ
+- `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
 
 ### PostgreSQL Database settings
@@ -147,8 +147,8 @@ Otherwise the processing continues with verification:
 
 ## Communication
 
-- Verify reads messages from one rabbitmq queue (commonly `archived`).
-- Verify writes messages to one rabbitmq queue (commonly `verified`).
+- Verify reads messages from one RabbitMQ queue (commonly `archived`).
+- Verify writes messages to one RabbitMQ queue (commonly `verified`).
 - Verify gets the file encryption header from the database using `GetHeader`,
 and marks the files as `verified` (`COMPLETED` in db version <= 2.0) using `MarkCompleted`.
 - Verify reads file data from archive storage and removes data from inbox storage.


### PR DESCRIPTION
- some db extra lines removed
- spell check for neic-sda docs
- use some standard way of writing names for e.g. RabbitMQ

Marking this ready so we can update easier the neic-sda docs