### PR TITLE
Make linter happier by not naming unused parameters

### DIFF
--- a/sda-download/api/middleware/middleware_test.go
+++ b/sda-download/api/middleware/middleware_test.go
@@ -28,7 +28,7 @@ func TestTokenMiddleware_Fail_GetToken(t *testing.T) {
 	originalGetToken := auth.GetToken
 
 	// Substitute mock functions
-	auth.GetToken = func(header http.Header) (string, int, error) {
+	auth.GetToken = func(_ http.Header) (string, int, error) {
 		return "", 401, errors.New("access token must be provided")
 	}
 
@@ -70,10 +70,10 @@ func TestTokenMiddleware_Fail_GetVisas(t *testing.T) {
 	originalGetVisas := auth.GetVisas
 
 	// Substitute mock functions
-	auth.GetToken = func(header http.Header) (string, int, error) {
+	auth.GetToken = func(_ http.Header) (string, int, error) {
 		return token, 200, nil
 	}
-	auth.GetVisas = func(o auth.OIDCDetails, token string) (*auth.Visas, error) {
+	auth.GetVisas = func(_ auth.OIDCDetails, _ string) (*auth.Visas, error) {
 		return nil, errors.New("get visas failed")
 	}
 
@@ -117,13 +117,13 @@ func TestTokenMiddleware_Fail_GetPermissions(t *testing.T) {
 	originalGetPermissions := auth.GetPermissions
 
 	// Substitute mock functions
-	auth.GetToken = func(header http.Header) (string, int, error) {
+	auth.GetToken = func(_ http.Header) (string, int, error) {
 		return token, 200, nil
 	}
-	auth.GetVisas = func(o auth.OIDCDetails, token string) (*auth.Visas, error) {
+	auth.GetVisas = func(_ auth.OIDCDetails, _ string) (*auth.Visas, error) {
 		return &auth.Visas{}, nil
 	}
-	auth.GetPermissions = func(visas auth.Visas) []string {
+	auth.GetPermissions = func(_ auth.Visas) []string {
 		return []string{}
 	}
 
@@ -161,13 +161,13 @@ func TestTokenMiddleware_Success_NoCache(t *testing.T) {
 	originalNewSessionKey := session.NewSessionKey
 
 	// Substitute mock functions
-	auth.GetToken = func(header http.Header) (string, int, error) {
+	auth.GetToken = func(_ http.Header) (string, int, error) {
 		return token, 200, nil
 	}
-	auth.GetVisas = func(o auth.OIDCDetails, token string) (*auth.Visas, error) {
+	auth.GetVisas = func(_ auth.OIDCDetails, _ string) (*auth.Visas, error) {
 		return &auth.Visas{}, nil
 	}
-	auth.GetPermissions = func(visas auth.Visas) []string {
+	auth.GetPermissions = func(_ auth.Visas) []string {
 		return []string{"dataset1", "dataset2"}
 	}
 	session.NewSessionKey = func() string {

--- a/sda-download/api/s3/s3_test.go
+++ b/sda-download/api/s3/s3_test.go
@@ -39,13 +39,13 @@ func (suite *S3TestSuite) SetupTest() {
 	database.DB = &database.SQLdb{DB: db, ConnInfo: testConnInfo}
 
 	// Substitute mock functions
-	auth.GetToken = func(header http.Header) (string, int, error) {
+	auth.GetToken = func(_ http.Header) (string, int, error) {
 		return "token", 200, nil
 	}
-	auth.GetVisas = func(o auth.OIDCDetails, token string) (*auth.Visas, error) {
+	auth.GetVisas = func(_ auth.OIDCDetails, _ string) (*auth.Visas, error) {
 		return &auth.Visas{}, nil
 	}
-	auth.GetPermissions = func(visas auth.Visas) []string {
+	auth.GetPermissions = func(_ auth.Visas) []string {
 		return []string{"dataset1", "dataset10", "https://url/dataset"}
 	}
 	session.NewSessionKey = func() string {

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -22,7 +22,7 @@ func TestDatasets(t *testing.T) {
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 
 	// Substitute mock functions
-	middleware.GetCacheFromContext = func(c *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
 			Datasets: []string{"dataset1", "dataset2"},
 		}
@@ -97,12 +97,12 @@ func TestGetFiles_Fail_Database(t *testing.T) {
 	originalGetFilesDB := database.GetFiles
 
 	// Substitute mock functions
-	middleware.GetCacheFromContext = func(ctx *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
 			Datasets: []string{"dataset1", "dataset2"},
 		}
 	}
-	database.GetFiles = func(datasetID string) ([]*database.FileInfo, error) {
+	database.GetFiles = func(_ string) ([]*database.FileInfo, error) {
 		return nil, errors.New("something went wrong")
 	}
 
@@ -137,7 +137,7 @@ func TestGetFiles_Fail_NotFound(t *testing.T) {
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 
 	// Substitute mock functions
-	middleware.GetCacheFromContext = func(ctx *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
 			Datasets: []string{"dataset1", "dataset2"},
 		}
@@ -173,12 +173,12 @@ func TestGetFiles_Success(t *testing.T) {
 	originalGetFilesDB := database.GetFiles
 
 	// Substitute mock functions
-	middleware.GetCacheFromContext = func(ctx *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
 			Datasets: []string{"dataset1", "dataset2"},
 		}
 	}
-	database.GetFiles = func(datasetID string) ([]*database.FileInfo, error) {
+	database.GetFiles = func(_ string) ([]*database.FileInfo, error) {
 		fileInfo := database.FileInfo{
 			FileID: "file1",
 		}
@@ -219,7 +219,7 @@ func TestFiles_Fail(t *testing.T) {
 	originalGetFiles := getFiles
 
 	// Substitute mock functions
-	getFiles = func(datasetID string, ctx *gin.Context) ([]*database.FileInfo, int, error) {
+	getFiles = func(_ string, _ *gin.Context) ([]*database.FileInfo, int, error) {
 		return nil, 404, errors.New("dataset not found")
 	}
 
@@ -262,7 +262,7 @@ func TestFiles_Success(t *testing.T) {
 	originalGetFiles := getFiles
 
 	// Substitute mock functions
-	getFiles = func(datasetID string, ctx *gin.Context) ([]*database.FileInfo, int, error) {
+	getFiles = func(_ string, _ *gin.Context) ([]*database.FileInfo, int, error) {
 		fileInfo := database.FileInfo{
 			FileID:                    "file1",
 			DatasetID:                 "dataset1",
@@ -326,7 +326,7 @@ func TestDownload_Fail_FileNotFound(t *testing.T) {
 	originalCheckFilePermission := database.CheckFilePermission
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(fileID string) (string, error) {
+	database.CheckFilePermission = func(_ string) (string, error) {
 		return "", errors.New("file not found")
 	}
 
@@ -364,11 +364,11 @@ func TestDownload_Fail_NoPermissions(t *testing.T) {
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(fileID string) (string, error) {
+	database.CheckFilePermission = func(_ string) (string, error) {
 		// nolint:goconst
 		return "dataset1", nil
 	}
-	middleware.GetCacheFromContext = func(ctx *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{}
 	}
 
@@ -408,15 +408,15 @@ func TestDownload_Fail_GetFile(t *testing.T) {
 	originalGetFile := database.GetFile
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(fileID string) (string, error) {
+	database.CheckFilePermission = func(_ string) (string, error) {
 		return "dataset1", nil
 	}
-	middleware.GetCacheFromContext = func(ctx *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
 			Datasets: []string{"dataset1"},
 		}
 	}
-	database.GetFile = func(fileID string) (*database.FileDownload, error) {
+	database.GetFile = func(_ string) (*database.FileDownload, error) {
 		return nil, errors.New("database error")
 	}
 
@@ -458,15 +458,15 @@ func TestDownload_Fail_OpenFile(t *testing.T) {
 	Backend, _ = storage.NewBackend(config.Config.Archive)
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(fileID string) (string, error) {
+	database.CheckFilePermission = func(_ string) (string, error) {
 		return "dataset1", nil
 	}
-	middleware.GetCacheFromContext = func(ctx *gin.Context) session.Cache {
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
 			Datasets: []string{"dataset1"},
 		}
 	}
-	database.GetFile = func(fileID string) (*database.FileDownload, error) {
+	database.GetFile = func(_ string) (*database.FileDownload, error) {
 		fileDetails := &database.FileDownload{
 			ArchivePath: "non-existant-file.txt",
 			ArchiveSize: 0,

--- a/sda-download/internal/database/database_test.go
+++ b/sda-download/internal/database/database_test.go
@@ -109,7 +109,7 @@ func TestNewDB(t *testing.T) {
 
 	// Test failure first
 
-	sqlOpen = func(x string, y string) (*sql.DB, error) {
+	sqlOpen = func(_ string, _ string) (*sql.DB, error) {
 		return nil, errors.New("fail for testing")
 	}
 

--- a/sda-download/pkg/auth/auth_test.go
+++ b/sda-download/pkg/auth/auth_test.go
@@ -19,7 +19,7 @@ func TestGetOIDCDetails_Fail_MakeRequest(t *testing.T) {
 	originalMakeRequest := request.MakeRequest
 
 	// Substitute mock functions
-	request.MakeRequest = func(method, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	request.MakeRequest = func(_, _ string, _ map[string]string, _ []byte) (*http.Response, error) {
 		return nil, errors.New("error")
 	}
 
@@ -51,7 +51,7 @@ func TestGetOIDCDetails_Fail_JSONDecode(t *testing.T) {
 	originalMakeRequest := request.MakeRequest
 
 	// Substitute mock functions
-	request.MakeRequest = func(method, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	request.MakeRequest = func(_, _ string, _ map[string]string, _ []byte) (*http.Response, error) {
 		response := &http.Response{
 			StatusCode: 200,
 			// Response body
@@ -91,7 +91,7 @@ func TestGetOIDCDetails_Success(t *testing.T) {
 	originalMakeRequest := request.MakeRequest
 
 	// Substitute mock functions
-	request.MakeRequest = func(method, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	request.MakeRequest = func(_, _ string, _ map[string]string, _ []byte) (*http.Response, error) {
 		response := &http.Response{
 			StatusCode: 200,
 			// Response body
@@ -248,7 +248,7 @@ func TestGetVisas_Fail_MakeRequest(t *testing.T) {
 	originalMakeRequest := request.MakeRequest
 
 	// Substitute mock functions
-	request.MakeRequest = func(method, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	request.MakeRequest = func(_, _ string, _ map[string]string, _ []byte) (*http.Response, error) {
 		return nil, errors.New("error")
 	}
 
@@ -277,7 +277,7 @@ func TestGetVisas_Fail_JSONDecode(t *testing.T) {
 	originalMakeRequest := request.MakeRequest
 
 	// Substitute mock functions
-	request.MakeRequest = func(method, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	request.MakeRequest = func(_, _ string, _ map[string]string, _ []byte) (*http.Response, error) {
 		response := &http.Response{
 			StatusCode: 200,
 			// Response body
@@ -314,7 +314,7 @@ func TestGetVisas_Success(t *testing.T) {
 	originalMakeRequest := request.MakeRequest
 
 	// Substitute mock functions
-	request.MakeRequest = func(method, url string, headers map[string]string, body []byte) (*http.Response, error) {
+	request.MakeRequest = func(_, _ string, _ map[string]string, _ []byte) (*http.Response, error) {
 		response := &http.Response{
 			StatusCode: 200,
 			// Response body

--- a/sda-download/pkg/request/request_test.go
+++ b/sda-download/pkg/request/request_test.go
@@ -46,7 +46,7 @@ func TestMakeRequest_Fail_HTTPNewRequest(t *testing.T) {
 	originalHTTPMakeRequest := HTTPNewRequest
 
 	// Substitute mock functions
-	HTTPNewRequest = func(method, url string, body io.Reader) (*http.Request, error) {
+	HTTPNewRequest = func(_, _ string, _ io.Reader) (*http.Request, error) {
 		return nil, errors.New("failed to build http request")
 	}
 
@@ -74,7 +74,7 @@ func TestMakeRequest_Fail_HTTPNewRequest(t *testing.T) {
 func TestMakeRequest_Fail_StatusCode(t *testing.T) {
 
 	// Create mock client
-	client := newTestClient(func(req *http.Request) *http.Response {
+	client := newTestClient(func(_ *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 500,
 			// Response body
@@ -89,7 +89,7 @@ func TestMakeRequest_Fail_StatusCode(t *testing.T) {
 	originalHTTPMakeRequest := HTTPNewRequest
 
 	// Substitute mock functions
-	HTTPNewRequest = func(method, requestUrl string, body io.Reader) (*http.Request, error) {
+	HTTPNewRequest = func(_, _ string, _ io.Reader) (*http.Request, error) {
 		u, _ := url.ParseRequestURI("https://testing.fi")
 		r := &http.Request{
 			Method: "GET",
@@ -122,7 +122,7 @@ func TestMakeRequest_Fail_StatusCode(t *testing.T) {
 func TestMakeRequest_Success(t *testing.T) {
 
 	// Create mock client
-	client := newTestClient(func(req *http.Request) *http.Response {
+	client := newTestClient(func(_ *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: 200,
 			// Response body
@@ -137,7 +137,7 @@ func TestMakeRequest_Success(t *testing.T) {
 	originalHTTPMakeRequest := HTTPNewRequest
 
 	// Substitute mock functions
-	HTTPNewRequest = func(method, requestUrl string, body io.Reader) (*http.Request, error) {
+	HTTPNewRequest = func(_, _ string, _ io.Reader) (*http.Request, error) {
 		u, _ := url.ParseRequestURI("https://testing.fi")
 		r := &http.Request{
 			Method: "GET",


### PR DESCRIPTION
This hopefully fixes linter warnings in sda-downloads for unused variables being named.