### PR TITLE
Update k8s versions used in the tests

### DIFF
--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -240,14 +240,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["1.26", "1.27"]
+        version: ["1.28", "1.29"]
         tls: ["true", "false"]
         storage: ["posix", "s3"]
         exclude:
-          - version: "1.26"
+          - version: "1.28"
             tls: "false"
             storage: "posix"
-          - version: "1.27"
+          - version: "1.29"
             tls: "false"
             storage: "posix"
     steps:


### PR DESCRIPTION
k8s 1.29 is the latest release and we should test against the 2 latest versions.
