### PR TITLE
Update GO version to 1.22

### DIFF
--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.21']
+        go-version: ['1.22']
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.21']
+        go-version: ['1.22']
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5

--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         storagetype: [s3, posix, s3notls]
-        go-version: ['1.21']
+        go-version: ['1.22']
       fail-fast: false
     steps:
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21']
+        go-version: ['1.22']
     steps:
 
       - name: Set up Go ${{ matrix.go-version }}
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21']
+        go-version: ['1.22']
     steps:
 
       - name: Set up Go ${{ matrix.go-version }}

--- a/sda-download/Dockerfile
+++ b/sda-download/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 ENV GOPATH=$PWD
 ENV CGO_ENABLED=0

--- a/sda-download/go.mod
+++ b/sda-download/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sda-download
 
-go 1.21
+go 1.22
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/sda/Dockerfile
+++ b/sda/Dockerfile
@@ -1,4 +1,4 @@
-FROM "golang:${GOLANG_VERSION:-1.21}-bullseye" AS Build
+FROM "golang:${GOLANG_VERSION:-1.22}-bullseye" AS Build
 ENV GO111MODULE=on
 ENV GOPATH=$PWD
 ENV CGO_ENABLED=0

--- a/sda/go.mod
+++ b/sda/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sensitive-data-archive
 
-go 1.21
+go 1.22
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Updates the go version used, this was brought up due to a pending package update #841