### PR TITLE
Restore lega_in and lega_out password setting

### DIFF
--- a/postgresql/entrypoint.sh
+++ b/postgresql/entrypoint.sh
@@ -98,26 +98,26 @@ setup_hba_conf() {
 
 setup_lega_users(){
 	if [ -z "$LEGA_IN_PASSWORD" ]; then
-      echo "Environment variable LEGA_IN_PASSWORD is empty"
-  elif [ -z "$LEGA_OUT_PASSWORD" ]; then
-      echo "Environment variable LEGA_OUT_PASSWORD is empty"
+		echo "Environment variable LEGA_IN_PASSWORD is empty. No password setting operation performed."
+	elif [ -z "$LEGA_OUT_PASSWORD" ]; then
+		echo "Environment variable LEGA_OUT_PASSWORD is empty. No password setting operation performed."
 	else
 		echo "Altering users passwords..."
 		export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
 		temp_server_start
 		sleep 2
-    psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname "${POSTGRES_DB:-sda}" <<-EOSQL
-      DO \$\$
-      BEGIN
-        IF (SELECT usename FROM pg_shadow WHERE usename = 'lega_in' AND passwd IS NULL) IS NOT NULL THEN
-          ALTER USER lega_in WITH PASSWORD '$LEGA_IN_PASSWORD';
-        END IF;
+		psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname "${POSTGRES_DB:-sda}" <<-EOSQL
+			DO \$\$
+			BEGIN
+				IF (SELECT usename FROM pg_shadow WHERE usename = 'lega_in' AND passwd IS NULL) IS NOT NULL THEN
+					ALTER USER lega_in WITH PASSWORD '$LEGA_IN_PASSWORD';
+				END IF;
 
-        IF (SELECT usename FROM pg_shadow WHERE usename = 'lega_out' AND passwd IS NULL) IS NOT NULL THEN
-          ALTER USER lega_out WITH PASSWORD '$LEGA_OUT_PASSWORD';
-        END IF;
-      END
-      \$\$;
+				IF (SELECT usename FROM pg_shadow WHERE usename = 'lega_out' AND passwd IS NULL) IS NOT NULL THEN
+					ALTER USER lega_out WITH PASSWORD '$LEGA_OUT_PASSWORD';
+				END IF;
+			END
+			\$\$;
 EOSQL
 		pg_ctl -D "$PGDATA" -w stop
 		unset PGPASSWORD
@@ -127,7 +127,7 @@ EOSQL
 if [ -s "$PGDATA/PG_VERSION" ]; then
 	migrate "$@"
 
-  setup_lega_users
+	setup_lega_users
 
 	setup_hba_conf
 
@@ -159,9 +159,9 @@ for f in docker-entrypoint-initdb.d/*; do
 done
 
 if [ -z "$LEGA_IN_PASSWORD" ]; then
-    echo "Environment variable LEGA_IN_PASSWORD is empty"
+	echo "Environment variable LEGA_IN_PASSWORD is empty. No password setting operation performed."
 elif [ -z "$LEGA_OUT_PASSWORD" ]; then
-    echo "Environment variable LEGA_OUT_PASSWORD is empty"
+	echo "Environment variable LEGA_OUT_PASSWORD is empty. No password setting operation performed."
 else
 	echo "Altering users passwords..."
 	psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname "${POSTGRES_DB:-sda}" <<-EOSQL

--- a/postgresql/entrypoint.sh
+++ b/postgresql/entrypoint.sh
@@ -118,7 +118,7 @@ setup_lega_users(){
 				END IF;
 			END
 			\$\$;
-EOSQL
+		EOSQL
 		pg_ctl -D "$PGDATA" -w stop
 		unset PGPASSWORD
 	fi
@@ -167,7 +167,7 @@ else
 	psql -v ON_ERROR_STOP=1 --username postgres --no-password --dbname "${POSTGRES_DB:-sda}" <<-EOSQL
 		ALTER USER lega_in WITH PASSWORD '$LEGA_IN_PASSWORD';
 		ALTER USER lega_out WITH PASSWORD '$LEGA_OUT_PASSWORD';
-EOSQL
+	EOSQL
 fi
 
 pg_ctl -D "$PGDATA" -m fast -w stop


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #865 .


**Description**
We need to reintroduce the lines that set passwords when the db is initializing, and check if the passwords have not been set then set them if they are present when the db already exists. 
