### PR TITLE
Hotfix: reencrypt tls configuration

### DIFF
--- a/.github/integration/sda-posix-integration.yml
+++ b/.github/integration/sda-posix-integration.yml
@@ -36,6 +36,29 @@ services:
       - client_certs:/certs
       - shared:/shared
 
+  reencrypt:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
+    command: [ sda-reencrypt ]
+    container_name: reencrypt
+    depends_on:
+      certfixer:
+        condition: service_completed_successfully
+      credentials:
+        condition: service_completed_successfully
+    environment:
+      - GRPC_CACERT=/certs/ca.crt
+      - GRPC_SERVERCERT=/certs/server.crt
+      - GRPC_SERVERKEY=/certs/server.key
+    ports:
+      - "50443:50443"
+    restart: always
+    user: 1000:1000
+    volumes:
+      - ./sda/config.yaml:/config.yaml
+      - certs:/certs
+      - client_certs:/client
+      - shared:/shared
+
   cega-nss:
     container_name: cega-nss
     depends_on:

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -334,8 +334,7 @@ func MakeCerts(outDir string) {
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(0, 0, 1),
-		KeyUsage:              x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}
@@ -374,13 +373,13 @@ func MakeCerts(outDir string) {
 			Organization: []string{"NEIC"},
 			CommonName:   "test_cert",
 		},
-		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-		DNSNames:    []string{"localhost", "mq", "proxy", "s3"},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().AddDate(0, 0, 1),
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		IsCA:        false,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:              []string{"localhost", "mq", "proxy", "s3"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 1),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IsCA:                  false,
+		BasicConstraintsValid: true,
 	}
 
 	// create the TLS certificate


### PR DESCRIPTION
**Description**
Mutual TLS didn't work properly because the CA certificate wasn't configured in the correct place.

This PR fixes the configuration issue and also adds the following:
- a mTLS case for the static code tests.
- reencrypt service to the posix compose file so that mTLS can be tested manually

**How to test**
```cmd
make test-sda
```

Testing the docker container:
```cmd
make build-all
PR_NUMBER=$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml up -d reencrypt
docker cp reencrypt:/client/ca.crt .
docker cp reencrypt:/client/client.crt .
docker cp reencrypt:/client/client.key .
grpcurl -cacert ca.crt -cert client.crt -key client.key localhost:50443 list
```