### PR TITLE
Add nginx-affinity label to ingress templates in the SDA-SVC chart.

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 0.26.4
+version: 0.26.5
 appVersion: v0.3.77
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/templates/auth-ingress.yaml
+++ b/charts/sda-svc/templates/auth-ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- if eq "nginx" .Values.global.ingress.ingressClassName }}
     nginx.ingress.kubernetes.io/rewrite-target: "/"
     nginx.ingress.kubernetes.io/backend-protocol: "{{ ternary "HTTPS" "HTTP" .Values.global.tls.enabled }}"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
     {{- end }}
     {{- if .Values.global.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.clusterIssuer | quote }}

--- a/charts/sda-svc/templates/doa-ingress.yaml
+++ b/charts/sda-svc/templates/doa-ingress.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- if eq "nginx" .Values.global.ingress.ingressClassName }}
     nginx.ingress.kubernetes.io/rewrite-target: "/"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
     {{- end }}
     {{- if .Values.global.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.clusterIssuer | quote }}

--- a/charts/sda-svc/templates/download-ingress.yaml
+++ b/charts/sda-svc/templates/download-ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- if eq "nginx" .Values.global.ingress.ingressClassName }}
     nginx.ingress.kubernetes.io/rewrite-target: "/"
     nginx.ingress.kubernetes.io/backend-protocol: "{{ ternary "HTTPS" "HTTP" .Values.global.tls.enabled }}"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
     {{- end }}
     {{- if .Values.global.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.clusterIssuer | quote }}

--- a/charts/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/charts/sda-svc/templates/s3-inbox-ingress.yaml
@@ -19,6 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: 2000m
     nginx.ingress.kubernetes.io/proxy-read-timeout: 300s
     nginx.ingress.kubernetes.io/proxy-request-buffering: "on"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
     {{- end }}
     {{- if .Values.global.ingress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.ingress.clusterIssuer | quote }}


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #431 


**Description**
This PR resolves an issue when the number of replicas for the Auth pod is greater than 1.
By using nginx specific labels a user can be directed to the same pod for each request.

The label is added to all ingress templates, so we don't get the same problem with DOA, Download or the Inbox.

* Chart version is updated.
