### PR TITLE
[intercept] handling unknown message type

### DIFF
--- a/.github/integration/rabbitmq-federation.yml
+++ b/.github/integration/rabbitmq-federation.yml
@@ -72,7 +72,6 @@ services:
       - BROKER_PASSWORD=guest
       - BROKER_VHOST=sda
       - BROKER_QUEUE=from_cega
-      - BROKER_ROUTINGERROR=error
       - BROKER_VERIFYPEER=false
       - BROKER_SSL=true
       - BROKER_CLIENTCERT=/certs/client.crt

--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -292,7 +292,6 @@ services:
       - BROKER_PASSWORD=ingest
       - BROKER_USER=ingest
       - BROKER_ROUTINGKEY=ingest
-      - BROKER_ROUTINGERROR=error
       - DB_PASSWORD=download
       - DB_USER=download
     image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}

--- a/.github/integration/tests/rabbitmq/10_federation_test.sh
+++ b/.github/integration/tests/rabbitmq/10_federation_test.sh
@@ -73,7 +73,7 @@ for r in completed error inbox verified; do
 
 	curl -s --cacert /tmp/certs/ca.crt -u guest:guest "https://$MQHOST/api/exchanges/sda/sda/publish" \
 		-H 'Content-Type: application/json;charset=UTF-8' \
-		-d "$request_body"
+		-d "$request_body" | jq
 done
 
 # check that message arrived in queue v1.files.inbox in cega MQ
