### PR TITLE
Feat/htsget random access - PLACEHOLDER

### DIFF
--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        storagetype: [s3, posix, s3notls]
+        storagetype: [s3, posix, s3notls, s3seekable]
         go-version: ['1.21']
       fail-fast: false
     steps:

--- a/sda-download/.github/integration/setup/posix/1_posix_env_setup.sh
+++ b/sda-download/.github/integration/setup/posix/1_posix_env_setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed -i 's/=s3/=posix/g' dev_utils/env.download
+sed -i 's/ARCHIVE_TYPE=.*/ARCHIVE_TYPE=posix/g' dev_utils/env.download
 

--- a/sda-download/.github/integration/setup/s3seekable/100_s3_storage_setup.sh
+++ b/sda-download/.github/integration/setup/s3seekable/100_s3_storage_setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pip3 install s3cmd
+
+cd dev_utils || exit 1
+
+# Make buckets if they don't exist already 
+s3cmd -c s3cmd.conf mb s3://archive || true
+
+# # Upload test file
+s3cmd -c s3cmd.conf put archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6 s3://archive/4293c9a7-dc50-46db-b79a-27ddc0dad1c6

--- a/sda-download/.github/integration/setup/s3seekable/1_s3seekable_env_setup.sh
+++ b/sda-download/.github/integration/setup/s3seekable/1_s3seekable_env_setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i 's/ARCHIVE_TYPE=.*/ARCHIVE_TYPE=s3seekable/g' dev_utils/env.download
+

--- a/sda-download/api/api.go
+++ b/sda-download/api/api.go
@@ -52,12 +52,7 @@ func Setup() *http.Server {
 	// Configure TLS settings
 	log.Info("(3/5) Configuring TLS")
 	cfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		},
+		MinVersion: tls.VersionTLS12,
 	}
 
 	// Configure web server

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -328,15 +328,17 @@ func Download(c *gin.Context) {
 			reencKey = c.GetHeader("Client-Public-Key")
 			log.Warnf("htsget: using client key %v", reencKey)
 		}
-		c.Header("Server-Additional-Bytes", fmt.Sprint(bytes.NewReader(fileDetails.Header).Size()))
+		headerSize := bytes.NewReader(fileDetails.Header).Size()
+		c.Header("Server-Additional-Bytes", fmt.Sprint(headerSize))
 		if reencKey != "" {
 			log.Warnf("do we have reencryption key? yes: %v", reencKey)
 			newHeader, _ := reencryptHeader(fileDetails.Header, reencKey)
-			c.Header("Client-Additional-Bytes", fmt.Sprint(bytes.NewReader(newHeader).Size()))
+			headerSize = bytes.NewReader(newHeader).Size()
+			c.Header("Client-Additional-Bytes", fmt.Sprint(headerSize))
 		}
 		if c.Param("type") == "encrypted" {
 			// update the content length to match the encrypted file size
-			c.Header("Content-Length", fmt.Sprint(fileDetails.ArchiveSize))
+			c.Header("Content-Length", fmt.Sprint(int(headerSize)+fileDetails.ArchiveSize))
 		}
 
 		return

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -494,7 +494,8 @@ var calculateEncryptedCoords = func(start, end int64, htsget_range string, fileD
 				return 0, 0, fmt.Errorf("endCoordinate must be greater than startCoordinate")
 			}
 
-			return a, b, nil
+			// Byte ranges are inclusive; +1 so that the last byte is included
+			return a, b + 1, nil
 		}
 	}
 	// Adapt end coordinate to follow the crypt4gh block boundaries

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -360,7 +360,6 @@ func Download(c *gin.Context) {
 
 			return
 		}
