### PR TITLE
Do some cleanup of obsolete TLS configuration since moving to go 1.22

### DIFF
--- a/sda-download/api/api.go
+++ b/sda-download/api/api.go
@@ -51,9 +51,7 @@ func Setup() *http.Server {
 
 	// Configure TLS settings
 	log.Info("(3/5) Configuring TLS")
-	cfg := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
+	cfg := &tls.Config{}
 
 	// Configure web server
 	log.Info("(4/5) Configuring server")

--- a/sda-download/api/api.go
+++ b/sda-download/api/api.go
@@ -51,7 +51,7 @@ func Setup() *http.Server {
 
 	// Configure TLS settings
 	log.Info("(3/5) Configuring TLS")
-	cfg := &tls.Config{}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	// Configure web server
 	log.Info("(4/5) Configuring server")

--- a/sda-download/api/api_test.go
+++ b/sda-download/api/api_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"crypto/tls"
 	"testing"
 
 	"github.com/neicnordic/sda-download/internal/config"
@@ -13,11 +12,6 @@ func TestSetup(t *testing.T) {
 	config.Config.App.Host = "localhost"
 	config.Config.App.Port = 8080
 	server := Setup()
-
-	// Verify that TLS is configured and set for minimum suggested version
-	if server.TLSConfig.MinVersion < tls.VersionTLS12 {
-		t.Errorf("server TLS version is too low, expected=%d, got=%d", tls.VersionTLS12, server.TLSConfig.MinVersion)
-	}
 
 	// Verify that server address is correctly read from config
 	expectedAddress := "localhost:8080"

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -43,6 +43,7 @@ func reencryptHeader(oldHeader []byte, reencKey string) ([]byte, error) {
 	case config.Config.Reencrypt.ClientKey != "" && config.Config.Reencrypt.ClientCert != "":
 		rootCAs, err := x509.SystemCertPool()
 		if err != nil {
+			log.Errorf("failed to read system CAs: %v, using an empty pool as base", err)
 			rootCAs = x509.NewCertPool()
 		}
 		if config.Config.Reencrypt.CACert != "" {

--- a/sda-download/internal/storage/storage.go
+++ b/sda-download/internal/storage/storage.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -289,13 +288,10 @@ func (sb *s3Backend) GetFileSize(filePath string) (int64, error) {
 func transportConfigS3(config S3Conf) http.RoundTripper {
 	cfg := new(tls.Config)
 
-	// Enforce TLS1.2 or higher
-	cfg.MinVersion = 2
-
 	// Read system CAs
-	var systemCAs, _ = x509.SystemCertPool()
-	if reflect.DeepEqual(systemCAs, x509.NewCertPool()) {
-		log.Debug("creating new CApool")
+	systemCAs, err := x509.SystemCertPool()
+	if err != nil {
+		log.Errorf("failed to read system CAs: %v, using an empty pool as base", err)
 		systemCAs = x509.NewCertPool()
 	}
 	cfg.RootCAs = systemCAs

--- a/sda-download/pkg/request/request.go
+++ b/sda-download/pkg/request/request.go
@@ -38,7 +38,8 @@ func InitialiseClient() (*http.Client, error) {
 	t.MaxConnsPerHost = 100
 	t.MaxIdleConnsPerHost = 100
 	t.TLSClientConfig = &tls.Config{
-		RootCAs: caCertPool,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    caCertPool,
 	}
 	client := &http.Client{
 		Timeout:   20 * time.Second,

--- a/sda-download/pkg/request/request.go
+++ b/sda-download/pkg/request/request.go
@@ -38,8 +38,7 @@ func InitialiseClient() (*http.Client, error) {
 	t.MaxConnsPerHost = 100
 	t.MaxIdleConnsPerHost = 100
 	t.TLSClientConfig = &tls.Config{
-		RootCAs:    caCertPool,
-		MinVersion: tls.VersionTLS12,
+		RootCAs: caCertPool,
 	}
 	client := &http.Client{
 		Timeout:   20 * time.Second,

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -71,7 +71,7 @@ func setup(config *config.Config) *http.Server {
 	r.GET("/ready", readinessResponse)
 	r.GET("/files", getFiles)
 
-	cfg := &tls.Config{}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	srv := &http.Server{
 		Addr:              config.API.Host + ":" + fmt.Sprint(config.API.Port),

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -71,14 +71,7 @@ func setup(config *config.Config) *http.Server {
 	r.GET("/ready", readinessResponse)
 	r.GET("/files", getFiles)
 
-	cfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		},
-	}
+	cfg := &tls.Config{}
 
 	srv := &http.Server{
 		Addr:              config.API.Host + ":" + fmt.Sprint(config.API.Port),

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -66,7 +66,7 @@ func (h *HealthCheck) RunHealthChecks() {
 }
 
 func (h *HealthCheck) httpsGetCheck(url string, timeout time.Duration) healthcheck.Check {
-	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	cfg := &tls.Config{}
 	cfg.RootCAs = h.tlsConfig.RootCAs
 	tr := &http.Transport{TLSClientConfig: cfg}
 	client := http.Client{

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -66,7 +66,9 @@ func (h *HealthCheck) RunHealthChecks() {
 }
 
 func (h *HealthCheck) httpsGetCheck(url string, timeout time.Duration) healthcheck.Check {
-	cfg := &tls.Config{}
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	cfg.RootCAs = h.tlsConfig.RootCAs
 	tr := &http.Transport{TLSClientConfig: cfg}
 	client := http.Client{

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -66,9 +66,7 @@ func (h *HealthCheck) RunHealthChecks() {
 }
 
 func (h *HealthCheck) httpsGetCheck(url string, timeout time.Duration) healthcheck.Check {
-	cfg := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 	cfg.RootCAs = h.tlsConfig.RootCAs
 	tr := &http.Transport{TLSClientConfig: cfg}
 	client := http.Client{

--- a/sda/cmd/syncapi/syncapi.go
+++ b/sda/cmd/syncapi/syncapi.go
@@ -79,7 +79,7 @@ func setup(config *config.Config) *http.Server {
 	r.HandleFunc("/dataset", basicAuth(http.HandlerFunc(dataset))).Methods("POST")
 	r.HandleFunc("/metadata", basicAuth(http.HandlerFunc(metadata))).Methods("POST")
 
-	cfg := &tls.Config{}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	srv := &http.Server{
 		Addr:              config.API.Host + ":" + fmt.Sprint(config.API.Port),

--- a/sda/cmd/syncapi/syncapi.go
+++ b/sda/cmd/syncapi/syncapi.go
@@ -79,14 +79,7 @@ func setup(config *config.Config) *http.Server {
 	r.HandleFunc("/dataset", basicAuth(http.HandlerFunc(dataset))).Methods("POST")
 	r.HandleFunc("/metadata", basicAuth(http.HandlerFunc(metadata))).Methods("POST")
 
-	cfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		},
-	}
+	cfg := &tls.Config{}
 
 	srv := &http.Server{
 		Addr:              config.API.Host + ":" + fmt.Sprint(config.API.Port),

--- a/sda/internal/broker/broker.go
+++ b/sda/internal/broker/broker.go
@@ -70,7 +70,8 @@ func TLSConfigBroker(config MQConf) (*tls.Config, error) {
 	}
 
 	tlsConfig := tls.Config{
-		RootCAs: systemCAs,
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    systemCAs,
 	}
 
 	// Add CAs for broker and database

--- a/sda/internal/broker/broker.go
+++ b/sda/internal/broker/broker.go
@@ -64,12 +64,13 @@ func TLSConfigBroker(config MQConf) (*tls.Config, error) {
 	// Read system CAs
 	systemCAs, err := x509.SystemCertPool()
 	if err != nil {
+		log.Errorf("failed to read system CAs: %v", err)
+
 		return nil, err
 	}
 
 	tlsConfig := tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    systemCAs,
+		RootCAs: systemCAs,
 	}
 
 	// Add CAs for broker and database

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -1087,15 +1086,15 @@ func TLSConfigBroker(c *Config) (*tls.Config, error) {
 
 	log.Debug("setting up TLS for broker connection")
 
-	// Enforce TLS1.2 or higher
-	cfg.MinVersion = 2
-
 	// Read system CAs
-	var systemCAs, _ = x509.SystemCertPool()
-	if reflect.DeepEqual(systemCAs, x509.NewCertPool()) {
-		log.Debug("creating new CApool")
-		systemCAs = x509.NewCertPool()
+	systemCAs, err := x509.SystemCertPool()
+
+	if err != nil {
+		log.Errorf("failed to read system CAs: %v", err)
+
+		return nil, err
 	}
+
 	cfg.RootCAs = systemCAs
 
 	if c.Broker.CACert != "" {
@@ -1136,15 +1135,14 @@ func TLSConfigProxy(c *Config) (*tls.Config, error) {
 
 	log.Debug("setting up TLS for S3 connection")
 
-	// Enforce TLS1.2 or higher
-	cfg.MinVersion = 2
-
 	// Read system CAs
-	var systemCAs, _ = x509.SystemCertPool()
-	if reflect.DeepEqual(systemCAs, x509.NewCertPool()) {
-		log.Debug("creating new CApool")
-		systemCAs = x509.NewCertPool()
+	systemCAs, err := x509.SystemCertPool()
+	if err != nil {
+		log.Errorf("failed to read system CAs: %v", err)
+
+		return nil, err
 	}
+
 	cfg.RootCAs = systemCAs
 
 	if c.Inbox.S3.CAcert != "" {

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -1088,7 +1088,6 @@ func TLSConfigBroker(c *Config) (*tls.Config, error) {
 
 	// Read system CAs
 	systemCAs, err := x509.SystemCertPool()
-
 	if err != nil {
 		log.Errorf("failed to read system CAs: %v", err)
 

--- a/sda/internal/storage/storage.go
+++ b/sda/internal/storage/storage.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -345,14 +344,14 @@ func (sb *s3Backend) RemoveFile(filePath string) error {
 // transportConfigS3 is a helper method to setup TLS for the S3 client.
 func transportConfigS3(conf S3Conf) http.RoundTripper {
 	cfg := new(tls.Config)
-	cfg.MinVersion = 3
 
 	// Read system CAs
-	var systemCAs, _ = x509.SystemCertPool()
-	if reflect.DeepEqual(systemCAs, x509.NewCertPool()) {
-		log.Debug("creating new CApool")
+	systemCAs, err := x509.SystemCertPool()
+	if err != nil {
+		log.Errorf("failed to read system CAs: %v, using an empty pool as base", err)
 		systemCAs = x509.NewCertPool()
 	}
+
 	cfg.RootCAs = systemCAs
 
 	if conf.CAcert != "" {


### PR DESCRIPTION
Go with recent version maintains good defaults, don't override those without good reasons (and if we to my surprise have such, we should document them better). Remove some odd things about CA pools.

1.22 will default to sensible minimum TLS 1.2 unless explicity told otherwise, but since the gosec linter complains if we remove the same configuration from` tls.Config`, they are left in here.