### PR TITLE
[actions] update container pruning action

### DIFF
--- a/.github/workflows/ghcr-actions.yml
+++ b/.github/workflows/ghcr-actions.yml
@@ -8,6 +8,7 @@ name: ghcr.io
 on:
   schedule:
     - cron: "21 21 * * *"
+  workflow_dispatch:
 
 jobs:
   clean-ghcr:
@@ -19,11 +20,10 @@ jobs:
       - name: Delete 'PR' containers older than one month
         uses: snok/container-retention-policy@v3.0.0
         with:
+          account: ${{ github.repository_owner }}
           image-names: sensitive-data-archive
-          skip-tags: v*
+          image-tags: "!v*"
           cut-off: One month ago UTC
-          account-type: org
-          org-name: ${{ github.repository_owner }}
-          keep-at-least: 1
+          keep-n-most-recent: 1
           token: ${{ secrets.GHCR_TOKEN }}
           timestamp-to-use: updated_at


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
Related to #903


**Description**
The config syntax changed with v3 of the action, this PR fixes that.

As for the TOKEN, a standard GITHUB_TOKEN can't be given admin access which is needed to delete packages.


**How to test**
