### PR TITLE
Use reencrypt service in download

### DIFF
--- a/.github/integration/scripts/charts/values.yaml
+++ b/.github/integration/scripts/charts/values.yaml
@@ -77,7 +77,9 @@ global:
     s3Bucket: "inbox"
     s3ReadyPath: "/minio/health/ready"
     existingClaim: inbox-pvc
-
+  reencrypt:
+    host: reencrypt
+    port: 50443
 auth:
   replicaCount: 1
   resources: null

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -45,6 +45,8 @@ Parameter | Description | Default
 `global.networkPolicy.databaseNamespace` | Namespace where the database is deployed. | `""`
 `global.networkPolicy.externalNamespace` | Namespace where the external components are deployed. | `""`
 `global.networkPolicy.internalNamespace` | Namespace where the internal components are deployed. | `""`
+`global.networkPolicy.ingressNamespace` | Namespace where the ingress is deployed. | `""`
+`global.networkPolicy.ingressLabelMatch` | Match to use to allow connections from ingress controller pod. | `""`
 `global.revisionHistory` | Number of revisions to keep for the option to rollback a deployment | `3`
 `global.podAnnotations` | Annotations applied to pods of all services. |`{}`
 `global.pkiService` | If an external PKI infrastructure is used set this to true. |`false`

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -99,8 +99,6 @@ spec:
         - name: OIDC_TRUSTED_ISS
           value: {{ include "trustedIssPath" . }}/{{ default "iss.json" .Values.global.download.trusted.configFile }}
       {{- end }}
-        - name: C4GH_FILEPATH
-          value: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}"
       {{- if .Values.global.tls.enabled }}
         - name: DB_CACERT
           value: {{ include "tlsPath" . }}/ca.crt
@@ -122,6 +120,18 @@ spec:
           value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
         - name: DB_PORT
           value: {{ .Values.global.db.port | quote }}
+      {{- if .Values.global.tls.enabled }}
+        - name: GRPC_CACERT
+          value: {{ include "tlsPath" . }}/ca.crt
+        - name: GRPC_CLIENTCERT
+          value: {{ include "tlsPath" . }}/tls.crt
+        - name: GRPC_CLIENTKEY
+          value: {{ include "tlsPath" . }}/tls.key
+      {{- end }}
+        - name: GRPC_HOST
+          value: {{ required "A valid grpc host is required" .Values.global.reencrypt.host | quote }}
+        - name: GRPC_PORT
+          value: {{ .Values.global.reencrypt.port | quote }}
       {{- if .Values.global.log.format }}
         - name: LOG_FORMAT
           value: {{ .Values.global.log.format | quote }}
@@ -158,11 +168,6 @@ spec:
               name: {{ template "sda.fullname" . }}-s3archive-keys
               key: s3ArchiveSecretKey
         {{- end }}
-        - name: C4GH_PASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-download
-              key: c4ghPassphrase
         - name: DB_PASSWORD
           valueFrom:
               secretKeyRef:

--- a/charts/sda-svc/templates/download-networkpolicy.yaml
+++ b/charts/sda-svc/templates/download-networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.global.networkPolicy.create }}
+{{- if or (or (eq "all" .Values.global.deploymentType) (eq "external" .Values.global.deploymentType) ) (not .Values.global.deploymentType) }}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "sda.fullname" . }}-download
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "sda.name" . }}-download
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - to:
+    {{- if .Values.global.networkPolicy.databaseNamespace }}
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .Values.global.networkPolicy.databaseNamespace }}
+    {{- end }}
+    - podSelector:
+        matchLabels:
+          role: database
+    ports:
+    - protocol: TCP
+      port: {{ .Values.global.db.port | default 5432 | int }}
+  - to:
+    {{- if .Values.global.networkPolicy.internalNamespace }}
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .Values.global.networkPolicy.internalNamespace }}
+    {{- end }}
+    - podSelector:
+        matchLabels:
+          role: reencrypt
+    ports:
+    - protocol: TCP
+      port: {{ .Values.global.reencrypt.port | int }}
+  {{- if .Values.global.networkPolicy.ingressNamespace }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ .Values.global.networkPolicy.ingressNamespace }}
+          podSelector:
+            matchLabels:
+              {{ .Values.global.networkPolicy.ingressLabelMatch | nindent 14 }}
+        ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 8443
+          - protocol: TCP
+            port: 443
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -70,6 +70,8 @@ global:
     databaseNamespace: ""
     externalNamespace: ""
     internalNamespace: ""
