### PR TITLE
Remove obsolete checks from Github Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,14 +38,7 @@ updates:
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
   - package-ecosystem: docker
-    directory: "/sda-pipeline"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    reviewers:
-      - "neicnordic/sensitive-data-development-collaboration"
-  - package-ecosystem: docker
-    directory: "/sda-s3proxy"
+    directory: "/sda"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -93,20 +86,6 @@ updates:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
       interval: weekly
-  - package-ecosystem: gomod
-    directory: "/sda-pipeline"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    reviewers:
-      - "neicnordic/sensitive-data-development-collaboration"
-  - package-ecosystem: gomod
-    directory: "/sda-s3proxy"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    reviewers:
-      - "neicnordic/sensitive-data-development-collaboration"
 
 # Each subfolder needs to be checked separately
   - package-ecosystem: maven

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -62,25 +62,37 @@ updates:
 # Each subfolder needs to be checked separately
   - package-ecosystem: gomod
     directory: "/sda-auth"
-    schedule:
-      interval: weekly
+    groups:
+      all-modules:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: weekly
   - package-ecosystem: gomod
-    directory: "/sda-common"
-    schedule:
-      interval: weekly
+    directory: "/sda"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: weekly
   - package-ecosystem: gomod
     directory: "/sda-download"
-    schedule:
-      interval: weekly
+    groups:
+      all-modules:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: weekly
   - package-ecosystem: gomod
     directory: "/sda-pipeline"
     schedule:
@@ -99,8 +111,12 @@ updates:
 # Each subfolder needs to be checked separately
   - package-ecosystem: maven
     directory: "/sda-sftp-inbox"
-    schedule:
-      interval: weekly
+    groups:
+      all-modules:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: weekly

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -7,6 +7,7 @@ on:
       - ".gitignore"
       - "**/*.md"
       - ".github/dependabot.yaml"
+      - "charts/**"
 
 env:
   PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -55,19 +55,6 @@ jobs:
             org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             org.opencontainers.image.revision=${{ github.sha }}
 
-      - name: Build container for sda-pipeline
-        uses: docker/build-push-action@v5
-        with:
-          context: ./sda-pipeline
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:sha-${{ github.sha }}-pipeline
-            ghcr.io/${{ github.repository }}:PR${{ github.event.number }}-pipeline
-          labels: |
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-            org.opencontainers.image.revision=${{ github.sha }}
-
       - name: Build container for sensitive-data-archive
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/**"
       - ".gitignore"
       - "**/*.md"
+      - ".github/dependabot.yaml"
 
 env:
   PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - ".github/workflows/**"
       - ".gitignore"
-      - "**/README.md"
+      - "**/*.md"
 
 env:
   PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -53,29 +53,6 @@ jobs:
           args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck -e G401,G501,G107 --timeout 5m
           working-directory: sda-download
 
-  lint_pipeline:
-    name: Lint pipeline code
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ['1.20']
-    steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go-version }}
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
-        with:
-          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,rowserrcheck --timeout 5m
-          working-directory: sda-pipeline
-
   lint_sda:
     name: Lint sda code
     runs-on: ubuntu-latest

--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -3,15 +3,11 @@ name: Functionality tests
 on:
   pull_request:
 
-env:
-  svc_list: 'finalize inbox ingest mapper verify'
-
 jobs:
   check_changes:
     outputs:
       sda-auth: ${{ steps.changes.outputs.sda-auth }}
       sda-download: ${{ steps.changes.outputs.sda-download }}
-      sda-pipeline: ${{ steps.changes.outputs.sda-pipeline }}
       sftp-inbox: ${{ steps.changes.outputs.sftp-inbox }}
     runs-on: ubuntu-latest
     steps:
@@ -24,8 +20,6 @@ jobs:
               - 'sda-auth/**'
             sda-download:
               - 'sda-download/**'
-            sda-pipeline:
-              - 'sda-pipeline/**'
             sftp-inbox:
             - 'sftp-inbox/**'
 
@@ -93,43 +87,6 @@ jobs:
       - name: Run tests
         run: |
           cd sda-download
