### PR TITLE
[sync-api] Increase server timeout limits

### DIFF
--- a/sda/cmd/syncapi/syncapi.go
+++ b/sda/cmd/syncapi/syncapi.go
@@ -93,10 +93,10 @@ func setup(config *config.Config) *http.Server {
 		Handler:           r,
 		TLSConfig:         cfg,
 		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      5 * time.Second,
+		ReadTimeout:       5 * time.Minute,
+		WriteTimeout:      -1,
 		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
+		ReadHeaderTimeout: 20 * time.Second,
 	}
 
 	return srv


### PR DESCRIPTION
This is a fix to an issue we found during mirroring a large dataset with @blankdots .

**Description**

When receiving a sizeable json blob that corresponds to a big dataset, sync-api closes the connection before the transfer is complete.
Changing the timeout limits will hopefully fix behavior. New limits are in line with what we use for [download](https://github.com/neicnordic/sensitive-data-archive/blob/76dba35af9bc61d7c0d5816a6f679462925a7b20/sda-download/api/api.go#L70-L72).

