### PR TITLE
Feat/htsget seekable

### DIFF
--- a/sda-download/api/api.go
+++ b/sda-download/api/api.go
@@ -52,7 +52,7 @@ func Setup() *http.Server {
 	// Configure TLS settings
 	log.Info("(3/5) Configuring TLS")
 	cfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	// Configure web server

--- a/sda-download/api/api.go
+++ b/sda-download/api/api.go
@@ -53,11 +53,6 @@ func Setup() *http.Server {
 	log.Info("(3/5) Configuring TLS")
 	cfg := &tls.Config{
 		MinVersion:               tls.VersionTLS12,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		},
 	}
 
 	// Configure web server

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -388,7 +388,7 @@ func Download(c *gin.Context) {
 
 				return
 			}
-			start, end, err = seekStart(seekStream, start, end)
+			start, end, err = adjustSeekPos(seekStream, start, end)
 			if err != nil {
 				log.Errorf("Could not seek stream: %v", err)
 				c.String(http.StatusInternalServerError, "file decoding error")
@@ -430,7 +430,7 @@ func Download(c *gin.Context) {
 
 			return
 		}
-		start, end, err = seekStart(c4ghfileStream, start, end)
+		start, end, err = adjustSeekPos(c4ghfileStream, start, end)
 		if err != nil {
 			log.Errorf("Could not seek stream: %v", err)
 			c.String(http.StatusInternalServerError, "file decoding error")
@@ -449,7 +449,7 @@ func Download(c *gin.Context) {
 	}
 }
 
-var seekStart = func(fileStream io.ReadSeeker, start, end int64) (int64, int64, error) {
+var adjustSeekPos = func(fileStream io.ReadSeeker, start, end int64) (int64, int64, error) {
 	if start != 0 {
 
 		// We don't want to read from start, skip ahead to where we should be

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -327,7 +327,6 @@ func Download(c *gin.Context) {
 		// set the user and server public keys that is send from htsget
 		log.Debugf("Got to setting the headers: %s", c.GetHeader("client-public-key"))
 		c.Header("Client-Public-Key", c.GetHeader("Client-Public-Key"))
-		c.Header("Server-Public-Key", c.GetHeader("Server-Public-Key"))
 	}
 
 	if c.Request.Method == http.MethodHead {

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -389,6 +389,12 @@ func Download(c *gin.Context) {
 				return
 			}
 			start, end, err = seekStart(seekStream, start, end)
+			if err != nil {
+				log.Errorf("Could not seek stream: %v", err)
+				c.String(http.StatusInternalServerError, "file decoding error")
+
+				return
+			}
 			fileStream = seekStream
 		}
 	default:
@@ -425,6 +431,12 @@ func Download(c *gin.Context) {
 			return
 		}
 		start, end, err = seekStart(c4ghfileStream, start, end)
+		if err != nil {
+			log.Errorf("Could not seek stream: %v", err)
+			c.String(http.StatusInternalServerError, "file decoding error")
+
+			return
+		}
 		fileStream = c4ghfileStream
 	}
 

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -358,11 +358,8 @@ func Download(c *gin.Context) {
 	case "encrypted":
 		// The key provided in the header should be base64 encoded
 		reencKey := c.GetHeader("Client-Public-Key")
-		if strings.HasPrefix(c.GetHeader("User-Agent"), "htsget") {
-			reencKey = c.GetHeader("Server-Public-Key")
-		}
 		if reencKey == "" {
-			c.String(http.StatusBadRequest, "c4gh public key is mmissing from the header")
+			c.String(http.StatusBadRequest, "c4gh public key is missing from the header")
 
 			return
 		}

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -491,9 +491,14 @@ func TestDownload_Fail_OpenFile(t *testing.T) {
 		return fileDetails, nil
 	}
 
-	// Mock request and response holders
+	// Mock request and response holders and initialize headers
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
+	req := &http.Request{
+		URL:    &url.URL{},
+		Header: make(http.Header),
+	}
+	c.Request = req
 
 	// Test the outcomes of the handler
 	Download(c)
@@ -520,7 +525,7 @@ func TestDownload_Fail_OpenFile(t *testing.T) {
 
 }
 
-func TestEncrypted_Coords(t *testing.T) {
+func Test_CalucalateCoords(t *testing.T) {
 	var to, from int64
 	from, to = 0, 1000
 	fileDetails := &database.FileDownload{
@@ -529,41 +534,44 @@ func TestEncrypted_Coords(t *testing.T) {
 		Header:      make([]byte, 124),
 	}
 
-	//	htsget_range should be used first and as is
+	//	htsget_range should be used first and its end position should be increased by one
 	headerSize := bytes.NewReader(fileDetails.Header).Size()
 	fullSize := headerSize + int64(fileDetails.ArchiveSize)
-	start, end, err := calculateEncryptedCoords(from, to, "bytes=10-20", fileDetails)
+	var endPos int64
+	endPos = 20
+	start, end, err := calculateCoords(from, to, "bytes=10-"+strconv.FormatInt(endPos, 10), fileDetails, "default")
 	assert.Equal(t, start, int64(10))
-	assert.Equal(t, end, int64(20))
+	assert.Equal(t, end, endPos+1)
 	assert.NoError(t, err)
 
 	// end should be greater than or equal to inputted end
-	_, end, err = calculateEncryptedCoords(from, to, "", fileDetails)
+	_, end, err = calculateCoords(from, to, "", fileDetails, "encrypted")
 	assert.GreaterOrEqual(t, end, from)
 	assert.NoError(t, err)
 
 	// end should not be smaller than a header
-	_, end, err = calculateEncryptedCoords(from, headerSize-10, "", fileDetails)
+	_, end, err = calculateCoords(from, headerSize-10, "", fileDetails, "encrypted")
 	assert.GreaterOrEqual(t, end, headerSize)
 	assert.NoError(t, err)
 
 	// end should not be larger than file length + header
-	_, end, err = calculateEncryptedCoords(from, fullSize+1900, "", fileDetails)
+	_, end, err = calculateCoords(from, fullSize+1900, "", fileDetails, "encrypted")
 	assert.Equal(t, fullSize, end)
 	assert.NoError(t, err)
 
-	// range 0-0 should give whole file
-	start, end, err = calculateEncryptedCoords(0, 0, "", fileDetails)
+	// param range 0-0 should give whole file
+	start, end, err = calculateCoords(0, 0, "", fileDetails, "encrypted")
 	assert.Equal(t, end-start, fullSize)
 	assert.NoError(t, err)
 
-	// range 0-0 with range in the header should return the range size
-	_, end, err = calculateEncryptedCoords(0, 0, "bytes=0-1000", fileDetails)
-	assert.Equal(t, end, int64(1000))
+	// byte range 0-1000 should return the range size, end coord inclusive
+	endPos = 1000
+	_, end, err = calculateCoords(0, 0, "bytes=0-"+strconv.FormatInt(endPos, 10), fileDetails, "encrypted")
+	assert.Equal(t, end, endPos+1)
 	assert.NoError(t, err)
 
 	// range in the header should return error if values are not numbers
-	_, _, err = calculateEncryptedCoords(0, 0, "bytes=start-end", fileDetails)
+	_, _, err = calculateCoords(0, 0, "bytes=start-end", fileDetails, "encrypted")
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #696 and neicnordic/sda-download#372.
It includes the changes of #820, but is based on #826 instead of #703.


**Description**

- Remove the second header for re-encryption (server-public-key)
- Remove the user-agent check for the requester
- The content-length is now including the header size when htsget requests the encrypted file size
- The range header returns an extra character, according to specification
- Includes the PR #826 code, to make random access possible

**How to test**
- make sure full and partial files can be downloaded from the `s3` endpoint
- make sure  full and partial files can be downloaded from the `s3-encrypted` endpoint
- make sure it works with htsget (instructions: https://github.com/GenomicDataInfrastructure/starter-kit-htsget?tab=readme-ov-file#accessing-data-with-htsget)


Also see #701 and #776.