-
 	}
 
 	switch c.Param("type") {

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -474,7 +474,7 @@ var sendStream = func(reader io.ReadSeeker, writer http.ResponseWriter, start, e
 // Calculates the start and end coordinats to use. If a range is set in HTTP headers,
 // it will be used as is. If not, the functions parameters will be used.
 // If in encrypted mode, the parameters will be adjusted to match the data block boundaries.
-var calculateEncryptedCoords = func(start, end int64, htsget_range string, fileDetails *database.FileDownload, encryptedType string) (int64, int64, error) {
+var calculateCoords = func(start, end int64, htsget_range string, fileDetails *database.FileDownload, encryptedType string) (int64, int64, error) {
 	log.Warnf("calculate")
 	if htsget_range != "" {
 		log.Warnf("calculate non empty")

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -353,7 +353,14 @@ func Download(c *gin.Context) {
 	if !ok {
 		mr = io.MultiReader(hr, file)
 	} else {
-		mr = storage.SeekableMultiReader(hr, file)
+		mr, err = storage.SeekableMultiReader(hr, file)
+		if err != nil {
+			log.Errorf("Construct SeekableMultiReader for file: %v", err)
+			c.String(http.StatusInternalServerError, "file stream error")
+
+			return
+		}
+
 	}
 
 	switch c.Param("type") {

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -514,7 +514,7 @@ func TestDownload_Fail_OpenFile(t *testing.T) {
 
 }
 
-func TestEncrypted_Coords(t *testing.T) {
+func Test_CalucalateCoords(t *testing.T) {
 	var to, from int64
 	from, to = 0, 1000
 	fileDetails := &database.FileDownload{
@@ -528,38 +528,38 @@ func TestEncrypted_Coords(t *testing.T) {
 	fullSize := headerSize + int64(fileDetails.ArchiveSize)
 	var endPos int64
 	endPos = 20
-	start, end, err := calculateEncryptedCoords(from, to, "bytes=10-"+strconv.FormatInt(endPos, 10), fileDetails, "default")
+	start, end, err := calculateCoords(from, to, "bytes=10-"+strconv.FormatInt(endPos, 10), fileDetails, "default")
 	assert.Equal(t, start, int64(10))
 	assert.Equal(t, end, endPos+1)
 	assert.NoError(t, err)
 
 	// end should be greater than or equal to inputted end
-	_, end, err = calculateEncryptedCoords(from, to, "", fileDetails, "encrypted")
+	_, end, err = calculateCoords(from, to, "", fileDetails, "encrypted")
 	assert.GreaterOrEqual(t, end, from)
 	assert.NoError(t, err)
 
 	// end should not be smaller than a header
-	_, end, err = calculateEncryptedCoords(from, headerSize-10, "", fileDetails, "encrypted")
+	_, end, err = calculateCoords(from, headerSize-10, "", fileDetails, "encrypted")
 	assert.GreaterOrEqual(t, end, headerSize)
 	assert.NoError(t, err)
 
 	// end should not be larger than file length + header
-	_, end, err = calculateEncryptedCoords(from, fullSize+1900, "", fileDetails, "encrypted")
+	_, end, err = calculateCoords(from, fullSize+1900, "", fileDetails, "encrypted")
 	assert.Equal(t, fullSize, end)
 	assert.NoError(t, err)
 
 	// param range 0-0 should give whole file
-	start, end, err = calculateEncryptedCoords(0, 0, "", fileDetails, "encrypted")
+	start, end, err = calculateCoords(0, 0, "", fileDetails, "encrypted")
 	assert.Equal(t, end-start, fullSize)
 	assert.NoError(t, err)
 
 	// byte range 0-1000 should return the range size, end coord inclusive
 	endPos = 1000
-	_, end, err = calculateEncryptedCoords(0, 0, "bytes=0-"+strconv.FormatInt(endPos, 10), fileDetails, "encrypted")
+	_, end, err = calculateCoords(0, 0, "bytes=0-"+strconv.FormatInt(endPos, 10), fileDetails, "encrypted")
 	assert.Equal(t, end, endPos+1)
 	assert.NoError(t, err)
 
 	// range in the header should return error if values are not numbers
-	_, _, err = calculateEncryptedCoords(0, 0, "bytes=start-end", fileDetails, "encrypted")
+	_, _, err = calculateCoords(0, 0, "bytes=start-end", fileDetails, "encrypted")
 	assert.Error(t, err)
 }

--- a/sda-download/internal/config/config.go
+++ b/sda-download/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 
 const POSIX = "posix"
 const S3 = "s3"
+const S3seekable = "s3seekable"
 
 // availableMiddlewares list the options for middlewares
 // empty string "" is an alias for default, for when the config key is not set, or it's empty
@@ -176,7 +177,7 @@ func NewConfig() (*Map, error) {
 		"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.configuration.url",
 	}
 
-	if viper.GetString("archive.type") == S3 {
+	if viper.GetString("archive.type") == S3 || viper.GetString("archive.type") == S3seekable {
 		requiredConfVars = append(requiredConfVars, []string{"archive.url", "archive.accesskey", "archive.secretkey", "archive.bucket"}...)
 	} else if viper.GetString("archive.type") == POSIX {
 		requiredConfVars = append(requiredConfVars, []string{"archive.location"}...)

--- a/sda-download/internal/config/config.go
+++ b/sda-download/internal/config/config.go
@@ -306,10 +306,17 @@ func (c *Map) configureOIDC() error {
 // configArchive provides configuration for the archive storage
 // we default to POSIX unless S3 specified
 func (c *Map) configArchive() {
-	if viper.GetString("archive.type") == S3 {
+
+	switch viper.GetString("archive.type") {
+	case S3:
 		c.Archive.Type = S3
 		c.Archive.S3 = configS3Storage("archive")
-	} else {
+
+	case S3seekable:
+		c.Archive.Type = S3seekable
+		c.Archive.S3 = configS3Storage("archive")
+
+	default:
 		c.Archive.Type = POSIX
 		c.Archive.Posix.Location = viper.GetString("archive.location")
 	}

--- a/sda-download/internal/config/config_test.go
+++ b/sda-download/internal/config/config_test.go
@@ -99,6 +99,32 @@ func (suite *TestSuite) TestArchiveConfig() {
 
 }
 
+func (suite *TestSuite) TestArchiveS3Config() {
+	for _, archiveType := range []string{S3, S3seekable} {
+		viper.Set("archive.type", archiveType)
+		viper.Set("archive.url", "localhost")
+		viper.Set("archive.accesskey", "access")
+		viper.Set("archive.secretkey", "secret")
+		viper.Set("archive.bucket", "bucket")
+		viper.Set("archive.port", "9090")
+		viper.Set("archive.chunksize", "10")
+		viper.Set("archive.region", "us-west-1")
+		viper.Set("archive.cacert", "filename")
+
+		c := &Map{}
+		c.configArchive()
+		assert.Equal(suite.T(), "localhost", c.Archive.S3.URL)
+		assert.Equal(suite.T(), "access", c.Archive.S3.AccessKey)
+		assert.Equal(suite.T(), "secret", c.Archive.S3.SecretKey)
+		assert.Equal(suite.T(), "bucket", c.Archive.S3.Bucket)
+		assert.Equal(suite.T(), "us-west-1", c.Archive.S3.Region)
+		assert.Equal(suite.T(), "filename", c.Archive.S3.Cacert)
+		assert.Equal(suite.T(), 10*1024*1024, c.Archive.S3.Chunksize)
+		assert.Equal(suite.T(), 9090, c.Archive.S3.Port)
+
+	}
+}
+
 func (suite *TestSuite) TestSessionConfig() {
 
 	viper.Set("session.expiration", 3600)

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -353,7 +353,6 @@ func transportConfigS3(config S3Conf) http.RoundTripper {
 }
 
 func (sb *s3SeekableBackend) NewFileReader(filePath string) (io.ReadCloser, error) {
-
 	s := sb.s3Backend
 	objectSize, err := s.GetFileSize(filePath)
 
@@ -377,7 +376,6 @@ func (sb *s3SeekableBackend) NewFileReader(filePath string) (io.ReadCloser, erro
 }
 
 func (sb *s3SeekableBackend) GetFileSize(filePath string) (int64, error) {
-
 	s := sb.s3Backend
 
 	return s.GetFileSize(filePath)
@@ -402,7 +400,6 @@ func (r *s3SeekableReader) pruneCache() {
 }
 
 func (r *s3SeekableReader) prefetchSize() int64 {
-
 	n := r.Conf.Chunksize
 
 	if n >= 5*1024*1024 {
@@ -478,7 +475,6 @@ func (r *s3SeekableReader) prefetchAt(offset int64) {
 	// Store in cache
 	cacheBytes := b.Bytes()
 	r.local = append(r.local, s3CacheBlock{offset, int64(len(cacheBytes)), cacheBytes})
-
 }
 
 func (r *s3SeekableReader) Seek(offset int64, whence int) (int64, error) {
@@ -542,7 +538,6 @@ func (r *s3SeekableReader) removeFromOutstanding(toRemove int64) {
 		// Check if it's the one we should remove
 		if r.outstandingPrefetches[0] == toRemove {
 			r.outstandingPrefetches = r.outstandingPrefetches[:0]
-
 		}
 
 	default:
@@ -558,7 +553,6 @@ func (r *s3SeekableReader) removeFromOutstanding(toRemove int64) {
 			r.outstandingPrefetches[remove] = r.outstandingPrefetches[len(r.outstandingPrefetches)-1]
 			r.outstandingPrefetches = r.outstandingPrefetches[:len(r.outstandingPrefetches)-1]
 		}
-
 	}
 }
 

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -780,8 +780,8 @@ func (r *seekableMultiReader) Read(dst []byte) (int, error) {
 		r.currentOffset += int64(n)
 
 		if n > 0 || err != io.EOF {
-			if err == io.EOF && len(r.readers) > 0 {
-				// More readers left, hold that EOF
+			if err == io.EOF && r.currentOffset < r.totalSize {
+				// More data left, hold that EOF
 				err = nil
 			}
 

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -624,14 +624,9 @@ func (r *s3SeekableReader) Read(dst []byte) (n int, err error) {
 			// At least part of the data is here
 
 			offsetInBlock := start - p.start
-			wanted := int64(len(dst))
-
-			if p.length-offsetInBlock < wanted {
-				wanted = p.length - offsetInBlock
-			}
 
 			// Pull out wanted data (as much as we have)
-			n = copy(dst, p.data[offsetInBlock:offsetInBlock+wanted])
+			n = copy(dst, p.data[offsetInBlock:])
 			r.currentOffset += int64(n)
 
 			// Prefetch the next bit

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -611,6 +611,11 @@ func (r *s3SeekableReader) Read(dst []byte) (n int, err error) {
 		return n, err
 	}
 
+	if r.currentOffset >= r.objectSize {
+		// For reading when there is no more data, just return EOF
+		return 0, io.EOF
+	}
+
 	start := r.currentOffset
 
 	// Walk through the cache

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -680,7 +680,6 @@ func (r *s3SeekableReader) Read(dst []byte) (n int, err error) {
 	// Add to cache
 	cacheBytes := bytes.Clone(b.Bytes())
 	r.local = append(r.local, s3CacheBlock{start, int64(len(cacheBytes)), cacheBytes})
-	log.Infof("Stored into cache starting at %v, length %v", start, len(cacheBytes))
 
 	n, err = b.Read(dst)
 

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -709,18 +709,19 @@ func SeekableMultiReader(readers ...io.Reader) (io.ReadSeeker, error) {
 
 	var totalSize int64
 	for i, reader := range readers {
-		if seeker, ok := reader.(io.ReadSeeker); !ok {
+		seeker, ok := reader.(io.ReadSeeker)
+		if !ok {
 			return nil, fmt.Errorf("Reader %d to SeekableMultiReader is not seekable", i)
-		} else {
-
-			size, err := seeker.Seek(0, io.SeekEnd)
-			if err != nil {
-				return nil, fmt.Errorf("Size determination failed for reader %d to SeekableMultiReader: %v", i, err)
-			}
-
-			sizes[i] = size
-			totalSize += size
 		}
+
+		size, err := seeker.Seek(0, io.SeekEnd)
+		if err != nil {
+			return nil, fmt.Errorf("Size determination failed for reader %d to SeekableMultiReader: %v", i, err)
+		}
+
+		sizes[i] = size
+		totalSize += size
+
 	}
 
 	return &seekableMultiReader{r, sizes, 0, totalSize}, nil

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -728,17 +728,13 @@ func SeekableMultiReader(readers ...io.Reader) (io.ReadSeeker, error) {
 
 func (r *seekableMultiReader) Seek(offset int64, whence int) (int64, error) {
 
-	if !r.allSeekable {
-		return 0, fmt.Errorf("Not all readers are seekable")
-	}
-
 	switch whence {
-	case 0:
+	case io.SeekStart:
 		r.currentOffset = offset
-	case 1:
+	case io.SeekCurrent:
 		r.currentOffset += offset
-	case 2:
-		return 0, fmt.Errorf("Seeking from end not supported")
+	case io.SeekEnd:
+		r.currentOffset = r.totalSize + offset
 
 	default:
 		return 0, fmt.Errorf("Unsupported whence")
@@ -793,9 +789,7 @@ func (r *seekableMultiReader) Read(dst []byte) (int, error) {
 		}
 
 		readerStartAt += r.sizes[i]
-
 	}
 
 	return 0, io.EOF
-
 }

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -2,6 +2,7 @@
 package storage
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -52,6 +54,9 @@ func NewBackend(config Conf) (Backend, error) {
 	switch config.Type {
 	case "s3":
 		return newS3Backend(config.S3)
+	case "s3seekable":
+		return newS3SeekableBackend(config.S3)
+
 	default:
 		return newPosixBackend(config.Posix)
 	}
@@ -126,6 +131,25 @@ type s3Backend struct {
 	Conf     *S3Conf
 }
 
+type s3CacheBlock struct {
+	start  int64
+	length int64
+	data   []byte
+}
+
+type s3SeekableBackend struct {
+	s3Backend
+}
+
+type s3SeekableReader struct {
+	s3SeekableBackend
+	currentOffset int64
+	local         []s3CacheBlock
+	filePath      string
+	objectSize    int64
+	lock          sync.Mutex
+}
+
 // S3Conf stores information about the S3 storage backend
 type S3Conf struct {
 	URL               string
@@ -138,6 +162,15 @@ type S3Conf struct {
 	Chunksize         int
 	Cacert            string
 	NonExistRetryTime time.Duration
+}
+
+func newS3SeekableBackend(config S3Conf) (*s3SeekableBackend, error) {
+	sb, err := newS3Backend(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s3SeekableBackend{*sb}, nil
 }
 
 func newS3Backend(config S3Conf) (*s3Backend, error) {
@@ -314,4 +347,311 @@ func transportConfigS3(config S3Conf) http.RoundTripper {
 		ForceAttemptHTTP2: true}
 
 	return trConfig
+}
+
+func (sb *s3SeekableBackend) NewFileReader(filePath string) (io.ReadCloser, error) {
+
+	s := sb.s3Backend
+	objectSize, err := s.GetFileSize(filePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	reader := &s3SeekableReader{
+		*sb,
+		0,
+		make([]s3CacheBlock, 0, 32),
+		filePath,
+		objectSize,
+		sync.Mutex{},
+	}
+
+	return reader, nil
+}
+
+func (sb *s3SeekableBackend) GetFileSize(filePath string) (int64, error) {
+
+	s := sb.s3Backend
+	return s.GetFileSize(filePath)
+}
+
+func (r *s3SeekableReader) Close() (err error) {
+	return nil
+}
+
+func (r *s3SeekableReader) pruneCache() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if len(r.local) < 16 {
+		return nil
+	}
+
+	// Prune the cache
+	keepfrom := len(r.local) - 8
+	r.local = r.local[keepfrom:]
+
+	return nil
+}
+
+func (r *s3SeekableReader) prefetchAt(offset int64) error {
+	r.pruneCache()
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for _, p := range r.local {
+		if offset >= p.start && offset < p.start+p.length {
+			// At least part of the data is here
+			return nil
+		}
+	}
+
+	bucket := aws.String(r.Bucket)
+	key := aws.String(r.filePath)
+	r.lock.Unlock()
+
+	wantedRange := aws.String(fmt.Sprintf("bytes=%d-%d", offset, offset+int64(r.Conf.Chunksize)))
+
+	object, err := r.Client.GetObject(&s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Range:  wantedRange,
+	})
+
+	r.lock.Lock()
+
+	if err != nil {
+		return err
+	}
+
+	if len(r.local) > 16 {
+		// Don't cache anything more right now
+		return nil
+	}
+
+	b := bytes.Buffer{}
+	_, err = io.Copy(&b, object.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to read object: %v", err)
+	}
+
+	cacheBytes := bytes.Clone(b.Bytes())
+	r.local = append(r.local, s3CacheBlock{offset, int64(len(cacheBytes)), cacheBytes})
+
+	return nil
+}
+
+func (r *s3SeekableReader) Seek(offset int64, whence int) (int64, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	switch whence {
+	case 0:
+		if offset < 0 {
+			return r.currentOffset, fmt.Errorf("Invalid offset %v- can't be negative when seeking from start", offset)
+		}
+		if offset >= r.objectSize {
+			return r.currentOffset, fmt.Errorf("Invalid offset %v - beyond end of object (size %v)", offset, r.objectSize)
+		}
+
+		r.currentOffset = offset
+		go r.prefetchAt(r.currentOffset)
+		return offset, nil
+	case 1:
+		if r.currentOffset+offset < 0 {
+			return r.currentOffset, fmt.Errorf("Invalid offset %v from %v would be be before start", offset, r.currentOffset)
+		}
+		if offset >= r.objectSize {
+			return r.currentOffset, fmt.Errorf("Invalid offset - %v from %v would end up beyond of object %v", offset, r.currentOffset, r.objectSize)
+		}
+
+		r.currentOffset = offset
+		go r.prefetchAt(r.currentOffset)
+		return offset, nil
+
+	case 2:
+
+		if r.objectSize+offset < 0 {
+			return r.currentOffset, fmt.Errorf("Invalid offset %v from end in %v bytes object, would be before file start", offset, r.objectSize)
+		}
+		if r.objectSize+offset >= r.objectSize {
+			return r.currentOffset, fmt.Errorf("Invalid offset %v from end in %v bytes object", offset, r.objectSize)
+		}
+
+		r.currentOffset = r.objectSize + offset
+		go r.prefetchAt(r.currentOffset)
+		return r.currentOffset, nil
+
+	default:
+		return r.currentOffset, fmt.Errorf("Bad whence")
+
+	}
+
+	return r.currentOffset, fmt.Errorf("How did we get here?")
+}
+
+func (r *s3SeekableReader) Read(dst []byte) (n int, err error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	start := r.currentOffset
+
+	for _, p := range r.local {
+		if start >= p.start && start < p.start+p.length {
+			// At least part of the data is here
+
+			offsetInBlock := start - p.start
+			wanted := int64(len(dst))
+
+			if p.length-offsetInBlock < wanted {
+				wanted = p.length - offsetInBlock
+			}
+
+			// Pull out wanted data (as much as we have)
+			n = copy(dst, p.data[offsetInBlock:offsetInBlock+wanted])
+			r.currentOffset += int64(n)
+
+			// Prefetch the next bit
+			go r.prefetchAt(r.currentOffset)
+			return n, nil
+		}
+	}
+
+	// Need to fetch data
+
+	bucket := aws.String(r.Bucket)
+	key := aws.String(r.filePath)
+
+	wantedRange := aws.String(fmt.Sprintf("bytes=%d-%d", r.currentOffset, r.currentOffset+int64(len(dst))))
+	r.lock.Unlock()
+
+	// We don't bother putting the object into the cache, as we're going to read it all anyway
+
+	object, err := r.Client.GetObject(&s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    key,
+		Range:  wantedRange,
+	})
+
+	r.lock.Lock()
+
+	if err != nil {
+		return 0, err
+	}
+
+	n, err = object.Body.Read(dst)
+
+	r.currentOffset += int64(n)
+	go r.prefetchAt(r.currentOffset)
+
+	return n, err
+}
+
+// seekableMultiReader is a helper struct to allow io.MultiReader to be used with a seekable reader
+type seekableMultiReader struct {
+	readers       []io.Reader
+	sizes         []int64
+	currentOffset int64
+	allSeekable   bool
+}
+
+// SeekableMultiReader constructs a multireader that supports seeking
+func SeekableMultiReader(readers ...io.Reader) io.ReadSeeker {
+
+	r := make([]io.Reader, len(readers))
+	s := make([]int64, len(readers))
+
+	copy(r, readers)
+
+	allSeekable := true
+	for i, reader := range readers {
+		if seeker, ok := reader.(io.ReadSeeker); !ok {
+			allSeekable = false
+		} else {
+			s[i], _ = seeker.Seek(0, 2)
+		}
+	}
+
+	return &seekableMultiReader{r, s, 0, allSeekable}
+}
+
+func (r *seekableMultiReader) Seek(offset int64, whence int) (int64, error) {
+
+	if !r.allSeekable {
+		return 0, fmt.Errorf("Not all readers are seekable")
+	}
+
+	switch whence {
+	case 0:
+		r.currentOffset = offset
+	case 1:
+		r.currentOffset += offset
+	case 2:
+		return 0, fmt.Errorf("Seeking from end not supported")
+
+	default:
+		return 0, fmt.Errorf("Unsupported whence")
+
+	}
+
+	return r.currentOffset, nil
+}
+
+func (r *seekableMultiReader) Read(dst []byte) (int, error) {
+
+	if !r.allSeekable {
+		// Modeled after io.MultiReader. Is it better to refuse at creation
+		// if not all are seekable?
+
+		for len(r.readers) > 0 {
+			n, err := r.readers[0].Read(dst)
+			if err == io.EOF {
+				r.readers = r.readers[1:]
+			}
+			if n > 0 || err != io.EOF {
+				if err == io.EOF && len(r.readers) > 0 {
+					// More readers left, hold that EOF
+					err = nil
+				}
+				return n, err
+			}
+		}
+		// no readers left and no data to return
+		return 0, io.EOF
+	}
+
+	var readerStartAt int64 = 0
+
+	for i, reader := range r.readers {
+		if r.currentOffset >= readerStartAt && r.currentOffset < int64(readerStartAt)+r.sizes[i] {
+			// At least part of the data is in this reader
+
+			seekable, ok := reader.(io.ReadSeeker)
+			if !ok {
+				return 0, fmt.Errorf("Expected seekable reader but changed")
+			}
+
+			_, err := seekable.Seek(r.currentOffset-int64(readerStartAt), 0)
+			if err != nil {
+				return 0, fmt.Errorf("Unexpected error while seeking: %v", err)
+			}
+
+			n, err := seekable.Read(dst)
+			r.currentOffset += int64(n)
+
+			if n > 0 || err != io.EOF {
+				if err == io.EOF && len(r.readers) > 0 {
+					// More readers left, hold that EOF
+					err = nil
+				}
+				return n, err
+			}
+		}
+		readerStartAt += r.sizes[i]
+	}
+
+	return 0, io.EOF
+
 }

--- a/sda-download/internal/storage/storage_test.go
+++ b/sda-download/internal/storage/storage_test.go
@@ -415,7 +415,7 @@ func TestSeekableBackend(t *testing.T) {
 
 		// Wait for consistency after s3 write
 		if testConf.Type == s3SeekableType {
-			time.Sleep(750 * time.Millisecond)
+			time.Sleep(1500 * time.Millisecond)
 		}
 
 		reader, err := backend.NewFileReader(path)

--- a/sda-download/internal/storage/storage_test.go
+++ b/sda-download/internal/storage/storage_test.go
@@ -478,6 +478,7 @@ func TestSeekableBackend(t *testing.T) {
 
 		n, err := seeker.Read(readBackBuffer[0:4096])
 		assert.Equal(t, 5, n, "Unexpected amount of read bytes")
+		assert.Nil(t, err, "Read failed when it shouldn't")
 
 		n, err = seeker.Read(readBackBuffer[0:4096])
 
@@ -490,6 +491,7 @@ func TestSeekableBackend(t *testing.T) {
 
 		n, err = seeker.Read(readBackBuffer[0:4096])
 		assert.Equal(t, 0, n, "Unexpected amount of read bytes")
+		assert.Equal(t, io.EOF, err, "Read returned unexpected error when EOF")
 
 		offset, err = seeker.Seek(6302, io.SeekStart)
 
@@ -687,7 +689,10 @@ func TestSeekableMultiReader(t *testing.T) {
 	assert.Equal(t, writeData[4:], readBackBuffer[:10], "did not read back data as expected")
 	assert.Nil(t, err, "Read failed when it should not")
 
-	seeker.Seek(0, io.SeekEnd)
+	offset, err = seeker.Seek(0, io.SeekEnd)
+	assert.Equal(t, int64(140), offset, "Seek did not return expected offset")
+	assert.Nil(t, err, "Seek failed when it should not")
+
 	n, err := seeker.Read(readBackBuffer[0:4096])
 
 	assert.Equal(t, 0, n, "Read did not return expected amounts of bytes")

--- a/sda-download/internal/storage/storage_test.go
+++ b/sda-download/internal/storage/storage_test.go
@@ -494,13 +494,11 @@ func TestSeekableBackend(t *testing.T) {
 		assert.Equal(t, io.EOF, err, "Read returned unexpected error when EOF")
 
 		offset, err = seeker.Seek(6302, io.SeekStart)
-
 		assert.Nil(t, err, "Seek failed")
 		assert.Equal(t, int64(6302), offset, "Seek did not return expected offset")
 
 		n, err = seeker.Read(readBackBuffer[0:4096])
 		assert.Equal(t, 4096, n, "Read did not return expected amounts of bytes")
-
 		assert.Equal(t, writeData[2:], readBackBuffer[:12], "did not read back data as expected")
 
 		if err != nil && err != io.EOF {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This pull request is a **placeholder** for the version containing the htsget random access. The image of `sda-download` in the storage-and-interfaces of GDI is based on the code from this PR


**Description**
- Remove the second header for re-encryption (`server-public-key`)
- Remove the `user-agent` check for the requester
- The `content-length` is now including the header size when htsget requests the encrypted file size
- The range header returns an extra character, according to specification
- Includes the PR #703 code, to make random access possible

**How to test**
