### PR TITLE
Update metadata from sda-download API

### DIFF
--- a/sda-download/api/s3/s3.go
+++ b/sda-download/api/s3/s3.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/neicnordic/sda-download/api/middleware"
@@ -39,7 +38,6 @@ type Object struct {
 	ChecksumAlgorithm []string `xml:"ChecksumAlgorithm,omitempty"`
 	ETag              string   `xml:"ETag,omitempty"`
 	Key               string   `xml:"Key"`
-	LastModified      string   `xml:"LastModified,omitempty"`
 	Owner             Owner    `xml:"Owner,omitempty"`
 	Size              int      `xml:"Size,omitempty"`
 	StorageClass      string   `xml:"StorageClass,omitempty"`
@@ -160,7 +158,6 @@ func ListObjects(c *gin.Context) {
 		if !strings.HasPrefix(key, c.Param("prefix")) {
 			continue
 		}
-		lastModified, err := time.Parse(time.RFC3339, file.LastModified)
 		if err != nil {
 			log.Errorf("failed to parse last modified time: %v", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
@@ -168,9 +165,8 @@ func ListObjects(c *gin.Context) {
 			return
 		}
 		objects = append(objects, Object{
-			Key:          key,
-			Size:         int(file.DecryptedFileSize),
-			LastModified: lastModified.Format(http.TimeFormat),
+			Key:  key,
+			Size: int(file.DecryptedFileSize),
 		})
 	}
 

--- a/sda-download/api/s3/s3_test.go
+++ b/sda-download/api/s3/s3_test.go
@@ -124,31 +124,33 @@ func (suite *S3TestSuite) TestListByPrefix() {
 		DatasetID:                 "dataset1",
 		DisplayFileName:           "file.txt",
 		FilePath:                  "dir/file.txt",
-		FileName:                  "urn:file1",
-		FileSize:                  60,
+		EncryptedFileSize:         60,
+		EncryptedFileChecksum:     "hash",
+		EncryptedFileChecksumType: "sha256",
 		DecryptedFileSize:         32,
 		DecryptedFileChecksum:     "hash",
 		DecryptedFileChecksumType: "sha256",
-		Status:                    "ready",
-		CreatedAt:                 "a while ago",
-		LastModified:              "2023-04-17T14:40:12.567Z",
 	}
+
+	userId := "user1"
+
 	query := `
 		SELECT files.stable_id AS id,
 			datasets.stable_id AS dataset_id,
 			reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
+			files.submission_user AS user_id,
 			files.submission_file_path AS file_path,
 			files.archive_file_path AS file_name,
 			files.archive_file_size AS file_size,
+			lef.archive_file_checksum AS encrypted_file_checksum,
+			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
 			files.decrypted_file_size,
 			sha.checksum AS decrypted_file_checksum,
-			sha.type AS decrypted_file_checksum_type,
-			log.event AS status,
-			files.created_at,
-			files.last_modified
+			sha.type AS decrypted_file_checksum_type
 		FROM sda.files
 		JOIN sda.file_dataset ON file_id = files.id
 		JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
+		LEFT JOIN local_ega.files lef ON files.stable_id = lef.stable_id
 		LEFT JOIN \(SELECT file_id, \(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event FROM sda.file_event_log GROUP BY file_id\) log ON files.id = log.file_id
 		LEFT JOIN \(SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED'\) sha ON files.id = sha.file_id
 		WHERE datasets.stable_id = \$1;
@@ -156,14 +158,13 @@ func (suite *S3TestSuite) TestListByPrefix() {
 	suite.Mock.ExpectQuery(query).
 		WithArgs("dataset1").
 		WillReturnRows(sqlmock.NewRows([]string{"file_id", "dataset_id",
-			"display_file_name", "file_path", "file_name", "file_size",
+			"display_file_name", "user_id", "file_path", "file_name", "file_size",
 			"decrypted_file_size", "decrypted_file_checksum",
 			"decrypted_file_checksum_type", "file_status", "created_at",
 			"last_modified"}).AddRow(fileInfo.FileID, fileInfo.DatasetID,
-			fileInfo.DisplayFileName, fileInfo.FilePath, fileInfo.FileName,
-			fileInfo.FileSize, fileInfo.DecryptedFileSize,
-			fileInfo.DecryptedFileChecksum, fileInfo.DecryptedFileChecksumType,
-			fileInfo.Status, fileInfo.CreatedAt, fileInfo.LastModified))
+			fileInfo.DisplayFileName, userId, fileInfo.FilePath,
+			fileInfo.EncryptedFileSize, fileInfo.EncryptedFileChecksum, fileInfo.EncryptedFileChecksumType, fileInfo.DecryptedFileSize,
+			fileInfo.DecryptedFileChecksum, fileInfo.DecryptedFileChecksumType))
 
 	// Send a request through the middleware to get files for the dataset and
 	// prefix
@@ -203,31 +204,32 @@ func (suite *S3TestSuite) TestListObjects() {
 		DatasetID:                 "dataset1",
 		DisplayFileName:           "file.txt",
 		FilePath:                  "dir/file.txt",
-		FileName:                  "urn:file1",
-		FileSize:                  60,
+		EncryptedFileSize:         60,
+		EncryptedFileChecksum:     "hash",
+		EncryptedFileChecksumType: "sha256",
 		DecryptedFileSize:         32,
 		DecryptedFileChecksum:     "hash",
 		DecryptedFileChecksumType: "sha256",
-		Status:                    "ready",
-		CreatedAt:                 "a while ago",
-		LastModified:              "2023-04-17T14:40:12.567Z",
 	}
+
+	userId := "user1"
+
 	query := `
 		SELECT files.stable_id AS id,
 			datasets.stable_id AS dataset_id,
 			reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
+			files.submission_user AS user_id,
 			files.submission_file_path AS file_path,
-			files.archive_file_path AS file_name,
 			files.archive_file_size AS file_size,
+			lef.archive_file_checksum AS encrypted_file_checksum,
+			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
 			files.decrypted_file_size,
 			sha.checksum AS decrypted_file_checksum,
-			sha.type AS decrypted_file_checksum_type,
-			log.event AS status,
-			files.created_at,
-			files.last_modified
+			sha.type AS decrypted_file_checksum_type
 		FROM sda.files
 		JOIN sda.file_dataset ON file_id = files.id
 		JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
+		LEFT JOIN local_ega.files lef ON files.stable_id = lef.stable_id
 		LEFT JOIN \(SELECT file_id, \(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event FROM sda.file_event_log GROUP BY file_id\) log ON files.id = log.file_id
 		LEFT JOIN \(SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED'\) sha ON files.id = sha.file_id
 		WHERE datasets.stable_id = \$1;
@@ -235,14 +237,13 @@ func (suite *S3TestSuite) TestListObjects() {
 	suite.Mock.ExpectQuery(query).
 		WithArgs("dataset1").
 		WillReturnRows(sqlmock.NewRows([]string{"file_id", "dataset_id",
-			"display_file_name", "file_path", "file_name", "file_size",
+			"display_file_name", "user_id", "file_path", "file_size",
+			"encrypted_file_checksum", "encrypted_file_checksum_type",
 			"decrypted_file_size", "decrypted_file_checksum",
-			"decrypted_file_checksum_type", "file_status", "created_at",
-			"last_modified"}).AddRow(fileInfo.FileID, fileInfo.DatasetID,
-			fileInfo.DisplayFileName, fileInfo.FilePath, fileInfo.FileName,
-			fileInfo.FileSize, fileInfo.DecryptedFileSize,
-			fileInfo.DecryptedFileChecksum, fileInfo.DecryptedFileChecksumType,
-			fileInfo.Status, fileInfo.CreatedAt, fileInfo.LastModified))
+			"decrypted_file_checksum_type"}).AddRow(fileInfo.FileID, fileInfo.DatasetID,
+			fileInfo.DisplayFileName, userId, fileInfo.FilePath,
+			fileInfo.EncryptedFileSize, fileInfo.EncryptedFileChecksum, fileInfo.EncryptedFileChecksumType, fileInfo.DecryptedFileSize,
+			fileInfo.DecryptedFileChecksum, fileInfo.DecryptedFileChecksumType))
 
 	// Send a request through the middleware to get datasets
 
@@ -260,7 +261,6 @@ func (suite *S3TestSuite) TestListObjects() {
 	expected := xml.Header +
 		"<ListBucketResult><CommonPrefixes></CommonPrefixes><Contents>" +
 		"<Key>file.txt</Key>" +
-		"<LastModified>Mon, 17 Apr 2023 14:40:12 GMT</LastModified>" +
 		"<Owner></Owner>" +
 		"<Size>32</Size>" +
 		"</Contents>" +

--- a/sda-download/api/s3/s3_test.go
+++ b/sda-download/api/s3/s3_test.go
@@ -140,7 +140,6 @@ func (suite *S3TestSuite) TestListByPrefix() {
 			reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
 			files.submission_user AS user_id,
 			files.submission_file_path AS file_path,
-			files.archive_file_path AS file_name,
 			files.archive_file_size AS file_size,
 			lef.archive_file_checksum AS encrypted_file_checksum,
 			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
@@ -158,10 +157,10 @@ func (suite *S3TestSuite) TestListByPrefix() {
 	suite.Mock.ExpectQuery(query).
 		WithArgs("dataset1").
 		WillReturnRows(sqlmock.NewRows([]string{"file_id", "dataset_id",
-			"display_file_name", "user_id", "file_path", "file_name", "file_size",
+			"display_file_name", "user_id", "file_path", "file_size",
+			"decrypted_file_checksum", "decrypted_file_checksum_type",
 			"decrypted_file_size", "decrypted_file_checksum",
-			"decrypted_file_checksum_type", "file_status", "created_at",
-			"last_modified"}).AddRow(fileInfo.FileID, fileInfo.DatasetID,
+			"decrypted_file_checksum_type"}).AddRow(fileInfo.FileID, fileInfo.DatasetID,
 			fileInfo.DisplayFileName, userId, fileInfo.FilePath,
 			fileInfo.EncryptedFileSize, fileInfo.EncryptedFileChecksum, fileInfo.EncryptedFileChecksumType, fileInfo.DecryptedFileSize,
 			fileInfo.DecryptedFileChecksum, fileInfo.DecryptedFileChecksumType))
@@ -183,7 +182,6 @@ func (suite *S3TestSuite) TestListByPrefix() {
 	expected := xml.Header +
 		"<ListBucketResult><CommonPrefixes></CommonPrefixes><Contents>" +
 		"<Key>file.txt</Key>" +
-		"<LastModified>Mon, 17 Apr 2023 14:40:12 GMT</LastModified>" +
 		"<Owner></Owner>" +
 		"<Size>32</Size>" +
 		"</Contents>" +

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -283,14 +283,12 @@ func TestFiles_Success(t *testing.T) {
 			DatasetID:                 "dataset1",
 			DisplayFileName:           "file1.txt",
 			FilePath:                  "dir/file1.txt",
-			FileName:                  "file1.txt",
-			FileSize:                  200,
+			EncryptedFileSize:         200,
+			EncryptedFileChecksum:     "hash",
+			EncryptedFileChecksumType: "sha256",
 			DecryptedFileSize:         100,
 			DecryptedFileChecksum:     "hash",
 			DecryptedFileChecksumType: "sha256",
-			Status:                    "READY",
-			CreatedAt:                 "a while ago",
-			LastModified:              "now",
 		}
 		files := []*database.FileInfo{}
 		files = append(files, &fileInfo)
@@ -316,9 +314,10 @@ func TestFiles_Success(t *testing.T) {
 	expectedStatusCode := 200
 	expectedBody := []byte(
 		`[{"fileId":"file1","datasetId":"dataset1","displayFileName":"file1.txt","filePath":` +
-			`"dir/file1.txt","fileName":"file1.txt","fileSize":200,"decryptedFileSize":100,` +
-			`"decryptedFileChecksum":"hash","decryptedFileChecksumType":"sha256",` +
-			`"fileStatus":"READY","createdAt":"a while ago","lastModified":"now"}]`)
+			`"dir/file1.txt","encryptedFileSize":200,` +
+			`"encryptedFileChecksum":"hash","encryptedFileChecksumType":"sha256",` +
+			`"decryptedFileSize":100,` +
+			`"decryptedFileChecksum":"hash","decryptedFileChecksumType":"sha256"}]`)
 
 	if response.StatusCode != expectedStatusCode {
 		t.Errorf("TestDatasets failed, got %d expected %d", response.StatusCode, expectedStatusCode)

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -37,7 +37,6 @@ type FileInfo struct {
 	DecryptedFileSize         int64  `json:"decryptedFileSize"`
 	DecryptedFileChecksum     string `json:"decryptedFileChecksum"`
 	DecryptedFileChecksumType string `json:"decryptedFileChecksumType"`
-	LastModified              string `json:"lastModified"`
 }
 
 type DatasetInfo struct {
@@ -190,8 +189,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
 			files.decrypted_file_size,
 			sha.checksum AS decrypted_file_checksum,
-			sha.type AS decrypted_file_checksum_type,
-			files.last_modified
+			sha.type AS decrypted_file_checksum_type
 		FROM sda.files
 		JOIN sda.file_dataset ON file_id = files.id
 		JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
@@ -220,8 +218,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		err := rows.Scan(&fi.FileID, &fi.DatasetID, &fi.DisplayFileName,
 			&userId, &fi.FilePath, &fi.FileName,
 			&fi.EncryptedFileSize, &fi.EncryptedFileChecksum, &fi.EncryptedFileChecksumType,
-			&fi.DecryptedFileSize, &fi.DecryptedFileChecksum, &fi.DecryptedFileChecksumType,
-			&fi.LastModified)
+			&fi.DecryptedFileSize, &fi.DecryptedFileChecksum, &fi.DecryptedFileChecksumType)
 		if err != nil {
 			log.Error(err)
 
@@ -369,8 +366,7 @@ func (dbs *SQLdb) getDatasetFileInfo(datasetID, filePath string) (*FileInfo, err
 			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
 			f.decrypted_file_size,
 			dc.checksum AS decrypted_file_checksum,
-			dc.type AS decrypted_file_checksum_type,
-			f.last_modified
+			dc.type AS decrypted_file_checksum_type
 		FROM sda.files f
 		JOIN sda.file_dataset fd ON fd.file_id = f.id
 		JOIN sda.datasets d ON fd.dataset_id = d.id
@@ -394,8 +390,7 @@ func (dbs *SQLdb) getDatasetFileInfo(datasetID, filePath string) (*FileInfo, err
 	err := db.QueryRow(query, datasetID, filePath).Scan(&file.FileID,
 		&file.DatasetID, &file.DisplayFileName, &userId, &file.FilePath, &file.FileName,
 		&file.EncryptedFileSize, &file.EncryptedFileChecksum, &file.EncryptedFileChecksumType,
-		&file.DecryptedFileSize, &file.DecryptedFileChecksum, &file.DecryptedFileChecksumType,
-		&file.LastModified)
+		&file.DecryptedFileSize, &file.DecryptedFileChecksum, &file.DecryptedFileChecksumType)
 
 	if err != nil {
 		log.Error(err)

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -30,7 +30,6 @@ type FileInfo struct {
 	DatasetID                 string `json:"datasetId"`
 	DisplayFileName           string `json:"displayFileName"`
 	FilePath                  string `json:"filePath"`
-	FileName                  string `json:"fileName"`
 	EncryptedFileSize         int64  `json:"encryptedFileSize"`
 	EncryptedFileChecksum     string `json:"encryptedFileChecksum"`
 	EncryptedFileChecksumType string `json:"encryptedFileChecksumType"`
@@ -183,7 +182,6 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 			reverse(split_part(reverse(files.submission_file_path::text), '/'::text, 1)) AS display_file_name,
 			files.submission_user AS user_id,
 			files.submission_file_path AS file_path,
-			files.archive_file_path AS file_name,
 			files.archive_file_size AS file_size,
 			lef.archive_file_checksum AS encrypted_file_checksum,
 			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
@@ -216,7 +214,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		// Read rows into struct
 		fi := &FileInfo{}
 		err := rows.Scan(&fi.FileID, &fi.DatasetID, &fi.DisplayFileName,
-			&userId, &fi.FilePath, &fi.FileName,
+			&userId, &fi.FilePath,
 			&fi.EncryptedFileSize, &fi.EncryptedFileChecksum, &fi.EncryptedFileChecksumType,
 			&fi.DecryptedFileSize, &fi.DecryptedFileChecksum, &fi.DecryptedFileChecksumType)
 		if err != nil {
@@ -360,7 +358,6 @@ func (dbs *SQLdb) getDatasetFileInfo(datasetID, filePath string) (*FileInfo, err
 			reverse(split_part(reverse(f.submission_file_path::text), '/'::text, 1)) AS display_file_name,
 			f.submission_user AS user_id,
 			f.submission_file_path AS file_path,
-			f.archive_file_path AS file_name,
 			f.archive_file_size AS file_size,
 			lef.archive_file_checksum AS encrypted_file_checksum,
 			lef.archive_file_checksum_type AS encrypted_file_checksum_type,
@@ -388,7 +385,7 @@ func (dbs *SQLdb) getDatasetFileInfo(datasetID, filePath string) (*FileInfo, err
 	var userId string
 	// nolint:rowserrcheck
 	err := db.QueryRow(query, datasetID, filePath).Scan(&file.FileID,
-		&file.DatasetID, &file.DisplayFileName, &userId, &file.FilePath, &file.FileName,
+		&file.DatasetID, &file.DisplayFileName, &userId, &file.FilePath,
 		&file.EncryptedFileSize, &file.EncryptedFileChecksum, &file.EncryptedFileChecksumType,
 		&file.DecryptedFileSize, &file.DecryptedFileChecksum, &file.DecryptedFileChecksumType)
 

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -30,7 +30,7 @@ type FileInfo struct {
 	DisplayFileName           string `json:"displayFileName"`
 	FilePath                  string `json:"filePath"`
 	FileName                  string `json:"fileName"`
-	FileSize                  int64  `json:"fileSize"`
+	EncryptedFileSize         int64  `json:"encryptedFileSize"`
 	DecryptedFileSize         int64  `json:"decryptedFileSize"`
 	DecryptedFileChecksum     string `json:"decryptedFileChecksum"`
 	DecryptedFileChecksumType string `json:"decryptedFileChecksumType"`
@@ -199,7 +199,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		// Read rows into struct
 		fi := &FileInfo{}
 		err := rows.Scan(&fi.FileID, &fi.DatasetID, &fi.DisplayFileName, &fi.FilePath, &fi.FileName,
-			&fi.FileSize, &fi.DecryptedFileSize, &fi.DecryptedFileChecksum,
+			&fi.EncryptedFileSize, &fi.DecryptedFileSize, &fi.DecryptedFileChecksum,
 			&fi.DecryptedFileChecksumType, &fi.LastModified)
 		if err != nil {
 			log.Error(err)
@@ -213,7 +213,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		// so the user needs to know the size of the header when downloading in encrypted format.
 		// A way to get this could be:
 		// fd := GetFile()
-		// fi.FileSize = fi.FileSize + len(fd.Header)
+		// fi.EncryptedFileSize = fi.EncryptedFileSize + len(fd.Header)
 		// But if the header is re-encrypted or a completely new header is generated, the length
 		// needs to be conveyd to the user in some other way.
 
@@ -365,7 +365,7 @@ func (dbs *SQLdb) getDatasetFileInfo(datasetID, filePath string) (*FileInfo, err
 	// nolint:rowserrcheck
 	err := db.QueryRow(query, datasetID, filePath).Scan(&file.FileID,
 		&file.DatasetID, &file.DisplayFileName, &file.FilePath, &file.FileName,
-		&file.FileSize, &file.DecryptedFileSize, &file.DecryptedFileChecksum,
+		&file.EncryptedFileSize, &file.DecryptedFileSize, &file.DecryptedFileChecksum,
 		&file.DecryptedFileChecksumType,
 		&file.LastModified)
 	if err != nil {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #875 


**Description**
This PR updates the metadata returned form the download API so that we don't leak any unnecessary info. Apart from that, checksum info for the encrypted files are also included. 


**How to test**
1. Build the image by running the following command in the sub-folder `sda-download`
```bash
docker build . -t harbor.nbis.se/gdi/sda-download:20240415
```

2. Start the docker setup from the repo `starter-kit-storage-and-interfaces` (main branch) by 
```bash
docker compose -f docker-compose-demo.yml up -d
```
note that you need to comment out [this line](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces/blob/main/docker-compose.yml#L139) for the download service so that the docker setup can be started properly

3. Get the token and check if the metadata returned from the API meet the A/C
```bash
token=$(curl -s -k https://localhost:8080/tokens | jq -r '.[0]')
curl  -H "Authorization: Bearer $token" http://localhost:8443/metadata/datasets/DATASET0001/files | jq 
```



