### PR TITLE
remove from merge group

### DIFF
--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -1,7 +1,6 @@
 name: Build PR container
 
 on:
-  merge_group:
   pull_request:
     paths-ignore:
       - ".github/workflows/**"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,6 @@
 name: "CodeQL"
 
 on:
-  merge_group:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
This should fix some actions failing because they require built images that merge queue  has no access to.