### PR TITLE
Bugfix/re-encrypt

### DIFF
--- a/sda/cmd/reencrypt/reencrypt.go
+++ b/sda/cmd/reencrypt/reencrypt.go
@@ -29,7 +29,10 @@ type server struct {
 	re.UnimplementedReencryptServer
 }
 
-var Conf config.Config
+var (
+	Conf *config.Config
+	err  error
+)
 
 // ReencryptHeader implements reencrypt.ReEncryptHeader
 func (s *server) ReencryptHeader(_ context.Context, in *re.ReencryptRequest) (*re.ReencryptResponse, error) {
@@ -65,7 +68,7 @@ func (s *server) ReencryptHeader(_ context.Context, in *re.ReencryptRequest) (*r
 }
 
 func main() {
-	Conf, err := config.NewConfig("reencrypt")
+	Conf, err = config.NewConfig("reencrypt")
 	if err != nil {
 		log.Fatalf("configuration loading failed, reason: %v", err)
 	}

--- a/sda/cmd/reencrypt/reencrypt_test.go
+++ b/sda/cmd/reencrypt/reencrypt_test.go
@@ -69,6 +69,7 @@ func (suite *ReEncryptTests) SetupTest() {
 	viper.Set("c4gh.filepath", suite.KeyPath+"/c4gh.key")
 	viper.Set("c4gh.passphrase", "test")
 
+	Conf, _ = config.NewConfig("reencrypt")
 	Conf.ReEncrypt.Crypt4GHKey, err = config.GetC4GHKey()
 	if err != nil {
 		suite.T().FailNow()


### PR DESCRIPTION
**Description**
This PR fixes a bug in the Re-encrypt service where the shared config variable wasn't declared properly. A fully functional integration test is also added for good measure.


**How to test**
Testing requires [grpcurl](https://github.com/fullstorydev/grpcurl), latest version can be downloaded from [here](https://github.com/fullstorydev/grpcurl/releases)


```cmd
make build-all
PR_NUMBER=$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml run integration_test
```
once that has completed manual testing can be done like this:

```$
docker cp oidc:/shared/NA12878.bam.c4gh /tmp/
docker cp oidc:/shared/sync.pub.pem /tmp/
grpcurl -plaintext -d "{\"oldheader\" : \"$(head -c 124 /tmp/NA12878.bam.c4gh | base64 -w0)\" , \"publickey\" : \"$(base64 -w0 /tmp/sync.pub.pem)\"}" localhost:50051 reencrypt.Reencrypt.ReencryptHeader
```

The expected response should look like this:

```json
{
  "header": "Y3J5cHQ0Z2gBAAAAAQAAAGwAAAAAAAAAeLJal5F35DkjR2iitH/l4+igaF8ellkSjWaWR0AGFgMnIb7WbVgMYqTEVPkRZIgGLKsU+yc1CEpksv1aFkCPADv/wGf5rfuZY+8iG2eMorc9VDiusSZQqak8uwLcDGiCA7bKTw=="
}
```