### PR TITLE
md5 not required in schemas

### DIFF
--- a/sda/internal/schema/schema_test.go
+++ b/sda/internal/schema/schema_test.go
@@ -193,7 +193,7 @@ func TestValidateJSONIngestionAccessionRequest(t *testing.T) {
 		User:     "JohnDoe",
 		FilePath: "path/to file",
 		DecryptedChecksums: []Checksums{
-			{Type: "sha256", Value: "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
+			{Type: "md5", Value: "68b329da9893e34099c7d8ad5cb9c940"},
 		},
 	}
 
@@ -248,7 +248,7 @@ func TestValidateJSONIngestionCompletion(t *testing.T) {
 		FilePath:    "path/to file",
 		AccessionID: "EGAF00123456789",
 		DecryptedChecksums: []Checksums{
-			{Type: "sha256", Value: "da886a89637d125ef9f15f6d676357f3a9e5e10306929f0bad246375af89c2e2"},
+			{Type: "md5", Value: "68b329da9893e34099c7d8ad5cb9c940"},
 		},
 	}
 

--- a/sda/schemas/federated/ingestion-accession-request.json
+++ b/sda/schemas/federated/ingestion-accession-request.json
@@ -123,7 +123,7 @@
                 "type": "object",
                 "properties": {
                     "type": {
-                        "const": "md5"
+                        "const": "sha256"
                     }
                 },
                 "required": [

--- a/sda/schemas/federated/ingestion-completion.json
+++ b/sda/schemas/federated/ingestion-completion.json
@@ -134,7 +134,7 @@
                 "type": "object",
                 "properties": {
                     "type": {
-                        "const": "md5"
+                        "const": "sha256"
                     }
                 },
                 "required": [


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes just a part of the MD5 validation for new, new versions of the EGA JSON schemas will render MD5 requirement as null.

**Description**

MD5 is not required in new versions of the schemas (and even now), so might as well remove it from the required schema validation


**How to test**
Same tests as before