+    ingressNamespace: ""
+    ingressLabelMatch: ""
 
 ## RevisionHistory
 ##  If defined, set the revisionHistoryLimit of the deployment, defaults to 3
@@ -254,6 +256,11 @@ global:
     s3Port: 443
     s3ReadyPath: ""
     s3Region: ""
+
+  reencrypt:
+    host: ""
+    port: 50051
+    timeout: 5
 
   sync:
     api:

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -372,8 +372,18 @@ func Download(c *gin.Context) {
 		fileStream = io.MultiReader(newHr, file)
 
 	default:
-		encryptedFileReader := io.MultiReader(bytes.NewReader(fileDetails.Header), file)
-		c4ghfileStream, err := streaming.NewCrypt4GHReader(encryptedFileReader, *config.Config.App.Crypt4GHKey, nil)
+		// Reencrypt header for use with our temporary key
+		newHeader, err := reencryptHeader(fileDetails.Header, config.Config.App.Crypt4GHPublicKeyB64)
+
+		if err != nil {
+			log.Errorf("Failed to reencrypt the file header, reason: %v", err)
+			c.String(http.StatusInternalServerError, "file re-encryption error")
+
+			return
+		}
+
+		encryptedFileReader := io.MultiReader(bytes.NewReader(newHeader), file)
+		c4ghfileStream, err := streaming.NewCrypt4GHReader(encryptedFileReader, config.Config.App.Crypt4GHPrivateKey, nil)
 		defer c4ghfileStream.Close()
 		if err != nil {
 			log.Errorf("could not prepare file for streaming, %s", err)

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -374,7 +374,6 @@ func Download(c *gin.Context) {
 	default:
 		// Reencrypt header for use with our temporary key
 		newHeader, err := reencryptHeader(fileDetails.Header, config.Config.App.Crypt4GHPublicKeyB64)
-
 		if err != nil {
 			log.Errorf("Failed to reencrypt the file header, reason: %v", err)
 			c.String(http.StatusInternalServerError, "file re-encryption error")

--- a/sda-download/dev_utils/compose-no-tls.yml
+++ b/sda-download/dev_utils/compose-no-tls.yml
@@ -91,5 +91,17 @@ services:
       - "8000:8000"
     restart: always
 
+  reencrypt:
+    image: ghcr.io/neicnordic/sensitive-data-archive:latest
+    build: ../../sda/
+    command: [ sda-reencrypt ]
+    container_name: reencrypt
+    ports:
+      - "50051:50051"
+    restart: always
+    volumes:
+      - ./config-notls.yaml:/config.yaml
+      - ./:/dev_utils/
+
 volumes:
   archive:

--- a/sda-download/dev_utils/compose.yml
+++ b/sda-download/dev_utils/compose.yml
@@ -106,7 +106,8 @@ services:
     restart: always
 
   reencrypt:
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.7
+    image: ghcr.io/neicnordic/sensitive-data-archive:latest
+    build: ../../sda
     command: [ sda-reencrypt ]
     container_name: reencrypt
     depends_on:

--- a/sda-download/dev_utils/config-notls.yaml
+++ b/sda-download/dev_utils/config-notls.yaml
@@ -14,6 +14,10 @@ archive:
   # posix backend
   location: "/tmp"
 
+grpc:
+  host: reencrypt
+  port: 50051
+
 c4gh:
   passphrase: "oaagCP1YgAZeEyl2eJAkHv9lkcWXWFgm"
   filepath: "./dev_utils/c4gh.sec.pem"

--- a/sda-download/internal/config/config.go
+++ b/sda-download/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -54,9 +56,9 @@ type AppConfig struct {
 	// Optional. Defaults to empty
 	ServerKey string
 
-	// Stores the Crypt4GH private key if the two configs above are set
-	// Unconfigurable. Depends on Crypt4GHKeyFile and Crypt4GHPassFile
-	Crypt4GHKey *[32]byte
+	// Stores the Crypt4GH private key used internally
+	Crypt4GHPrivateKey   [32]byte
+	Crypt4GHPublicKeyB64 string
 
 	// Selected middleware for authentication and authorizaton
 	// Optional. Default value is "default" for TokenMiddleware
@@ -173,7 +175,7 @@ func NewConfig() (*Map, error) {
 		}
 	}
 	requiredConfVars := []string{
-		"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.configuration.url",
+		"db.host", "db.user", "db.password", "db.database", "oidc.configuration.url",
 	}
 
 	if viper.GetString("archive.type") == S3 {
@@ -210,15 +212,12 @@ func NewConfig() (*Map, error) {
 	c.applyDefaults()
 	c.sessionConfig()
 	c.configArchive()
-	if viper.IsSet("grpc.host") {
-		err := c.configReencrypt()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		log.Info("Reencrypt service is not configured")
+	err := c.configReencrypt()
+	if err != nil {
+		return nil, err
 	}
-	err := c.configureOIDC()
+
+	err = c.configureOIDC()
 	if err != nil {
 		return nil, err
 	}
@@ -316,6 +315,10 @@ func (c *Map) configArchive() {
 
 func (c *Map) configReencrypt() error {
 	c.Reencrypt.Host = viper.GetString("grpc.host")
+	if c.Reencrypt.Host == "" {
+		return fmt.Errorf("grpc.host is not set")
+	}
+
 	viper.SetDefault("grpc.port", 50051)
 	viper.SetDefault("grpc.timeout", 5) // set default to 5 seconds
 	if viper.IsSet("grpc.port") {
@@ -354,7 +357,7 @@ func (c *Map) configReencrypt() error {
 			return errors.New("configured client certificate is a folder")
 		}
 	}
-	if c.Reencrypt.ClientCert != "" && c.Reencrypt.ClientKey != "" {
+	if c.Reencrypt.ClientCert != "" && c.Reencrypt.ClientKey != "" && !viper.IsSet("grpc.port") {
 		log.Infoln("client certificates detected, setting grpc port to 50443")
 		c.Reencrypt.Port = 50443
 	}
@@ -377,7 +380,7 @@ func (c *Map) appConfig() error {
 	}
 
 	var err error
-	c.App.Crypt4GHKey, err = GetC4GHKey()
+	c.App.Crypt4GHPrivateKey, c.App.Crypt4GHPublicKeyB64, err = GetC4GHKey()
 	if err != nil {
 		return err
 	}
@@ -479,24 +482,36 @@ func constructWhitelist(obj []TrustedISS) *jwk.MapWhitelist {
 }
 
 // GetC4GHKey reads and decrypts and returns the c4gh key
-func GetC4GHKey() (*[32]byte, error) {
-	log.Info("reading crypt4gh private key")
-	keyPath := viper.GetString("c4gh.filepath")
-	passphrase := viper.GetString("c4gh.passphrase")
+func GetC4GHKey() ([32]byte, string, error) {
+	log.Info("creating temporary crypt4gh key")
 
-	// Make sure the key path and passphrase is valid
-	keyFile, err := os.Open(keyPath)
+	public, private, err := keys.GenerateKeyPair()
+
 	if err != nil {
-		return nil, err
+		log.Errorf("Error when generating keys: %v", err)
+
+		return [32]byte{}, "", err
 	}
 
-	key, err := keys.ReadPrivateKey(keyFile, []byte(passphrase))
+	pem := bytes.Buffer{}
+	err = keys.WriteCrypt4GHX25519PublicKey(&pem, public)
+
 	if err != nil {
-		return nil, err
+		log.Errorf("Error when converting public key to PEM format: %v", err)
+
+		return [32]byte{}, "", err
 	}
 
-	keyFile.Close()
-	log.Info("crypt4gh private key loaded")
+	b64 := bytes.Buffer{}
 
-	return &key, nil
+	encoder := base64.NewEncoder(base64.StdEncoding, &b64)
+	_, err = encoder.Write(pem.Bytes())
+
+	if err != nil {
+		log.Errorf("Error when converting public key to PEM format: %v", err)
+
+		return [32]byte{}, "", err
+	}
+
+	return private, b64.String(), nil
 }

--- a/sda-download/internal/config/config.go
+++ b/sda-download/internal/config/config.go
@@ -175,7 +175,7 @@ func NewConfig() (*Map, error) {
 		}
 	}
 	requiredConfVars := []string{
-		"db.host", "db.user", "db.password", "db.database", "oidc.configuration.url", "grpc.host"
+		"db.host", "db.user", "db.password", "db.database", "oidc.configuration.url", "grpc.host",
 	}
 
 	if viper.GetString("archive.type") == S3 {

--- a/sda-download/internal/config/config.go
+++ b/sda-download/internal/config/config.go
@@ -477,7 +477,8 @@ func constructWhitelist(obj []TrustedISS) *jwk.MapWhitelist {
 	return wl
 }
 
-// GetC4GHKey reads and decrypts and returns the c4gh key
+// GeneerateC4GHKey generates a keypair and returns the private key as a byte
+// array and the public key as a base64 encoded string
 func GenerateC4GHKey() ([32]byte, string, error) {
 	log.Info("creating temporary crypt4gh key")
 
@@ -497,15 +498,7 @@ func GenerateC4GHKey() ([32]byte, string, error) {
 		return [32]byte{}, "", err
 	}
 
-	b64 := bytes.Buffer{}
+	b64 := base64.StdEncoding.EncodeToString(pem.Bytes())
 
-	encoder := base64.NewEncoder(base64.StdEncoding, &b64)
-	_, err = encoder.Write(pem.Bytes())
-	if err != nil {
-		log.Errorf("Error when converting public key to PEM format: %v", err)
-
-		return [32]byte{}, "", err
-	}
-
-	return private, b64.String(), nil
+	return private, b64, nil
 }

--- a/sda-download/internal/config/config_test.go
+++ b/sda-download/internal/config/config_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var requiredConfVars = []string{
-	"db.host", "db.user", "db.password", "db.database", "oidc.configuration.url",
+	"db.host", "db.user", "db.password", "db.database", "oidc.configuration.url", "grpc.host",
 }
 
 type TestSuite struct {

--- a/sda-download/internal/config/config_test.go
+++ b/sda-download/internal/config/config_test.go
@@ -2,19 +2,17 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
 var requiredConfVars = []string{
-	"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.configuration.url",
+	"db.host", "db.user", "db.password", "db.database", "oidc.configuration.url",
 }
 
 type TestSuite struct {
@@ -63,22 +61,27 @@ func (suite *TestSuite) TestMissingRequiredConfVar() {
 
 func (suite *TestSuite) TestAppConfig() {
 
-	// Test fail on key read error
+	// Test fail on missing middleware
 	viper.Set("app.host", "test")
 	viper.Set("app.port", 1234)
 	viper.Set("app.servercert", "test")
 	viper.Set("app.serverkey", "test")
 	viper.Set("log.logLevel", "debug")
-
 	viper.Set("db.sslmode", "disable")
+
+	viper.Set("app.middleware", "noexist")
 
 	c := &Map{}
 	err := c.appConfig()
 	assert.Error(suite.T(), err, "Error expected")
-	assert.Nil(suite.T(), c.App.Crypt4GHKey)
+	viper.Reset()
 
-	// Generate a Crypt4GH private key, so that ConfigMap.appConfig() doesn't fail
-	generateKeyForTest(suite)
+	viper.Set("app.host", "test")
+	viper.Set("app.port", 1234)
+	viper.Set("app.servercert", "test")
+	viper.Set("app.serverkey", "test")
+	viper.Set("log.logLevel", "debug")
+	viper.Set("db.sslmode", "disable")
 
 	c = &Map{}
 	err = c.appConfig()
@@ -87,6 +90,8 @@ func (suite *TestSuite) TestAppConfig() {
 	assert.Equal(suite.T(), 1234, c.App.Port)
 	assert.Equal(suite.T(), "test", c.App.ServerCert)
 	assert.Equal(suite.T(), "test", c.App.ServerKey)
+	assert.NotNil(suite.T(), c.App.Crypt4GHPrivateKey)
+	assert.NotNil(suite.T(), c.App.Crypt4GHPublicKeyB64)
 }
 
 func (suite *TestSuite) TestArchiveConfig() {
@@ -199,26 +204,11 @@ func (suite *TestSuite) TestConfigReencrypt() {
 	assert.ErrorContains(suite.T(), c.configReencrypt(), "no such file or directory")
 
 	// any existing flle will make it pass
-	generateKeyForTest(suite)
-	viper.Set("grpc.clientcert", viper.Get("c4gh.filepath"))
+	viper.Set("grpc.clientcert", "config_test.go")
 	assert.NoError(suite.T(), c.configReencrypt())
 
 	// it will fail if certificate is set to a folder
-	generateKeyForTest(suite)
 	viper.Set("grpc.clientcert", tempDir)
 	assert.ErrorContains(suite.T(), c.configReencrypt(), "is a folder")
 
-}
-
-func generateKeyForTest(suite *TestSuite) {
-	// Generate a key, so that ConfigMap.appConfig() doesn't fail
-	_, privateKey, err := keys.GenerateKeyPair()
-	assert.NoError(suite.T(), err)
-	tempDir := suite.T().TempDir()
-	privateKeyFile, err := os.Create(fmt.Sprintf("%s/c4fg.key", tempDir))
-	assert.NoError(suite.T(), err)
-	err = keys.WriteCrypt4GHX25519PrivateKey(privateKeyFile, privateKey, []byte("password"))
-	assert.NoError(suite.T(), err)
-	viper.Set("c4gh.filepath", fmt.Sprintf("%s/c4fg.key", tempDir))
-	viper.Set("c4gh.passphrase", "password")
 }

--- a/sda-download/internal/config/config_test.go
+++ b/sda-download/internal/config/config_test.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -92,6 +95,12 @@ func (suite *TestSuite) TestAppConfig() {
 	assert.Equal(suite.T(), "test", c.App.ServerKey)
 	assert.NotNil(suite.T(), c.App.Crypt4GHPrivateKey)
 	assert.NotNil(suite.T(), c.App.Crypt4GHPublicKeyB64)
+
+	// Check the key that was generated
+	publicKey, err := base64.StdEncoding.DecodeString(c.App.Crypt4GHPublicKeyB64)
+	assert.Nilf(suite.T(), err, "Incorrect public c4gh key generated (error in base64 encoding)")
+	_, err = keys.ReadPublicKey(bytes.NewReader(publicKey))
+	assert.Nilf(suite.T(), err, "Incorrect public c4gh key generated (bad key)")
 }
 
 func (suite *TestSuite) TestArchiveConfig() {


### PR DESCRIPTION
Make sda-download use a temporary key and reencrypt for that rather than having the archive key accessible to sda-download directly.

Also contains some followup chart changes and an added a network policy for download.

The use case for this is to support having an external deployment (that can be accessed in some way from the outside) that doesn't have access to the archive key. Since the key is quite sensitive, that is desirable for security reasons, but if we add key rotation, making sure we only need to implement it in only one place makes life easier.

While it aims to be drop-in ready, certain care should be ensured when deploying versions including this change if merged (e.g. to ensure reencrypt service is reachable from download service et.c).
