### PR TITLE
Fix/ssl config in tests

### DIFF
--- a/.github/integration/scripts/ssl.cnf
+++ b/.github/integration/scripts/ssl.cnf
@@ -59,7 +59,6 @@ commonName                      = SysDev root CA
 [ v3_ca ]
 # Extensions for a typical CA (`man x509v3_config`).
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = critical, CA:true
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 #nsCertType = sslCA
@@ -71,7 +70,6 @@ basicConstraints = CA:FALSE
 nsCertType = server,client
 nsComment = "LocalEGA Server+Client Certificate"
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = critical, clientAuth, serverAuth
 
@@ -79,7 +77,6 @@ extendedKeyUsage = critical, clientAuth, serverAuth
 # Extensions for client certificates (`man x509v3_config`).
 basicConstraints = critical,CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
 subjectAltName = DNS:localhost,DNS:intercept,IP:127.0.0.1
@@ -88,11 +85,9 @@ subjectAltName = DNS:localhost,DNS:intercept,IP:127.0.0.1
 # Extensions for server certificates (`man x509v3_config`).
 basicConstraints = critical,CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
 subjectAltName = DNS:localhost,DNS:cega-nss,DNS:cegamq,DNS:db,DNS:tlsdb,DNS:mq,DNS:rabbitmq,IP:127.0.0.1
 
 [ crl_ext ]
 # Extension for CRLs (`man x509v3_config`).
-authorityKeyIdentifier=keyid:always


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This should fix errors in  #877 #878 #879,

**Description**
This PR fixes an issue with ssl.conf that seems to appear after [a bug was fixed](https://github.com/openssl/openssl/issues/22966#issuecomment-1858396738) for openssl. The issue leads to an error in `certfixer` which makes integration tests fail.

The `authorityKeyIdentifier` resource is not needed to be specified here and removing it solves the issue.

**How to test**
