### PR TITLE
review docs + other consistency fixes

### DIFF
--- a/.github/integration/sda-posix-integration.yml
+++ b/.github/integration/sda-posix-integration.yml
@@ -30,7 +30,7 @@ services:
       - PGSSLROOTCERT=/certs/ca.crt
       - PGSSLCERT=/certs/client.crt
       - PGSSLKEY=/certs/client.key
-    image: python:3.10-slim
+    image: python:3.11-slim
     volumes:
       - ./scripts:/scripts
       - client_certs:/certs
@@ -170,7 +170,7 @@ services:
       - PGSSLKEY=/certs/client.key
       - PGSSLMODE=verify-ca
       - STORAGETYPE=posix
-    image: python:3.10-slim-bullseye
+    image: python:3.11-slim-bullseye
     profiles:
       - tests
     volumes:

--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -11,7 +11,7 @@ services:
         condition: service_healthy
     environment:
       - PGPASSWORD=rootpasswd
-    image: python:3.10-slim
+    image: python:3.11-slim
     volumes:
       - ./scripts:/scripts
       - shared:/shared
@@ -225,7 +225,7 @@ services:
       interval: 10s
       timeout: 2s
       retries: 6
-    image: python:3.10-slim
+    image: python:3.11-slim
     ports:
       - "8080:8080"
     restart: always
@@ -255,7 +255,7 @@ services:
     environment:
       - PGPASSWORD=rootpasswd
       - STORAGETYPE=s3
-    image: python:3.10-slim-bullseye
+    image: python:3.11-slim-bullseye
     profiles:
       - tests
     volumes:

--- a/.github/integration/sda/users.py
+++ b/.github/integration/sda/users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.11
 # -*- coding: utf-8 -*-
 
 import sys

--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -43,10 +43,10 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v4
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.11"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.11"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/sda-auth/.github/workflows/functionality.yml
+++ b/sda-auth/.github/workflows/functionality.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/sda-auth/tests/requirements.txt
+++ b/sda-auth/tests/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.31.0
-tox==3.19.0
-pytest==6.0.1
+tox==4.11.3
+pytest==7.4.3

--- a/sda-auth/tests/tox.ini
+++ b/sda-auth/tests/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist =  py{36,37}
+envlist =  py{311}
 skipsdist = True
 
 [testenv:unit_tests]
@@ -8,5 +8,4 @@ commands = pytest -s -x integration
 
 [gh-actions]
 python =
-    3.6: unit_tests
-    3.7: unit_tests
+    3.11: unit_tests

--- a/sda-download/.github/workflows/integration.yml
+++ b/sda-download/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/sda-download/dev_utils/compose-sda.yml
+++ b/sda-download/dev_utils/compose-sda.yml
@@ -101,7 +101,7 @@ services:
         pip install aiohttp Authlib
         python -u /mockoidc.py
     container_name: mockauth
-    image: python:3.8-slim
+    image: python:3.11-slim
     volumes:
       - ./mockoidc/mockoidc.py:/mockoidc.py
       - certs:/certs

--- a/sda-download/dev_utils/compose.yml
+++ b/sda-download/dev_utils/compose.yml
@@ -114,7 +114,7 @@ services:
         pip install aiohttp Authlib
         python -u /mockoidc.py
     container_name: mockauth
-    image: python:3.8-slim
+    image: python:3.11-slim
     volumes:
       - ./mockoidc/mockoidc.py:/mockoidc.py
       - certs:/certs

