### PR TITLE
[download] ignore trailing slashes in ISS and JKU URLs

### DIFF
--- a/sda-download/pkg/auth/auth.go
+++ b/sda-download/pkg/auth/auth.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -345,7 +347,7 @@ func validateTrustedIss(obj []config.TrustedISS, issuerValue string, jkuValue st
 	log.Debugf("check combination of iss: %s and jku: %s", issuerValue, jkuValue)
 	if obj != nil {
 		for _, value := range obj {
-			if value.ISS == issuerValue && value.JKU == jkuValue {
+			if cleanURL(value.ISS) == cleanURL(issuerValue) && cleanURL(value.JKU) == cleanURL(jkuValue) {
 				return true
 			}
 		}
@@ -354,4 +356,11 @@ func validateTrustedIss(obj []config.TrustedISS, issuerValue string, jkuValue st
 	}
 
 	return true
+}
+
+func cleanURL(clean string) string {
+	u, _ := url.Parse(clean)
+	u.Path = path.Clean(u.RequestURI())
+
+	return u.String()
 }

--- a/sda-download/pkg/auth/auth_test.go
+++ b/sda-download/pkg/auth/auth_test.go
@@ -351,11 +351,15 @@ func TestValidateTrustedIss(t *testing.T) {
 	trustedList := []config.TrustedISS([]config.TrustedISS{{ISS: "https://demo.example", JKU: "https://mockauth:8000/idp/profile/oidc/keyset"}, {ISS: "https://demo1.example", JKU: "https://mockauth:8000/idp/profile/oidc/keyset"}})
 
 	ok := validateTrustedIss(trustedList, "https://demo.example", "https://mockauth:8000/idp/profile/oidc/keyset")
-
 	assert.True(t, ok, "values might have changed in fixture")
 
-	ok = validateTrustedIss(trustedList, "https://demo3.example", "https://mockauth:8000/idp/profile/oidc/keyset")
+	ok = validateTrustedIss(trustedList, "https://demo.example/", "https://mockauth:8000/idp/profile/oidc/keyset")
+	assert.True(t, ok, "trailing slash in ISS should be allowed")
 
+	ok = validateTrustedIss(trustedList, "https://demo.example", "https://mockauth:8000/idp/profile/oidc/keyset/")
+	assert.True(t, ok, "trailing slash in JKU should be allowed")
+
+	ok = validateTrustedIss(trustedList, "https://demo3.example", "https://mockauth:8000/idp/profile/oidc/keyset")
 	assert.False(t, ok, "values might have changed in fixture")
 }
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #915 .


**Description**
This PR adds a small function that cleans URLs before comparison so that `http://example.com/` and `http://example.com` is identical. The current string matching will evaluate these as false.

**How to test**