@@ -130,7 +130,7 @@ request_body=$(
 
 curl --cacert /tmp/certs/ca.crt -u test:test "https://$CEGA/api/exchanges/cega/localega/publish" \
 	-H 'Content-Type: application/json;charset=UTF-8' \
-	-d "$request_body"
+	-d "$request_body" | jq
 
 # check that message arrived in queue ingest in MQ
 sleep 5

--- a/.github/integration/tests/rabbitmq/30_dac_msg_test.sh
+++ b/.github/integration/tests/rabbitmq/30_dac_msg_test.sh
@@ -37,7 +37,7 @@ dac_body=$(
 
 curl -s --cacert /tmp/certs/ca.crt -u guest:guest "https://$MQHOST/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$dac_body"
+    -d "$dac_body" | jq
 
 
 echo "waiting for message to be in catch_all.dead"

--- a/.github/integration/tests/rabbitmq/30_dac_msg_test.sh
+++ b/.github/integration/tests/rabbitmq/30_dac_msg_test.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -e
+
+MQHOST="localhost:15672"
+if [ -f /.dockerenv ]; then
+	MQHOST="mq:15671"
+fi
+
+## publish message to trigger dac or unknow type message
+properties=$(
+    jq -c -n \
+        --argjson delivery_mode 2 \
+        --arg content_encoding UTF-8 \
+        --arg content_type application/json \
+        '$ARGS.named'
+)
+
+dac_payload=$(
+    jq -r -c -n \
+        --arg type dac \
+        --arg title "DAC only used for testing all functionalities" \
+        --arg description "DAC only used for testing all functionalities" \
+        --arg accession_id "EGAD74900000101" \
+        '$ARGS.named|@base64'
+)
+
+dac_body=$(
+    jq -c -n \
+        --arg vhost sda \
+        --arg name sda \
+        --argjson properties "$properties" \
+        --arg routing_key "dac" \
+        --arg payload_encoding base64 \
+        --arg payload "$dac_payload" \
+        '$ARGS.named'
+)
+
+curl -s --cacert /tmp/certs/ca.crt -u guest:guest "https://$MQHOST/api/exchanges/sda/sda/publish" \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d "$dac_body"
+
+
+echo "waiting for message to be in catch_all.dead"
+RETRY_TIMES=0
+until [ "$(curl -s --cacert /tmp/certs/ca.crt -u guest:guest https://$MQHOST/api/queues/sda/catch_all.dead/ | jq -r '.messages_ready')" -eq 1 ]; do
+    echo "waiting for dac message"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for dac messages"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "unknown message (type dac) test completed successfully"

--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -54,7 +54,7 @@ for file in NA12878.bam NA12878_20k_b37.bam NA12878.bai NA12878_20k_b37.bai; do
 
     curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
         -H 'Content-Type: application/json;charset=UTF-8' \
-        -d "$ingest_body"
+        -d "$ingest_body" | jq
 done
 
 echo "waiting for verify to complete"

--- a/.github/integration/tests/sda/21_cancel_test.sh
+++ b/.github/integration/tests/sda/21_cancel_test.sh
@@ -52,7 +52,7 @@ cancel_body=$(
 
 curl -k -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$cancel_body"
+    -d "$cancel_body" | jq
 
 # check database to verify file status
 if [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.file_event_log where correlation_id = '$CORRID' order by id DESC LIMIT 1")" != "disabled" ]; then
@@ -83,7 +83,7 @@ ingest_body=$(
 
 curl -k -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$ingest_body"
+    -d "$ingest_body" | jq
 
 RETRY_TIMES=0
 until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ | jq -r '.messages_ready')" -eq 5 ]; do

--- a/.github/integration/tests/sda/22_error_test.sh
+++ b/.github/integration/tests/sda/22_error_test.sh
@@ -68,7 +68,7 @@ ingest_body=$(
 
 curl -k -u guest:guest "$URI/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$ingest_body"
+    -d "$ingest_body" | jq
 
 # check database to verify file status
 until [ "$(psql -U postgres -h postgres -d sda -At -c "SELECT event FROM sda.file_event_log WHERE correlation_id = '$CORRID' ORDER BY ID DESC LIMIT 1;")" = "error" ]; do
@@ -115,7 +115,7 @@ verify_body=$(
 
 curl -k -u guest:guest "$URI/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$verify_body"
+    -d "$verify_body" | jq
 
 # check database to verify file status
 RETRY_TIMES=0

--- a/.github/integration/tests/sda/30_backup-finalize_test.sh
+++ b/.github/integration/tests/sda/30_backup-finalize_test.sh
@@ -56,7 +56,7 @@ while [ $i -le 4 ]; do
 
     curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
         -H 'Content-Type: application/json;charset=UTF-8' \
-        -d "$accession_body"
+        -d "$accession_body" | jq
 
     i=$(( i + 1 ))
 done

--- a/.github/integration/tests/sda/31_cancel_test2.sh
+++ b/.github/integration/tests/sda/31_cancel_test2.sh
@@ -48,7 +48,7 @@ cancel_body=$(
 
 curl -k -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$cancel_body"
+    -d "$cancel_body" | jq
 
 # check database to verify file status
 RETRY_TIMES=0
@@ -85,7 +85,7 @@ ingest_body=$(
 
 curl -k -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$ingest_body"
+    -d "$ingest_body" | jq
 
 RETRY_TIMES=0
 until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ | jq -r '.messages_ready')" -eq 2 ]; do
@@ -129,7 +129,7 @@ accession_body=$(
 
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$accession_body"
+    -d "$accession_body" | jq
 
 RETRY_TIMES=0
 until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.file_event_log where correlation_id = '$CORRID' order by id DESC LIMIT 1")" = "ready" ]; do

--- a/.github/integration/tests/sda/32_test_race_condition.sh
+++ b/.github/integration/tests/sda/32_test_race_condition.sh
@@ -55,7 +55,7 @@ accession_body=$(
 
 curl -sq -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$accession_body"
+    -d "$accession_body" | jq
 
 sleep 10
 if [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/accession/ | jq -r '.messages_unacknowledged')" -ne 1 ]; then
@@ -92,7 +92,7 @@ ingest_body=$(
 
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$ingest_body"
+    -d "$ingest_body" | jq
 
 RETRY_TIMES=0
 until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ | jq -r '.messages_ready')" -eq 2 ]; do

--- a/.github/integration/tests/sda/40_mapper_test.sh
+++ b/.github/integration/tests/sda/40_mapper_test.sh
@@ -40,7 +40,7 @@ mapping_body=$(
 
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$mapping_body"
+    -d "$mapping_body" | jq
 
 # check DB for dataset contents
 RETRY_TIMES=0
@@ -106,7 +106,7 @@ release_body=$(
 
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$release_body"
+    -d "$release_body" | jq 
 
 until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.dataset_event_log where dataset_id = 'EGAD74900000101' order by event_date DESC LIMIT 1;")" = "released" ]; do
     echo "waiting for dataset be released"
@@ -141,7 +141,7 @@ deprecate_body=$(
 
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$deprecate_body"
+    -d "$deprecate_body" | jq
 
 until [ "$(psql -U postgres -h postgres -d sda -At -c "select event from sda.dataset_event_log where dataset_id = 'EGAD74900000101' order by event_date DESC LIMIT 1")" = "deprecated" ]; do
     echo "waiting for dataset be deprecated"
@@ -183,7 +183,7 @@ mapping_body=$(
 
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -d "$mapping_body"
+    -d "$mapping_body" | jq
 
 # check DB for dataset contents
 RETRY_TIMES=0

--- a/sda/cmd/intercept/intercept.go
+++ b/sda/cmd/intercept/intercept.go
@@ -77,7 +77,16 @@ func main() {
 			}
 
 			routingKey := routing[msgType]
+
 			if routingKey == "" {
+				log.Debugf("msg type: %s", msgType)
+				if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "undeliverable", delivered.Body); err != nil {
+					log.Errorf("failed to publish message, reason: (%v)", err)
+				}
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("failed to ack message for reason: %v", err)
+				}
+
 				continue
 			}
 

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -13,6 +13,7 @@ For each message, these steps are taken:
 3. The message is sent to the queue. 
    - This has no error handling as the resend-mechanism hasn't been finished.
 4. The message is Ack'ed.
+5. If the message type is of type unknown, we acknowledge it and send it to `catch_all.dead` (needs to exist)
 
 ## Communication
 

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -13,7 +13,7 @@ For each message, these steps are taken:
 3. The message is sent to the queue. 
    - This has no error handling as the resend-mechanism hasn't been finished.
 4. The message is Ack'ed.
-5. If the message type is of type unknown, we acknowledge it and send it to `catch_all.dead` (needs to exist)
+5. If the message type is of unknown type, we acknowledge it and send it to `catch_all.dead` (needs to exist)
 
 ## Communication
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes https://github.com/neicnordic/sensitive-data-archive/discussions/783.


**Description**

- When we get unknown message types in `intercept` service gets stuck and triggers an error.
This feature aims to fix that by sending all unknown message types to `catch_all.dead` queue (queue needs to exist)

- remove unnecessary: `BROKER_ROUTINGERROR=error`

**How to test**
`make integrationtest-sda` contains a test for sending an unknown message of type `dac` https://github.com/EGA-archive/LocalEGA/blob/master/src/handler/Messages%20format.md?plain=1#L344 and that should go to `catch_all.dead` queue