### PR TITLE
Use scoped token for bumping the chart version

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -118,11 +118,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GHCR_TOKEN }}
           commit-message: Bump chart version
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
+          author: neicnordic <neicnordic@users.noreply.github.com>
           base: main
           branch: bump
           delete-branch: true
@@ -131,5 +129,4 @@ jobs:
             Bump the appVersion to: ${{ needs.tag_release.outputs.tag }}
           labels: |
             automated pr
-          team-reviewers: sensitive-data-development-collaboration
-          draft: false
+          team-reviewers: neicnordic/sensitive-data-development-collaboration


### PR DESCRIPTION
**Description**
The normal `GITHUB_TOKEN` used in the actions can not trigger other actions on a PR, for security reasons.
So in order to trigger the necessary tests we have to use another token.