### PR TITLE
Fix CodeQL failure

### DIFF
--- a/sda-download/go.mod
+++ b/sda-download/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sda-download
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/sda/go.mod
+++ b/sda/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sensitive-data-archive
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
> Invalid Go toolchain version
> 
> As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
> 
> 1.22 in sda/go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.
> 
> CodeQL also found 1 other warning like this. See the workflow log for details.
> 