### PR TITLE
Run same workflows on merge_group events as on PRs

### DIFF
--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -1,6 +1,7 @@
 name: Build PR container
 
 on:
+  merge_group:
   pull_request:
     paths-ignore:
       - ".github/workflows/**"

--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -1,6 +1,7 @@
 name: Multilinters
 
 on:
+  merge_group:
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: "CodeQL"
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -1,6 +1,7 @@
 name: Functionality tests
 
 on:
+  merge_group:
   pull_request:
 
 jobs:

--- a/.github/workflows/publish_charts.yml
+++ b/.github/workflows/publish_charts.yml
@@ -1,6 +1,7 @@
 name: Publish charts
 
 on:
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,5 +1,6 @@
 name: Publish version tag
 on:
+  merge_group:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
To support merge queue, possibly with multiple pull requests grouped together in a single merge commit (similar to how dependabot can batch multiple changes into a single PR) and PRs rebased on earlier queue contents that's merged, it's recommended to handle the `merge_group` event.

This runs the same workflow for that trigger that we currently run for PRs.