-          ls -1 .github/integration/tests/{common,${{ matrix.storagetype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
-            echo "Executing test script $runscript";
-            bash -x "$runscript";
-          done
-
-  sda-pipeline:
-    needs: check_changes
-    if: needs.check_changes.outputs.sda-pipeline == 'true'
-    name: sda-pipeline-integration-${{ matrix.storagetype }}
-    runs-on: ubuntu-latest
-    env:
-      STORAGETYPE: ${{ matrix.storagetype }}
-
-    strategy:
-      matrix:
-        storagetype: [s3, posix, s3notls, s3header, s3notlsheader, posixheader, sftp, sftpheader]
-      fail-fast: false
-    steps:
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Run setup scripts
-        run: |
-          cd sda-pipeline
-          ls -1 .github/integration/setup/{common,${{ matrix.storagetype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
-            echo "Executing setup script $runscript";
-            bash -x "$runscript";
-          done
-
-      - name: Run tests
-        run: |
-          cd sda-pipeline
           ls -1 .github/integration/tests/{common,${{ matrix.storagetype }}}/*.sh 2>/dev/null | sort -t/ -k5 -n | while read -r runscript; do
             echo "Executing test script $runscript";
             bash -x "$runscript";

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Pull PR containers
         run : |
-          for t in -auth -download -pipeline -postgres -rabbitmq -sftp-inbox; do
+          for t in -auth -download -postgres -rabbitmq -sftp-inbox; do
             docker pull ghcr.io/${{ github.repository }}:PR${{ github.event.number }}$t
           done
           docker pull ghcr.io/${{ github.repository }}:PR${{ github.event.number }}
@@ -66,11 +66,6 @@ jobs:
         run: |
           docker tag ghcr.io/${{ github.repository }}:PR${{ github.event.number }}-download ghcr.io/${{ github.repository }}:${{ needs.tag_release.outputs.tag }}-download
           docker push ghcr.io/${{ github.repository }}:${{ needs.tag_release.outputs.tag }}-download
-
-      - name: Retag PR image for pipeline
-        run: |
-          docker tag ghcr.io/${{ github.repository }}:PR${{ github.event.number }}-pipeline ghcr.io/${{ github.repository }}:${{ needs.tag_release.outputs.tag }}-pipeline
-          docker push ghcr.io/${{ github.repository }}:${{ needs.tag_release.outputs.tag }}-pipeline
 
       - name: Retag PR image for postgres
         run: |

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -7,6 +7,7 @@ on:
       - ".github/**"
       - ".gitignore"
       - "**/*.md"
+      - "charts/**"
     types: [ closed ]
 
 jobs:

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - ".github/**"
       - ".gitignore"
-      - "**/README.md"
+      - "**/*.md"
     types: [ closed ]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,56 +29,6 @@ jobs:
       - name: Test
         run: cd sda-sftp-inbox && mvn test -B
 
-  test_pipeline:
-    name: Test ingestion pipeline
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.20']
-    steps:
-
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go-version }}
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Get dependencies
-        run: |
-          cd sda-pipeline
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-              dep ensure
-          fi
-
-      - name: Create certificates
-        run: |
-          cd sda-pipeline/dev_utils
-          bash ./make_certs.sh
-          cd ..
-
-      - name: Start MQ and DB
-        run: |
-          cd sda-pipeline
-          docker-compose -f dev_utils/compose-no-tls.yml up -d db mq
-
-      - name: Test
-        run: |
-          cd sda-pipeline
-          go test --tags=integration -v -coverprofile=coverage.txt -covermode=atomic ./...
-
-      - name: Codecov
-        uses: codecov/codecov-action@v3.1.4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./sda-pipeline/coverage.txt
-          flags: unittests
-          fail_ci_if_error: false
-
   test_download:
     name: Test Download
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Removes all tests related to the `sda-pipeline` folder
* Remove building and publishing container form `sda-pipeline` folder
* Remove dependabot checks for `sda-pipeline` and the removed `sda-common` and `sda-s3proxy` folders
* Add `groups` to dependabot config in order to get a single PR for each folder, rather than one PR for each library update