### PR TITLE
S3inbox log issues

### DIFF
--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -85,7 +85,7 @@ func NewProxy(s3conf storage.S3Conf, auth userauth.Authenticator, messenger *bro
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	token, err := p.auth.Authenticate(r)
 	if err != nil {
-		log.Debugf("Request not authenticated (%v)", err)
+		log.Debugln("Request not authenticated")
 		p.notAuthorized(w, r)
 
 		return

--- a/sda/cmd/s3inbox/s3inbox.go
+++ b/sda/cmd/s3inbox/s3inbox.go
@@ -80,8 +80,6 @@ func main() {
 		panic(err)
 	}
 
-	log.Debug("messenger acquired ", messenger)
-
 	go func() {
 		<-sigc
 		sdaDB.Close()
@@ -102,8 +100,6 @@ func main() {
 		}
 	}
 	proxy := NewProxy(Conf.Inbox.S3, auth, messenger, sdaDB, tlsProxy)
-
-	log.Debug("got the proxy ", proxy)
 
 	http.Handle("/", proxy)
 

--- a/sda/internal/userauth/userauth.go
+++ b/sda/internal/userauth/userauth.go
@@ -50,7 +50,7 @@ func (u *ValidateFromToken) Authenticate(r *http.Request) (jwt.Token, error) {
 		}
 		token, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(u.Keyset, jws.WithInferAlgorithmFromKey(true)), jwt.WithValidate(true))
 		if err != nil {
-			return nil, fmt.Errorf("signed token not valid: %s, (token was %s)", err.Error(), tokenStr)
+			return nil, err
 		}
 
 		iss, err := url.ParseRequestURI(token.Issuer())

--- a/sda/internal/userauth/userauth_test.go
+++ b/sda/internal/userauth/userauth_test.go
@@ -235,7 +235,7 @@ func (suite *UserAuthTest) TestUserTokenAuthenticator_ValidateSignature_RSA() {
 	r.URL.Path = "/username/"
 	_, nonvalidToken := a.Authenticate(r)
 	// The error output is huge so a smaller part is compared
-	assert.Equal(suite.T(), "signed token not valid: \"iat\" not satisfied", nonvalidToken.Error()[0:43])
+	assert.Equal(suite.T(), "\"iat\" not satisfied", nonvalidToken.Error())
 
 	// Elixir tokens broken
 	r, _ = http.NewRequest("", "/", nil)
@@ -243,7 +243,7 @@ func (suite *UserAuthTest) TestUserTokenAuthenticator_ValidateSignature_RSA() {
 	r.Header.Set("X-Amz-Security-Token", defaultToken[3:])
 	r.URL.Path = "/username/"
 	_, brokenToken := a.Authenticate(r)
-	assert.Equal(suite.T(), "signed token not valid: failed to parse jws: failed to parse JOSE headers:", brokenToken.Error()[0:74])
+	assert.Contains(suite.T(), brokenToken.Error(), "failed to parse jws: failed to parse JOSE headers:")
 
 	r, _ = http.NewRequest("", "/", nil)
 	r.Host = "localhost"
@@ -252,7 +252,7 @@ func (suite *UserAuthTest) TestUserTokenAuthenticator_ValidateSignature_RSA() {
 	_, err = a.Authenticate(r)
 	assert.Error(suite.T(), err)
 	_, brokenToken2 := a.Authenticate(r)
-	assert.Equal(suite.T(), "signed token not valid: failed to parse jws: failed to parse JOSE headers:", brokenToken2.Error()[0:74])
+	assert.Contains(suite.T(), brokenToken2.Error(), "failed to parse jws: failed to parse JOSE headers:")
 
 	// Bad issuer
 	basIss, err := helper.CreateRSAToken(prKeyParsed, "RS256", helper.WrongTokenAlgClaims)
@@ -322,7 +322,7 @@ func (suite *UserAuthTest) TestUserTokenAuthenticator_ValidateSignature_EC() {
 	r.URL.Path = "/username/"
 	_, nonvalidToken := a.Authenticate(r)
 	// The error output is huge so a smaller part is compared
-	assert.Equal(suite.T(), "signed token not valid: \"iat\" not satisfied", nonvalidToken.Error()[0:43])
+	assert.Equal(suite.T(), "\"iat\" not satisfied", nonvalidToken.Error())
 
 	// Elixir tokens broken
 	r, _ = http.NewRequest("", "/", nil)
@@ -330,14 +330,14 @@ func (suite *UserAuthTest) TestUserTokenAuthenticator_ValidateSignature_EC() {
 	r.Header.Set("X-Amz-Security-Token", defaultToken[3:])
 	r.URL.Path = "/username/"
 	_, brokenToken := a.Authenticate(r)
-	assert.Equal(suite.T(), "signed token not valid: failed to parse jws: failed to parse JOSE headers:", brokenToken.Error()[0:74])
+	assert.Contains(suite.T(), brokenToken.Error(), "failed to parse jws: failed to parse JOSE headers:")
 
 	r, _ = http.NewRequest("", "/", nil)
 	r.Host = "localhost"
 	r.Header.Set("X-Amz-Security-Token", "random"+defaultToken)
 	r.URL.Path = "/username/"
 	_, brokenToken2 := a.Authenticate(r)
-	assert.Equal(suite.T(), "signed token not valid: failed to parse jws: failed to parse JOSE headers:", brokenToken2.Error()[0:74])
+	assert.Contains(suite.T(), brokenToken2.Error(), "failed to parse jws: failed to parse JOSE headers:")
 
 	// Bad issuer
 	basIss, err := helper.CreateECToken(prKeyParsed, "ES256", helper.WrongTokenAlgClaims)
@@ -414,7 +414,7 @@ func (suite *UserAuthTest) TestUserTokenAuthenticator_ValidateSignature_HS() {
 	r.Header.Set("X-Amz-Security-Token", wrongAlgToken)
 	r.URL.Path = "/username/"
 	_, WrongAlg := a.Authenticate(r)
-	assert.Contains(suite.T(), WrongAlg.Error(), "signed token not valid:")
+	assert.Contains(suite.T(), WrongAlg.Error(), "failed to find key with key ID")
 }
 
 func TestGetBearerToken(t *testing.T) {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #802  #803 #804 .


**Description**
This PR fixes the security issues detected by CodeQL

Two debug messages where removed as they didn't give any useful information anymore.
One debug message was sanitized to not leak sensitive information.

**How to test**
