### PR TITLE
[charts] Added missing values in integration test values.yaml

### DIFF
--- a/.github/integration/scripts/charts/values.yaml
+++ b/.github/integration/scripts/charts/values.yaml
@@ -23,6 +23,8 @@ global:
     s3Bucket: "backup"
     s3Port: 9000
     existingClaim: backup-pvc
+    s3AccessKey: "access"
+    s3SecretKey: "secretkey"
   auth:
     jwtSecret: jwk
     jwtAlg: ES256
@@ -66,6 +68,8 @@ global:
     s3Bucket: "inbox"
     s3ReadyPath: "/minio/health/ready"
     existingClaim: inbox-pvc
+    s3AccessKey: "access"
+    s3SecretKey: "secretkey"
 
 auth:
   replicaCount: 1


### PR DESCRIPTION
The PR adds a couple of missing values in the `values.yaml` file of the integration scripts, so that the `helm template` command doesn't fail when testing locally.