### PR TITLE
[RabbitMQ]  Rollback to MQ version `3.12.13`

### DIFF
--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.13.1-management-alpine
+FROM rabbitmq:3.12.13-management-alpine
 
 ARG BUILD_DATE
 ARG SOURCE_COMMIT


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
Discussion #792 


**Description**
We need to stay with Erlang v.25.X in order to be able to communicate with CEGA for now.

**How to test**
