### PR TITLE
feat: report readable errors to users

### DIFF
--- a/.github/integration/tests/sda/10_upload_test.sh
+++ b/.github/integration/tests/sda/10_upload_test.sh
@@ -113,9 +113,10 @@ if [ "$STORAGETYPE" = "s3" ]; then
     ## test with token from OIDC service
     echo "testing with OIDC token"
     newToken=$(curl http://oidc:8080/tokens | jq '.[0]')
-    sed -i "s/access_token=.*/access_token=$newToken/" s3cfg
+    cp s3cfg oidc_s3cfg
+    sed -i "s/access_token=.*/access_token=$newToken/" oidc_s3cfg
 
-    s3cmd -c s3cfg put NA12878.bam.c4gh s3://requester_demo.org/data/file1.c4gh
+    s3cmd -c oidc_s3cfg put NA12878.bam.c4gh s3://requester_demo.org/data/file1.c4gh
 
     ## verify that messages exists in MQ
     echo "waiting for upload to complete"

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 
 if [ "$STORAGETYPE" != "s3" ]; then

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -ex
+
+if [ "$STORAGETYPE" != "s3" ]; then
+    exit 0
+fi
+
+cd shared || true
+
+# test that listing all buckets is not allowed
+set +e
+list_all_buckets=$(s3cmd -c s3cfg -q ls 2>&1)
+set -e
+if ! [[ "$list_all_buckets" =~ "not allowed response" ]]; then
+    echo "list buckets should fail"
+    exit 1
+fi
+
+# test disallowed characters
+set +e
+disallowed_characters=$(s3cmd -c s3cfg -q put s3cfg s3://test_dummy.org/fai\| 2>&1)
+set -e
+if ! [[ "$disallowed_characters" =~ "filepath contains disallowed characters" ]];then
+    echo "test with disallowed characters failed"
+    exit 1
+fi
+
+# test error message when using invalid token
+cp s3cfg bads3cfg
+sed -i "s/access_token=.*/access_token=invalid/" bads3cfg
+
+set +e
+unathorized=$(s3cmd -c bads3cfg -q ls s3://test_dummy.org/ 2>&1)
+set -e
+if ! [[ "$unathorized" =~ "not authorized" ]]; then
+    echo "testing unathorized call failed"
+    exit 1
+fi
+
+
+echo "s3cmd error messages tested successfully"

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -ex
 
 if [ "$STORAGETYPE" != "s3" ]; then
     exit 0
@@ -8,18 +7,14 @@ fi
 cd shared || true
 
 # test that listing all buckets is not allowed
-set +e
 list_all_buckets=$(s3cmd -c s3cfg -q ls 2>&1)
-set -e
 if ! [[ "$list_all_buckets" =~ "not allowed response" ]]; then
     echo "list buckets should fail"
     exit 1
 fi
 
 # test disallowed characters
-set +e
 disallowed_characters=$(s3cmd -c s3cfg -q put s3cfg s3://test_dummy.org/fai\| 2>&1)
-set -e
 if ! [[ "$disallowed_characters" =~ "filepath contains disallowed characters" ]];then
     echo "test with disallowed characters failed"
     exit 1
@@ -29,9 +24,7 @@ fi
 cp s3cfg bads3cfg
 sed -i "s/access_token=.*/access_token=invalid/" bads3cfg
 
-set +e
 unathorized=$(s3cmd -c bads3cfg -q ls s3://test_dummy.org/ 2>&1)
-set -e
 if ! [[ "$unathorized" =~ "not authorized" ]]; then
     echo "testing unathorized call failed"
     exit 1

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -103,18 +103,16 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Proxy) internalServerError(w http.ResponseWriter, r *http.Request) {
-	log.Debugf("Internal server error for request (%v)", r)
-	w.WriteHeader(http.StatusInternalServerError)
+	msg := fmt.Sprintf("Internal server error for request (%v)", r)
+	reportError(http.StatusInternalServerError, msg, w)
 }
 
 func (p *Proxy) notAllowedResponse(w http.ResponseWriter, _ *http.Request) {
-	log.Debug("not allowed response")
-	w.WriteHeader(http.StatusForbidden)
+	reportError(http.StatusForbidden, "not allowed response", w)
 }
 
 func (p *Proxy) notAuthorized(w http.ResponseWriter, _ *http.Request) {
-	log.Debug("not authorized")
-	w.WriteHeader(http.StatusUnauthorized)
+	reportError(http.StatusUnauthorized, "not authorized", w)
 }
 
 func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +132,6 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
 
 	filepath, err := formatUploadFilePath(rawFilepath)
 	if err != nil {
-		log.Error(err.Error())
 		reportError(http.StatusNotAcceptable, err.Error(), w)
 
 		return
@@ -526,7 +523,8 @@ func formatUploadFilePath(filePath string) (string, error) {
 // Write the error and its status code to the response
 func reportError(errorCode int, message string, w http.ResponseWriter) {
 
-	w.WriteHeader(http.StatusNotAcceptable)
+	log.Error(message)
+	w.WriteHeader(errorCode)
 	errorResponse := ErrorResponse{
 		Code:    http.StatusText(errorCode),
 		Message: message,

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -524,25 +524,18 @@ func formatUploadFilePath(filePath string) (string, error) {
 func reportError(errorCode int, message string, w http.ResponseWriter) {
 
 	log.Error(message)
-	w.WriteHeader(errorCode)
 	errorResponse := ErrorResponse{
 		Code:    http.StatusText(errorCode),
 		Message: message,
 	}
+	w.WriteHeader(errorCode)
 	xmlData, err := xml.Marshal(errorResponse)
 	if err != nil {
-		// if the error message cannot be processed, just send the error code
+		// errors are logged but otherwised ignored
 		log.Error(err)
-		w.WriteHeader(errorCode)
-	}
-
-	// Convert the XML byte slice to a string and write it to the response
-	_, err = io.WriteString(w, string(xmlData))
-
-	if err != nil {
-		// if the error message cannot be processed, just send the error code
-		log.Error(err)
-		w.WriteHeader(errorCode)
+	} else {
+		// write the error message to the response
+		io.WriteString(w, string(xmlData))
 	}
 
 }

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -533,9 +533,14 @@ func reportError(errorCode int, message string, w http.ResponseWriter) {
 	if err != nil {
 		// errors are logged but otherwised ignored
 		log.Error(err)
-	} else {
-		// write the error message to the response
-		io.WriteString(w, string(xmlData))
+
+		return
+	}
+	// write the error message to the response
+	_, err = io.WriteString(w, string(xmlData))
+	if err != nil {
+		// errors are logged but otherwised ignored
+		log.Error(err)
 	}
 
 }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #555.


**Description**
Adds structure for writing readable error messages to the user from the s3proxy.
Error messages are created for four cases (`notAuthorized`, `internalServerError`, `notAllowedResponse` and `dissallowedChars`).


**How to test**
Run the proxy, eg with
 ```
make build-sda
export PR_NUMBER=$(date +'%Y-%m-%d')
docker compose -f .github/integration/sda-s3-integration.yml up s3inbox
```
- using `s3cmd`:  try to upload a file with invalid characters in the file name
![2024-01-15-115907_1198x87_scrot](https://github.com/neicnordic/sensitive-data-archive/assets/1029190/87fb21b9-2438-4636-90d6-ff640400ac76)

- using `sda-cli`: [remove the checks for file path characters in sda-cli](https://github.com/NBISweden/sda-cli/blob/58566048e8682be6b4be1ee250e5f1062aeb8f6d/upload/upload.go#L74C1-L80C3) and try to upload a file with invalid characters in its name
![2024-01-15-115709_895x139_scrot](https://github.com/neicnordic/sensitive-data-archive/assets/1029190/6797fd5f-f4b9-4184-aa07-b0ec9a202bd6)


