### PR TITLE
[Auth] server public key as a base64 encoded string

### DIFF
--- a/sda/cmd/auth/info.go
+++ b/sda/cmd/auth/info.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"encoding/base64"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/kataras/iris/v12"
-	"github.com/neicnordic/crypt4gh/keys"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,19 +18,20 @@ type Info struct {
 }
 
 // Reads the public key file and returns the public key
-func readPublicKeyFile(filename string) (key *[32]byte, err error) {
+func readPublicKeyFile(filename string) (string, error) {
 	log.Info("Reading Public key file")
 	file, err := os.Open(filepath.Clean(filename))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer file.Close()
-	publicKey, err := keys.ReadPublicKey(file)
+
+	data, err := io.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return &publicKey, err
+	return base64.StdEncoding.EncodeToString(data), err
 }
 
 // getInfo returns information needed by the client to authenticate

--- a/sda/cmd/auth/info_test.go
+++ b/sda/cmd/auth/info_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/neicnordic/crypt4gh/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type InfoTests struct {
+	pubKeyb64 string
+	suite.Suite
+	TempDir string
+}
+
+func TestInfoTestSuite(t *testing.T) {
+	suite.Run(t, new(InfoTests))
+}
+
+func (suite *InfoTests) SetupTest() {
+	suite.TempDir, _ = os.MkdirTemp("", "key")
+
+	pub, _, err := keys.GenerateKeyPair()
+	if err != nil {
+		suite.FailNowf("Filed to generate crypt4gh keypair", err.Error())
+	}
+
+	buf := new(bytes.Buffer)
+	if err := keys.WriteCrypt4GHX25519PublicKey(buf, pub); err != nil {
+		suite.T().FailNow()
+	}
+	suite.pubKeyb64 = base64.StdEncoding.EncodeToString(buf.Bytes())
+
+	pubKeyFile, err := os.Create(suite.TempDir + "/pub.key")
+	if err != nil {
+		suite.T().FailNow()
+	}
+
+	_, err = pubKeyFile.Write(buf.Bytes())
+	if err != nil {
+		suite.T().FailNow()
+	}
+
+}
+
+func (suite *InfoTests) TestReadPublicKeyFile() {
+	pubKey, err := readPublicKeyFile(suite.TempDir + "/pub.key")
+	assert.NoError(suite.T(), err, "Reading public key from disk failed")
+	assert.Equal(suite.T(), suite.pubKeyb64, pubKey)
+}
+
+func (suite *InfoTests) TearDownTest() {
+	os.RemoveAll(suite.TempDir)
+}

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -415,11 +414,10 @@ func main() {
 	app.Get("/oidc/login", authHandler.getOIDCLogin)
 	app.Get("/oidc/cors_login", authHandler.getOIDCCORSLogin)
 
-	publicKey, err := readPublicKeyFile(authHandler.Config.PublicFile)
+	authHandler.pubKey, err = readPublicKeyFile(authHandler.Config.PublicFile)
 	if err != nil {
-		log.Fatalf("Failed to get public key: %s", err.Error())
+		log.Fatalf("Failed to read public key: %s", err.Error())
 	}
-	authHandler.pubKey = hex.EncodeToString(publicKey[:])
 
 	// Endpoint for client login info
 	app.Get("/info", authHandler.getInfo)


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #886.


**Description**
Serve the public key from the info endpoint as a base64 encoded string instead of a hex string.

**How to test**
```cmd
curl -sL HOSTNAME/info | jq -r '.public_key | @base64d' > pubkey.pem
```

The file should look like this:
```
-----BEGIN CRYPT4GH PUBLIC KEY-----
ji8ko8dTv4r+TR7h58TKzcqMfBkXf68mLDL9MZ/FBlk=
-----END CRYPT4GH PUBLIC KEY-----
```