### PR TITLE
Improve logging and handling of errors in s3proxy

### DIFF
--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -214,7 +214,8 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
 	}
 	_, err = io.Copy(w, s3response.Body)
 	if err != nil {
-		log.Fatalln("redirect error")
+		reportError(http.StatusInternalServerError, fmt.Sprintf("redirect error: %v", err), w)
+		return
 	}
 
 	// Read any remaining data in the connection and
@@ -409,7 +410,7 @@ func (p *Proxy) CreateMessageFromRequest(r *http.Request, claims jwt.Token) (Eve
 
 	checksum.Value, event.Filesize, err = p.requestInfo(r.URL.Path)
 	if err != nil {
-		log.Fatalf("could not get checksum information: %s", err)
+		return event, fmt.Errorf("could not get checksum information: %s", err)
 	}
 
 	// Case for simple upload

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -240,6 +240,15 @@ func (p *Proxy) checkAndSendMessage(jsonMessage []byte, r *http.Request) error {
 		}
 	}
 
+	if p.messenger.Channel.IsClosed() {
+		log.Warning("channel is closed, recreating...")
+		err := p.messenger.CreateNewChannel()
+
+		if err != nil {
+			return err
+		}
+	}
+
 	if err := p.messenger.SendMessage(p.fileIds[r.URL.Path], p.messenger.Conf.Exchange, p.messenger.Conf.RoutingKey, jsonMessage); err != nil {
 
 		return fmt.Errorf("error when sending message to broker: %v", err)

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -230,6 +230,9 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
 // Renew the connection to MQ if necessary, then send message
 func (p *Proxy) checkAndSendMessage(jsonMessage []byte, r *http.Request) error {
 	var err error
+	if p.messenger == nil {
+		return fmt.Errorf("messenger is down")
+	}
 	if p.messenger.IsConnClosed() {
 		log.Warning("connection is closed, reconnecting...")
 		p.messenger, err = broker.NewMQ(p.messenger.Conf)

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -153,7 +153,7 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request) {
 	s3response, err := p.forwardToBackend(r)
 
 	if err != nil {
-		log.Debugf("forwarding error: %v", err)
+		log.Errorf("forwarding error: %v", err)
 		p.internalServerError(w, r)
 
 		return

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -56,7 +56,7 @@ func (suite *ProxyTests) SetupTest() {
 		User:     "guest",
 		Password: "guest",
 		Vhost:    "/",
-		Exchange: "amq.default",
+		Exchange: "",
 	}
 
 	suite.messenger = &broker.AMQPBroker{}

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -269,7 +269,7 @@ func (suite *ProxyTests) TestServeHTTP_MQ_Unavailable() {
 	proxy.messenger.Conf.Port = 123456
 	proxy.messenger.Connection.Close()
 	assert.True(suite.T(), proxy.messenger.Connection.IsClosed())
-	r, _ := http.NewRequest("PUT", "/username/mqunavailbale-file", nil)
+	r, _ := http.NewRequest("PUT", "/username/mqunavailable-file", nil)
 	w := httptest.NewRecorder()
 	suite.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/db-test-file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	proxy.ServeHTTP(w, r)

--- a/sda/cmd/s3inbox/s3inbox_test.go
+++ b/sda/cmd/s3inbox/s3inbox_test.go
@@ -101,7 +101,7 @@ func TestMain(m *testing.M) {
 	mqHostAndPort := rabbitmq.GetHostPort("15672/tcp")
 
 	client := http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "http://"+mqHostAndPort+"/api/users", http.NoBody)
+	req, err := http.NewRequest(http.MethodPut, "http://"+mqHostAndPort+"/api/queues/%2F/inbox", http.NoBody)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #413 


**Description**
The original goal was to 
- make sure that errors are logged properly

While working on this, it also made sense to
- make sure errors are properly reported back to the user
- fix erroneous connection to mq in `s3inbox_test`.


**How to test**
Make sure all tests pass. Try making a request with s3cmd with an invalid token, or when either db or mq is disconnected, and make sure errors are logged and reported.