--- a/sda-pipeline/.github/workflows/integration.yml
+++ b/sda-pipeline/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.11"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/sda-sftp-inbox/dev_utils/users.py
+++ b/sda-sftp-inbox/dev_utils/users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.11
 # -*- coding: utf-8 -*-
 
 """

--- a/sda/Dockerfile
+++ b/sda/Dockerfile
@@ -15,7 +15,7 @@ ARG SOURCE_COMMIT
 LABEL org.opencontainers.image.authors="NeIC System Developers"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=now()
-LABEL org.label-schema.vcs-url="https://github.com/neicnordic/sda-pipeline"
+LABEL org.label-schema.vcs-url="https://github.com/neicnordic/sensitive-data-archive"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
 COPY --from=Build /go/sda-* /usr/local/bin/
@@ -30,7 +30,7 @@ ARG SOURCE_COMMIT
 LABEL org.opencontainers.image.authors="NeIC System Developers"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=now()
-LABEL org.label-schema.vcs-url="https://github.com/neicnordic/sda-pipeline"
+LABEL org.label-schema.vcs-url="https://github.com/neicnordic/sensitive-data-archive"
 LABEL org.label-schema.vcs-ref=$SOURCE_COMMIT
 
 COPY --from=Build /go/sda-* /usr/local/bin/

--- a/sda/cmd/finalize/finalize.md
+++ b/sda/cmd/finalize/finalize.md
@@ -1,4 +1,4 @@
-# sda-pipeline: finalize
+# finalize Service
 
 Handles the so-called _Accession ID (stable ID)_ to filename mappings from Central EGA.
 At the same time the service fulfills the replication requirement of having distinct backup copies.

--- a/sda/cmd/finalize/finalize.md
+++ b/sda/cmd/finalize/finalize.md
@@ -1,10 +1,12 @@
 # sda-pipeline: finalize
 
 Handles the so-called _Accession ID (stable ID)_ to filename mappings from Central EGA.
+At the same time the service fulfills the replication requirement of having distinct backup copies.
+For more information see [Federated EGA Node Operations v2](https://ega-archive.org/assets/files/EGA-Node-Operations-v2.pdf) document.
 
 ## Configuration
 
-There are a number of options that can be set for the finalize service.
+There are a number of options that can be set for the `finalize` service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
 ex.
 
@@ -23,25 +25,24 @@ export LOG_FORMAT="json"
 
 ### RabbitMQ broker settings
 
-These settings control how finalize connects to the RabbitMQ message broker.
+These settings control how `finalize` connects to the RabbitMQ message broker.
 
 - `BROKER_HOST`: hostname of the RabbitMQ server
-- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
-- `BROKER_QUEUE`: message queue to read messages from (commonly `accessionIDs`)
-- `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `backup`)
+- `BROKER_PORT`: RabbitMQ broker port (commonly: `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly: `accession`)
+- `BROKER_ROUTINGKEY`: Routing key for publishing messages (commonly: `completed`)
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
-- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
 
 ### PostgreSQL Database settings
 
 - `DB_HOST`: hostname for the postgresql database
-- `DB_PORT`: database port (commonly 5432)
+- `DB_PORT`: database port (commonly: `5432`)
 - `DB_USER`: username for the database
 - `DB_PASSWORD`: password for the database
 - `DB_DATABASE`: database name
-- `DB_SSLMODE`: The TLS encryption policy to use for database connections.
- Valid options are:
+- `DB_SSLMODE`: The TLS encryption policy to use for database connections, valid options are:
   - `disable`
   - `allow`
   - `prefer`
@@ -49,11 +50,11 @@ These settings control how finalize connects to the RabbitMQ message broker.
   - `verify-ca`
   - `verify-full`
 
-   More information is available
-   [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
+  More information is available
+  [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
 
-   Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
-   and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
+  Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
+  and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set.
 
 - `DB_CLIENTKEY`: key-file for the database client certificate
 - `DB_CLIENTCERT`: database client certificate file
@@ -61,9 +62,7 @@ These settings control how finalize connects to the RabbitMQ message broker.
 
 ### Logging settings
 
-- `LOG_FORMAT` can be set to “json” to get logs in json format.
- All other values result in text logging
-
+- `LOG_FORMAT` can be set to `json` to get logs in JSON format. All other values result in text logging.
 - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
   - `trace`
   - `debug`
@@ -93,7 +92,7 @@ if `*_TYPE` is `S3` then the following variables are available:
 - `*_PORT`: S3 connection port (default: `443`)
 - `*_REGION`: S3 region (default: `us-east-1`)
 - `*_CHUNKSIZE`: S3 chunk size for multipart uploads.
-- `*_CACERT`: Certificate Authority (CA) certificate for the storage system, tjhis is only needed if the S3 server has a certificate signed by a private entity
+- `*_CACERT`: Certificate Authority (CA) certificate for the storage system, this is only needed if the S3 server has a certificate signed by a private entity
 
 and if `*_TYPE` is `POSIX`:
 
@@ -101,25 +100,25 @@ and if `*_TYPE` is `POSIX`:
 
 ## Service Description
 
-Finalize adds stable, shareable _Accession ID_'s to archive files.
+`Finalize` adds stable, shareable _Accession ID_'s to archive files.
 If a backup location is configured it will perform backup of a file.
-When running, finalize reads messages from the configured RabbitMQ queue (default "accessionIDs").
+When running, `finalize` reads messages from the configured RabbitMQ queue (commonly: `accession`).
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
 
-1. The message is validated as valid JSON that matches the "ingestion-accession" schema. If the message can’t be validated it is discarded with an error message in the logs.
-2. If the service is configured to perform backups i.e. the `ARCHIVE_` and `BACKUP_` storage backends is set. Archived files will be copied to the backup location.
+1. The message is validated as valid JSON that matches the `ingestion-accession` schema. If the message can’t be validated it is discarded with an error message in the logs.
+2. If the service is configured to perform backups i.e. the `ARCHIVE_` and `BACKUP_` storage backend are set. Archived files will be copied to the backup location.
    1. The file size on disk is requested from the storage system.
    2. The database file size is compared against the disk file size.
-   3. A file reader is created for the archive storage file, and a file writer is created for the backup storage file..
+   3. A file reader is created for the archive storage file, and a file writer is created for the backup storage file.
 3. The file data is copied from the archive file reader to the backup file writer.
 4. If the type of the `DecryptedChecksums` field in the message is `sha256`, the value is stored.
-5. A new RabbitMQ "complete" message is created and validated against the "ingestion-completion" schema. If the validation fails, an error message is written to the logs.
-6. The file accession ID in the message is marked as "ready" in the database. On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
+5. A new RabbitMQ `complete` message is created and validated against the `ingestion-completion` schema. If the validation fails, an error message is written to the logs.
+6. The file accession ID in the message is marked as *ready* in the database. On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
 7. The complete message is sent to RabbitMQ. On error, a message is written to the logs.
 8. The original RabbitMQ message is Ack'ed.
 
 ## Communication
 
-- Finalize reads messages from one RabbitMQ queue (default `accessionIDs`).
-- Finalize writes messages to one RabbitMQ queue (default `backup`).
-- Finalize assigns the accession ID to a file in the database using the `SetAccessionID` function.
+- `Finalize` reads messages from one RabbitMQ queue (commonly: `accession`).
+- `Finalize` publishes messages with one routing key  (commonly: `completed`).
+- `Finalize` assigns the accession ID to a file in the database using the `SetAccessionID` function.

--- a/sda/cmd/ingest/ingest.md
+++ b/sda/cmd/ingest/ingest.md
@@ -5,7 +5,7 @@ is sent to the storage backend (archive). No cryptographic tasks are done.
 
 ## Configuration
 
-There are a number of options that can be set for the ingest service.
+There are a number of options that can be set for the `ingest` service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
 
 ex.
@@ -29,54 +29,40 @@ These settings control which crypt4gh keyfile is loaded.
 
 ### RabbitMQ broker settings
 
-These settings control how ingest connects to the RabbitMQ message broker.
+These settings control how `ingest` connects to the RabbitMQ message broker.
 
- - `BROKER_HOST`: hostname of the RabbitMQ server
-
- - `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
-
- - `BROKER_QUEUE`: message queue to read messages from (commonly `ingest`)
-
- - `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `archived`)
-
- - `BROKER_USER`: username to connect to RabbitMQ
-
- - `BROKER_PASSWORD`: password to connect to RabbitMQ
-
- - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+- `BROKER_HOST`: hostname of the RabbitMQ server
+- `BROKER_PORT`: RabbitMQ broker port (commonly: `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly: `ingest`)
+- `BROKER_ROUTINGKEY`: Routing key for publishing messages (commonly: `archived`)
+- `BROKER_USER`: username to connect to RabbitMQ
+- `BROKER_PASSWORD`: password to connect to RabbitMQ
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
 
 ### PostgreSQL Database settings:
 
- - `DB_HOST`: hostname for the postgresql database
+- `DB_HOST`: hostname for the postgresql database
+- `DB_PORT`: database port (commonly: `5432`)
+- `DB_USER`: username for the database
+- `DB_PASSWORD`: password for the database
+- `DB_DATABASE`: database name
+- `DB_SSLMODE`: The TLS encryption policy to use for database connections, valid options are:
+  - `disable`
+  - `allow`
+  - `prefer`
+  - `require`
+  - `verify-ca`
+  - `verify-full`
 
- - `DB_PORT`: database port (commonly 5432)
+  More information is available
+  [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
 
- - `DB_USER`: username for the database
+  Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
+  and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set.
 
- - `DB_PASSWORD`: password for the database
-
- - `DB_DATABASE`: database name
-
- - `DB_SSLMODE`: The TLS encryption policy to use for database connections.
-   Valid options are:
-    - `disable`
-    - `allow`
-    - `prefer`
-    - `require`
-    - `verify-ca`
-    - `verify-full`
-
-   More information is available
-   [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
-
-   Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
-   and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
-
- - `DB_CLIENTKEY`: key-file for the database client certificate
-
- - `DB_CLIENTCERT`: database client certificate file
-
- - `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
+- `DB_CLIENTKEY`: key-file for the database client certificate
+- `DB_CLIENTCERT`: database client certificate file
+- `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
 
 ### Storage settings
 
@@ -97,74 +83,58 @@ if `*_TYPE` is `S3` then the following variables are available:
  - `*_PORT`: S3 connection port (default: `443`)
  - `*_REGION`: S3 region (default: `us-east-1`)
  - `*_CHUNKSIZE`: S3 chunk size for multipart uploads.
-# CA certificate is only needed if the S3 server has a certificate signed by a private entity
- - `*_CACERT`: Certificate Authority (CA) certificate for the storage system
+ - `*_CACERT`: Certificate Authority (CA) certificate for the storage system, this is only needed if the S3 server has a certificate signed by a private entity
 
 and if `*_TYPE` is `POSIX`:
  - `*_LOCATION`: POSIX path to use as storage root
 
 ### Logging settings:
 
- - `LOG_FORMAT` can be set to “json” to get logs in json format.
-   All other values result in text logging
-
- - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
-    - `trace`
-    - `debug`
-    - `info`
-    - `warn` (or `warning`)
-    - `error`
-    - `fatal`
-    - `panic`
+- `LOG_FORMAT` can be set to `json` to get logs in JSON format. All other values result in text logging.
+- `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn` (or `warning`)
+  - `error`
+  - `fatal`
+  - `panic`
 
 ## Service Description
-The ingest service copies files from the file inbox to the archive, and registers them in the database.
 
-When running, ingest reads messages from the configured RabbitMQ queue (default: "ingest").
+The `ingest` service copies files from the file inbox to the archive, and registers them in the database.
+
+When running, `ingest` reads messages from the configured RabbitMQ queue (commonly: `ingest`).
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
 
-1. The message is validated as valid JSON that matches the "ingestion-trigger" schema.
+1. The message is validated as valid JSON that matches the `ingestion-trigger` schema.
 If the message can’t be validated it is discarded with an error message in the logs.
-
-1. If the message is of type `cancel`, the file will be marked as `disabled` and the next message in the queue will be read.
-
-1. A file reader is created for the filepath in the message.
+2. If the message is of type `cancel`, the file will be marked as `disabled` and the next message in the queue will be read.
+3. A file reader is created for the filepath in the message.
 If the file reader can’t be created an error is written to the logs, the message is Nacked and forwarded to the error queue.
-
-1. The file size is read from the file reader.
+4. The file size is read from the file reader.
 On error, the error is written to the logs, the message is Nacked and forwarded to the error queue.
-
-1. A uuid is generated, and a file writer is created in the archive using the uuid as filename.
+5. A uuid is generated, and a file writer is created in the archive using the uuid as filename.
 On error the error is written to the logs and the message is Nacked and then re-queued.
-
-1. The filename is inserted into the database along with the user id of the uploading user. In case the file is already existing in the database, the status is updated.
+6. The filename is inserted into the database along with the user id of the uploading user. In case the file is already existing in the database, the status is updated.
 Errors are written to the error log.
 Errors writing the filename to the database do not halt ingestion progress.
-
-1. The header is read from the file, and decrypted to ensure that it’s encrypted with the correct key.
+7. The header is read from the file, and decrypted to ensure that it’s encrypted with the correct key.
 If the decryption fails, an error is written to the error log, the message is Nacked, and the message is forwarded to the error queue.
-
-1. The header is written to the database.
+8. The header is written to the database.
 Errors are written to the error log.
-
-1. The header is stripped from the file data, and the remaining file data is written to the archive.
+9. The header is stripped from the file data, and the remaining file data is written to the archive.
 Errors are written to the error log.
-
-1. The size of the archived file is read.
+10. The size of the archived file is read.
 Errors are written to the error log.
-
-1. The database is updated with the file size, archive path, and archive checksum, and the file is set as “archived”.
+11. The database is updated with the file size, archive path, and archive checksum, and the file is set as *archived*.
 Errors are written to the error log.
 This error does not halt ingestion.
-
-1. A message is sent back to the original RabbitMQ broker containing the upload user, upload file path, database file id, archive file path and checksum of the archived file.
+12. A message is sent back to the original RabbitMQ broker containing the upload user, upload file path, database file id, archive file path and checksum of the archived file.
 
 ## Communication
 
- - Ingest reads messages from one RabbitMQ queue (commonly `ingest`).
-
- - Ingest writes messages to one RabbitMQ queue (commonly `archived`).
-
- - Ingest inserts file information in the database using three database functions, `InsertFile`, `StoreHeader`, and `SetArchived`.
-
- - Ingest reads file data from inbox storage and writes data to archive storage.
+- `Ingest` reads messages from one RabbitMQ queue (commonly: `ingest`).
+- `Ingest` publishes messages to one RabbitMQ queue (commonly: `archived`).
+- `Ingest` inserts file information in the database using three database functions, `InsertFile`, `StoreHeader`, and `SetArchived`.
+- `Ingest` reads file data from inbox storage and writes data to archive storage.

--- a/sda/cmd/ingest/ingest.md
+++ b/sda/cmd/ingest/ingest.md
@@ -1,4 +1,4 @@
-# sda-pipeline: ingest
+# ingest Service
 
 Splits the Crypt4GH header and moves it to database. The remainder of the file
 is sent to the storage backend (archive). No cryptographic tasks are done.

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -1,4 +1,4 @@
-# sda-pipeline: intercept
+# intercept Service
 
 The `intercept` service relays messages between Central EGA and Federated EGA nodes.
 

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -1,10 +1,10 @@
 # sda-pipeline: intercept
 
-The intercept service relays messages between Central EGA and Federated EGA nodes.
+The `intercept` service relays messages between Central EGA and Federated EGA nodes.
 
 ## Configuration
 
-There are a number of options that can be set for the intercept service.
+There are a number of options that can be set for the `intercept` service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
 
 ex.
@@ -24,17 +24,17 @@ export LOG_FORMAT="json"
 
 ### RabbitMQ broker settings
 
-These settings control how intercept connects to the RabbitMQ message broker.
+These settings control how `intercept` connects to the RabbitMQ message broker.
 
 - `BROKER_HOST`: hostname of the RabbitMQ server
-- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
-- `BROKER_QUEUE`: message queue to read messages from (commonly `from_cega`)
+- `BROKER_PORT`: RabbitMQ broker port (commonly: `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly: `from_cega`)
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
 
 ### Logging settings
 
-- `LOG_FORMAT` can be set to “json” to get logs in json format, all other values result in text logging
+- `LOG_FORMAT` can be set to “json” to get logs in json format, all other values result in text logging.
 - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
   - `trace`
   - `debug`
@@ -46,7 +46,7 @@ These settings control how intercept connects to the RabbitMQ message broker.
 
 ## Service Description
 
-When running, intercept reads messages from the configured RabbitMQ queue (default: "from_cega").
+When running, `intercept` reads messages from the configured RabbitMQ queue (commnly `from_cega`).
 For each message, these steps are taken:
 
 1. The message type is read from the message `type` field.
@@ -57,5 +57,5 @@ For each message, these steps are taken:
 
 ## Communication
 
-- Intercept reads messages from one queue (default `from_cega`).
-- Intercept writes messages to three queues, `accession`, `ingest`, and `mappings`.
+- `Intercept` reads messages from one queue (commonly: `from_cega`).
+- `Intercept` publishes messages to three queues, `accession`, `ingest`, and `mappings`.

--- a/sda/cmd/mapper/mapper.md
+++ b/sda/cmd/mapper/mapper.md
@@ -1,4 +1,4 @@
-# sda-pipeline: mapper
+# mapper Service
 
 The mapper service registers mapping of accessionIDs (stable ids for files) to datasetIDs.
 Once the file accession ID has been mapped to a dataset ID, the file is removed from the inbox.

--- a/sda/cmd/mapper/mapper.md
+++ b/sda/cmd/mapper/mapper.md
@@ -1,10 +1,11 @@
 # sda-pipeline: mapper
 
 The mapper service registers mapping of accessionIDs (stable ids for files) to datasetIDs.
+Once the file accession ID has been mapped to a dataset ID, the file is removed from the inbox.
 
 ## Configuration
 
-There are a number of options that can be set for the mapper service.
+There are a number of options that can be set for the `mapper` service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
 
 ex.
@@ -24,23 +25,23 @@ export LOG_FORMAT="json"
 
 ### RabbitMQ broker settings
 
-These settings control how mapper connects to the RabbitMQ message broker.
+These settings control how `mapper` connects to the RabbitMQ message broker.
 
 - `BROKER_HOST`: hostname of the RabbitMQ server
-- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
-- `BROKER_QUEUE`: message queue to read messages from (commonly `mapper`)
+- `BROKER_PORT`: RabbitMQ broker port (commonly: `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly: `mappings`)
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
-- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
 
 ### PostgreSQL Database settings
 
 - `DB_HOST`: hostname for the postgresql database
-- `DB_PORT`: database port (commonly 5432)
+- `DB_PORT`: database port (commonly: `5432`)
 - `DB_USER`: username for the database
 - `DB_PASSWORD`: password for the database
 - `DB_DATABASE`: database name
-- `DB_SSLMODE`: The TLS encryption policy to use for database connections.  Valid options are:
+- `DB_SSLMODE`: The TLS encryption policy to use for database connections, valid options are:
   - `disable`
   - `allow`
   - `prefer`
@@ -48,16 +49,42 @@ These settings control how mapper connects to the RabbitMQ message broker.
   - `verify-ca`
   - `verify-full`
 
-More information is available in the [postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)  
-Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set, and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
+  More information is available in the [postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)  
+  Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set, and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set.
 
 - `DB_CLIENTKEY`: key-file for the database client certificate
 - `DB_CLIENTCERT`: database client certificate file
 - `DB_CACERT`: Certificate Authority (CA) certificate for the database to use
 
+### Storage settings
+
+Storage backend is defined by the `INBOX_TYPE` variable.
+Valid values for these options are `S3` or `POSIX`
+(Defaults to `POSIX` on unknown values).
+
+The value of these variables define what other variables are read.
+The same variables are available for all storage types, differing by prefix (`INBOX_`)
+
+if `*_TYPE` is `S3` then the following variables are available:
+
+- `*_URL`: URL to the S3 system
+- `*_ACCESSKEY`: The S3 access and secret key are used to authenticate to S3,
+ [more info at AWS](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+- `*_SECRETKEY`: The S3 access and secret key are used to authenticate to S3,
+ [more info at AWS](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+- `*_BUCKET`: The S3 bucket to use as the storage root
+- `*_PORT`: S3 connection port (default: `443`)
+- `*_REGION`: S3 region (default: `us-east-1`)
+- `*_CHUNKSIZE`: S3 chunk size for multipart uploads.
+- `*_CACERT`: Certificate Authority (CA) certificate for the storage system, this is only needed if the S3 server has a certificate signed by a private entity
+
+and if `*_TYPE` is `POSIX`:
+
+- `*_LOCATION`: POSIX path to use as storage root
+
 ### Logging settings
 
-- `LOG_FORMAT` can be set to “json” to get logs in json format. All other values result in text logging
+- `LOG_FORMAT` can be set to `json` to get logs in JSON format. All other values result in text logging.
 - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
   - `trace`
   - `debug`
@@ -69,12 +96,12 @@ Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` nee
 
 ## Service Description
 
-The mapper service maps file accessionIDs to datasetIDs.
+The `mapper` service maps file `accessionIDs` to `datasetIDs`.
 
-When running, mapper reads messages from the configured RabbitMQ queue (default: "mappings").  
+When running, `mapper` reads messages from the configured RabbitMQ queue (commonly: `mappings`).  
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message):
 
-1. The message is validated as valid JSON that matches the "dataset-mapping" schema.  
+1. The message is validated as valid JSON that matches the `dataset-mapping` schema.  
 If the message can’t be validated it is discarded with an error message is logged.
 2. AccessionIDs from the message are mapped to a datasetID (also in the message) in the database.  
 On error the service sleeps for up to 5 minutes to allow for database recovery, after 5 minutes the message is Nacked, re-queued and an error message is written to the logs.
@@ -84,7 +111,8 @@ If this fails an error will be written to the logs.
 
 ## Communication
 
-- Mapper reads messages from one RabbitMQ queue (default `mappings`).
-- Mapper maps files to datasets in the database using the `MapFilesToDataset` function.
-- Mapper retrieves the inbox filepath from the database for each file using the `GetInboxPath` function.
-- Mapper sets the status of a dataset in the database using the `UpdateDatasetEvent` function.
+- `Mapper` reads messages from one RabbitMQ queue (commonly: `mappings`).
+- `Mapper` maps files to datasets in the database using the `MapFilesToDataset` function.
+- `Mapper` retrieves the inbox filepath from the database for each file using the `GetInboxPath` function.
+- `Mapper` sets the status of a dataset in the database using the `UpdateDatasetEvent` function.
+- `Mapper` removes data from inbox storage.

--- a/sda/cmd/s3inbox/s3inbox.md
+++ b/sda/cmd/s3inbox/s3inbox.md
@@ -1,10 +1,10 @@
 # sda-pipeline: s3inbox
 
-The s3inbox proxies uploads to the an S3 compatible storage backend. Users are authenticated with a JWT instead of `access_key` and `secret_key` used normally for `S3`.
+The `s3inbox` proxies uploads to the an S3 compatible storage backend. Users are authenticated with a JWT instead of `access_key` and `secret_key` used normally for `S3`.
 
 ## Configuration
 
-There are a number of options that can be set for the s3inbox service.
+There are a number of options that can be set for the `s3inbox` service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
 
 ex.
@@ -36,17 +36,17 @@ These settings control the TLS status and where the service gets the public keys
 These settings control how verify connects to the RabbitMQ message broker.
 
 - `BROKER_HOST`: hostname of the RabbitMQ server
-- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
-- `BROKER_QUEUE`: message queue to read messages from (commonly `archived`)
-- `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `verified`)
+- `BROKER_PORT`: RabbitMQ broker port (commonly: `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly: `archived`)
+- `BROKER_ROUTINGKEY`: Routing key for publishing messages (commonly: `verified`)
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
-- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
 
 ### PostgreSQL Database settings
 
 - `DB_HOST`: hostname for the postgresql database
-- `DB_PORT`: database port (commonly 5432)
+- `DB_PORT`: database port (commonly: `5432`)
 - `DB_PASSWORD`: password for the database
 - `DB_DATABASE`: database name
 - `DB_SSLMODE`: The TLS encryption policy to use for database connections, valid options are:
@@ -56,10 +56,11 @@ These settings control how verify connects to the RabbitMQ message broker.
   - `require`
   - `verify-ca`
   - `verify-full`  
-   More information is available
-   [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)  
 
-Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set, and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
+  More information is available
+  [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)  
+
+  Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set, and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set.
 
 - `DB_CLIENTKEY`: key-file for the database client certificate
 - `DB_CLIENTCERT`: database client certificate file
@@ -93,7 +94,7 @@ Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` nee
 
 ## Service Description
 
-The s3inbox proxies uploads to an S3 compatible storage backend.
+The `s3inbox` proxies uploads to an S3 compatible storage backend.
 
 1. Parses and validates the JWT token (`access_token` in the S3 config file) against the public keys, either locally provisioned or from OIDC JWK endpoints.
 2. If the token is valid the file is passed on to the S3 backend
@@ -102,6 +103,6 @@ The s3inbox proxies uploads to an S3 compatible storage backend.
 
 ## Communication
 
-- s3inbox proxies uploads to inbox storage.
-- s3inbox inserts file information in the database using the `RegisterFile` database function and marks it as uploaded in the `file_event_log`
-- s3inbox writes messages to one RabbitMQ queue (commonly `inbox`).
+- `s3inbox` proxies uploads to inbox storage.
+- `s3inbox` inserts file information in the database using the `RegisterFile` database function and marks it as uploaded in the `file_event_log`
+- `s3inbox` writes messages to one RabbitMQ queue (commonly: `inbox`).

--- a/sda/cmd/s3inbox/s3inbox.md
+++ b/sda/cmd/s3inbox/s3inbox.md
@@ -1,4 +1,4 @@
-# sda-pipeline: s3inbox
+# s3inbox Service
 
 The `s3inbox` proxies uploads to the an S3 compatible storage backend. Users are authenticated with a JWT instead of `access_key` and `secret_key` used normally for `S3`.
 

--- a/sda/cmd/verify/verify.md
+++ b/sda/cmd/verify/verify.md
@@ -1,4 +1,4 @@
-# sda-pipeline: verify
+# verify Service
 
 Uses a crypt4gh secret key, this service can decrypt the stored files and checksum them against the embedded checksum for the unencrypted file.
 

--- a/sda/cmd/verify/verify.md
+++ b/sda/cmd/verify/verify.md
@@ -4,7 +4,7 @@ Uses a crypt4gh secret key, this service can decrypt the stored files and checks
 
 ## Configuration
 
-There are a number of options that can be set for the verify service.
+There are a number of options that can be set for the `verify` service.
 These settings can be set by mounting a yaml-file at `/config.yaml` with settings.
 
 ex.
@@ -31,20 +31,20 @@ These settings control which crypt4gh keyfile is loaded.
 
 ### RabbitMQ broker settings
 
-These settings control how verify connects to the RabbitMQ message broker.
+These settings control how `verify` connects to the RabbitMQ message broker.
 
 - `BROKER_HOST`: hostname of the RabbitMQ server
-- `BROKER_PORT`: RabbitMQ broker port (commonly `5671` with TLS and `5672` without)
-- `BROKER_QUEUE`: message queue to read messages from (commonly `archived`)
-- `BROKER_ROUTINGKEY`: message queue to write success messages to (commonly `verified`)
+- `BROKER_PORT`: RabbitMQ broker port (commonly: `5671` with TLS and `5672` without)
+- `BROKER_QUEUE`: message queue to read messages from (commonly: `archived`)
+- `BROKER_ROUTINGKEY`: Routing key for publishing messages (commonly: `verified`)
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
-- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to 2)
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
 
 ### PostgreSQL Database settings
 
 - `DB_HOST`: hostname for the postgresql database
-- `DB_PORT`: database port (commonly 5432)
+- `DB_PORT`: database port (commonly: `5432`)
 - `DB_USER`: username for the database
 - `DB_PASSWORD`: password for the database
 - `DB_DATABASE`: database name
@@ -56,11 +56,11 @@ These settings control how verify connects to the RabbitMQ message broker.
   - `verify-ca`
   - `verify-full`
 
-   More information is available
-   [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
+  More information is available
+  [in the postgresql documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
 
-   Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
-   and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set
+  Note that if `DB_SSLMODE` is set to anything but `disable`, then `DB_CACERT` needs to be set,
+  and if set to `verify-full`, then `DB_CLIENTCERT`, and `DB_CLIENTKEY` must also be set.
 
 - `DB_CLIENTKEY`: key-file for the database client certificate
 - `DB_CLIENTCERT`: database client certificate file
@@ -68,12 +68,12 @@ These settings control how verify connects to the RabbitMQ message broker.
 
 ### Storage settings
 
-Storage backend is defined by the `ARCHIVE_TYPE`, and `INBOX_TYPE` variables.
+Storage backend is defined by the `ARCHIVE_TYPE` variable.
 Valid values for these options are `S3` or `POSIX`
 (Defaults to `POSIX` on unknown values).
 
 The value of these variables define what other variables are read.
-The same variables are available for all storage types, differing by prefix (`ARCHIVE_`, or  `INBOX_`)
+The same variables are available for all storage types, differing by prefix (`ARCHIVE_`)
 
 if `*_TYPE` is `S3` then the following variables are available:
 
@@ -94,7 +94,7 @@ and if `*_TYPE` is `POSIX`:
 
 ### Logging settings
 
-- `LOG_FORMAT` can be set to “json” to get logs in json format. All other values result in text logging
+- `LOG_FORMAT` can be set to `json` to get logs in JSON format. All other values result in text logging.
 - `LOG_LEVEL` can be set to one of the following, in increasing order of severity:
   - `trace`
   - `debug`
@@ -106,49 +106,38 @@ and if `*_TYPE` is `POSIX`:
 
 ## Service Description
 
-The verify service ensures that ingested files are encrypted with the correct key, and that the provided checksums match those of the ingested files.
+The `verify` service ensures that ingested files are encrypted with the correct key, and that the provided checksums match those of the ingested files.
 
-When running, verify reads messages from the configured RabbitMQ queue (default: "archived").
+When running, `verify` reads messages from the configured RabbitMQ queue (commonly: `archived`).
 For each message, these steps are taken (if not otherwise noted, errors halt progress and the service moves on to the next message.
 Unless explicitly stated, error messages are *not* written to the RabbitMQ error queue, and messages are not NACK or ACKed.):
 
-1. The message is validated as valid JSON that matches the "ingestion-verification" schema.
+1. The message is validated as valid JSON that matches the `ingestion-verification` schema.
 If the message can’t be validated it is discarded with an error message in the logs.
-
-1. The service attempts to fetch the header for the file id in the message from the database.
+2. The service attempts to fetch the header for the file id in the message from the database.
 If this fails a NACK will be sent for the RabbitMQ message, the error will be written to the logs, and sent to the RabbitMQ error queue.
-
-1. The file size of the encrypted file is fetched from the archive storage system.
+3. The file size of the encrypted file is fetched from the archive storage system.
 If this fails an error will be written to the logs.
-
-1. The archive file is then opened for reading.
+4. The archive file is then opened for reading.
 If this fails an error will be written to the logs and to the RabbitMQ error queue.
-
-1. A decryptor is opened with the archive file.
+5. A decryptor is opened with the archive file.
 If this fails an error will be written to the logs.
-
-1. The file size, md5 and sha256 checksum will be read from the decryptor.
+6. The file size, md5 and sha256 checksum will be read from the decryptor.
 If this fails an error will be written to the logs.
-
-1. If the `re_verify` boolean is not set in the RabbitMQ message, the message processing ends here, and continues with the next message.
+7. If the `re_verify` boolean is not set in the RabbitMQ message, the message processing ends here, and continues with the next message.
 Otherwise the processing continues with verification:
-
-    1. A verification message is created, and validated against the "ingestion-accession-request" schema.
-    If this fails an error will be written to the logs.
-
-    1. The file is marked as *verified* in the database (*COMPLETED* if you are using database schema <= 3).
-    If this fails an error will be written to the logs.
-
-    1. The verification message created in step 7.1 is sent to the "verified" queue.
-    If this fails an error will be written to the logs.
-
-    1. The original RabbitMQ message is ACKed.
-    If this fails an error is written to the logs, but processing continues to the next step.
+  1. A verification message is created, and validated against the `ingestion-accession-request` schema.
+  If this fails an error will be written to the logs.
+  2. The file is marked as *verified* in the database (*COMPLETED* if you are using database schema <= `3`).
+  If this fails an error will be written to the logs.
+  3. The verification message created in step 7.1 is sent to the `verified` queue.
+  If this fails an error will be written to the logs.
+  4. The original RabbitMQ message is ACKed.
+  If this fails an error is written to the logs, but processing continues to the next step.
 
 ## Communication
 
-- Verify reads messages from one RabbitMQ queue (commonly `archived`).
-- Verify writes messages to one RabbitMQ queue (commonly `verified`).
-- Verify gets the file encryption header from the database using `GetHeader`,
-and marks the files as `verified` (`COMPLETED` in db version <= 2.0) using `MarkCompleted`.
-- Verify reads file data from archive storage and removes data from inbox storage.
+- `Verify` reads messages from one RabbitMQ queue (commonly: `archived`).
+- `Verify` publishes messages to one RabbitMQ queue (commonly: `verified`).
+- `Verify` gets the file encryption header from the database using `GetHeader`,
+and marks the files as `verified` (`COMPLETED` in db version <= `2.0`) using `MarkCompleted`.

--- a/sda/sda.md
+++ b/sda/sda.md
@@ -1,0 +1,21 @@
+sda - sensitive-data-archive
+============
+
+Repository:
+[neicnordic/sensitive-data-archive](https://github.com/neicnordic/sensitive-data-archive)
+
+`sda` repository consists of a suite of services which are part of [NeIC Sensitive Data Archive](https://neic-sda.readthedocs.io/en/latest/) and implements the components required for data submission.
+It can be used as part of a [Federated EGA](https://ega-archive.org/federated) or as an isolated Sensitive Data Archive.
+`sda` was built with support for both S3 and POSIX storage.
+
+The SDA submission pipeline has four main steps:
+
+1. [Ingest](cmd/ingest.md) splits file headers from files, moving the header to the database and the file content to the archive storage.
+2. [Verify](cmd/verify.md) verifies that the header is encrypted with the correct key, and that the checksums match the user-provided checksums.
+3. [Finalize](cmd/finalize.md) associates a stable accessionID with each archive file and backups the file.
+4. [Mapper](cmd/mapper.md) maps file accessionIDs to a datasetID.
+
+There are also three additional support services:
+
+1. [Intercept](cmd/intercept.md) relays messages from Central EGA to the system.
+2. [s3inbox](cmd/s3inbox.md) proxies uploads to the an S3 compatible storage backend.


### PR DESCRIPTION
- there were inconsistent python versions 3.7, 3.8, 3.9, 3.10 or even 3.6 some of which were deprecated. Make use of 3.11 which should be a stable version.
- update repo url in Docker file in `./sda`
- update and standardise documentation (please mention if I missed something)