### PR TITLE
First stab at creating admin endpoints in the API

### DIFF
--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -282,13 +282,7 @@ func setAccession(c *gin.Context) {
 
 	accession.DecryptedChecksums = []schema.Checksums{{Type: "sha256", Value: fileInfo.DecryptedChecksum}}
 	accession.Type = "accession"
-	marshaledMsg, err := json.Marshal(&accession)
-	if err != nil {
-		log.Debugln(err.Error())
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
-
-		return
-	}
+	marshaledMsg, _ := json.Marshal(&accession)
 	if err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-accession.json", Conf.Broker.SchemasPath), marshaledMsg); err != nil {
 		log.Debugln(err.Error())
 		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
@@ -322,13 +316,7 @@ func createDataset(c *gin.Context) {
 	}
 
 	dataset.Type = "mapping"
-	marshaledMsg, err := json.Marshal(&dataset)
-	if err != nil {
-		log.Debugln(err.Error())
-		c.AbortWithStatusJSON(http.StatusConflict, err.Error())
-
-		return
-	}
+	marshaledMsg, _ := json.Marshal(&dataset)
 	if err := schema.ValidateJSON(fmt.Sprintf("%s/dataset-mapping.json", Conf.Broker.SchemasPath), marshaledMsg); err != nil {
 		log.Debugln(err.Error())
 		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
@@ -352,13 +340,7 @@ func releaseDataset(c *gin.Context) {
 		Type:      "release",
 		DatasetID: strings.TrimPrefix(c.Param("dataset"), "/"),
 	}
-	marshaledMsg, err := json.Marshal(&datasetMsg)
-	if err != nil {
-		log.Debugln(err.Error())
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
-
-		return
-	}
+	marshaledMsg, _ := json.Marshal(&datasetMsg)
 	if err := schema.ValidateJSON(fmt.Sprintf("%s/dataset-release.json", Conf.Broker.SchemasPath), marshaledMsg); err != nil {
 		log.Debugln(err.Error())
 		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
+	"github.com/neicnordic/sensitive-data-archive/internal/schema"
 	"github.com/neicnordic/sensitive-data-archive/internal/userauth"
 	log "github.com/sirupsen/logrus"
 )
@@ -71,6 +73,8 @@ func setup(config *config.Config) *http.Server {
 	r := gin.Default()
 	r.GET("/ready", readinessResponse)
 	r.GET("/files", getFiles)
+	// admin endpoints below here
+	r.POST("/file/ingest", isAdmin(), ingestFile) // start ingestion of a file
 
 	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 
@@ -192,4 +196,43 @@ func isAdmin() gin.HandlerFunc {
 			return
 		}
 	}
+}
+
+func ingestFile(c *gin.Context) {
+	var ingest schema.IngestionTrigger
+	if err := c.BindJSON(&ingest); err != nil {
+		c.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			gin.H{
+				"error":  "json decoding : " + err.Error(),
+				"status": http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	ingest.Type = "ingest"
+	marshaledMsg, _ := json.Marshal(&ingest)
+	if err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-trigger.json", Conf.Broker.SchemasPath), marshaledMsg); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	corrID, err := Conf.API.DB.GetCorrID(ingest.User, ingest.FilePath)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	err = Conf.API.MQ.SendMessage(corrID, Conf.Broker.Exchange, "ingest", marshaledMsg)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.Status(http.StatusOK)
 }

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
@@ -173,4 +174,22 @@ func getFiles(c *gin.Context) {
 
 	// Return response
 	c.JSON(200, files)
+}
+
+func isAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token, err := auth.Authenticate(c.Request)
+		if err != nil {
+			log.Debugln("bad token")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+
+			return
+		}
+		if !slices.Contains(Conf.API.Admins, token.Subject()) {
+			log.Debugf("%s is not an admin", token.Subject())
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "not authorized"})
+
+			return
+		}
+	}
 }

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -226,7 +226,12 @@ func ingestFile(c *gin.Context) {
 
 	corrID, err := Conf.API.DB.GetCorrID(ingest.User, ingest.FilePath)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		switch {
+		case corrID == "":
+			c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		default:
+			c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		}
 
 		return
 	}
@@ -257,8 +262,12 @@ func setAccession(c *gin.Context) {
 
 	corrID, err := Conf.API.DB.GetCorrID(accession.User, accession.FilePath)
 	if err != nil {
-		log.Debugln(err.Error())
-		c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		switch {
+		case corrID == "":
+			c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		default:
+			c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		}
 
 		return
 	}

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -51,3 +51,13 @@ Admin endpoints are only available to a set of whitelisted users specified in th
     ```bash
     curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"accession_idd": ["my-id-01", "my-id-02"], "dataset_id": "my-dataset-01"}' https://HOSTNAME/dataset/create
     ```
+
+- `/dataset/release/*dataset`
+  - accepts `POST` requests with the dataset name as last part of the path`
+  - releases a dataset so that it can be downloaded.
+
+    Example:
+
+    ```bash
+    curl -H "Authorization: Bearer $token" -X POST  https://HOSTNAME/dataset/release/my-dataset-01
+    ```

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -31,3 +31,13 @@ Admin endpoints are only available to a set of whitelisted users specified in th
     ```bash
     curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"filepath": "/uploads/file.c4gh", "user": "testuser"}' https://HOSTNAME/file/ingest
     ```
+
+- `/file/accession`
+  - accepts `POST` requests with JSON data with the format: `{"accession_id": "<FILE_ACCESSION>", "filepath": "</PATH/TO/FILE/IN/INBOX>", "user": "<USERNAME>"}`
+  - assigns accession ID to the file.
+
+    Example:
+
+    ```bash
+    curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"accession_id": "my-id-01", "filepath": "/uploads/file.c4gh", "user": "testuser"}' https://HOSTNAME/file/accession
+    ```

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -17,3 +17,17 @@ Endpoints:
     [{"inboxPath":"requester_demo.org/data/file1.c4gh","fileStatus":"uploaded","createAt":"2023-11-13T10:12:43.144242Z"}] 
     ```
      If the `token` is invalid, 401 is returned.
+
+### Admin endpoints
+
+Admin endpoints are only available to a set of whitelisted users specified in the application config.
+
+- `/file/ingest`
+  - accepts `POST` requests with JSON data with the format: `{"filepath": "</PATH/TO/FILE/IN/INBOX>", "user": "<USERNAME>"}`
+  - triggers the ingestion of the file.
+
+    Example:
+
+    ```bash
+    curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"filepath": "/uploads/file.c4gh", "user": "testuser"}' https://HOSTNAME/file/ingest
+    ```

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -1,22 +1,25 @@
 # API
+
 The API service provides data submitters with functionality to control
-their submissions. Users are authenticated with a JWT. 
+their submissions. Users are authenticated with a JWT.
 
 ## Service Description
 
 Endpoints:
-  - `/files`
-  
-    1. Parses and validates the JWT token against the public keys, either locally provisioned or from OIDC JWK endpoints.
-    2. The `sub` field from the token is extracted and used as the user's identifier
-    3. All files belonging to this user are extracted from the database, together with their latest status and creation date
-     
-     Example:
-      ```bash
-      $ curl 'https://server/files' -H "Authorization: Bearer $token"
-    [{"inboxPath":"requester_demo.org/data/file1.c4gh","fileStatus":"uploaded","createAt":"2023-11-13T10:12:43.144242Z"}] 
-    ```
-     If the `token` is invalid, 401 is returned.
+
+- `/files`
+  1. Parses and validates the JWT token against the public keys, either locally provisioned or from OIDC JWK endpoints.
+  2. The `sub` field from the token is extracted and used as the user's identifier
+  3. All files belonging to this user are extracted from the database, together with their latest status and creation date
+
+    Example:
+
+    ```bash
+    $ curl 'https://server/files' -H "Authorization: Bearer $token"
+  [{"inboxPath":"requester_demo.org/data/file1.c4gh","fileStatus":"uploaded","createAt":"2023-11-13T10:12:43.144242Z"}] 
+  ```
+
+  If the `token` is invalid, 401 is returned.
 
 ### Admin endpoints
 

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -41,3 +41,13 @@ Admin endpoints are only available to a set of whitelisted users specified in th
     ```bash
     curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"accession_id": "my-id-01", "filepath": "/uploads/file.c4gh", "user": "testuser"}' https://HOSTNAME/file/accession
     ```
+
+- `/dataset/create`
+  - accepts `POST` requests with JSON data with the format: `{"accession_ids": ["<FILE_ACCESSION_01>", "<FILE_ACCESSION_02>"], "dataset_id": "<DATASET_01>"}`
+  - creates a datset from the list of accession IDs and the dataset ID.
+
+    Example:
+
+    ```bash
+    curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"accession_idd": ["my-id-01", "my-id-02"], "dataset_id": "my-dataset-01"}' https://HOSTNAME/dataset/create
+    ```

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -29,6 +29,12 @@ Admin endpoints are only available to a set of whitelisted users specified in th
   - accepts `POST` requests with JSON data with the format: `{"filepath": "</PATH/TO/FILE/IN/INBOX>", "user": "<USERNAME>"}`
   - triggers the ingestion of the file.
 
+- Error codes
+  - `200` Query execute ok.
+  - `400` Error due to bad payload i.e. wrong `user` + `filepath` combination.
+  - `401` User is not in the list of admins.
+  - `500` Internal error due to DB or MQ failures.
+
     Example:
 
     ```bash
@@ -38,6 +44,12 @@ Admin endpoints are only available to a set of whitelisted users specified in th
 - `/file/accession`
   - accepts `POST` requests with JSON data with the format: `{"accession_id": "<FILE_ACCESSION>", "filepath": "</PATH/TO/FILE/IN/INBOX>", "user": "<USERNAME>"}`
   - assigns accession ID to the file.
+
+- Error codes
+  - `200` Query execute ok.
+  - `400` Error due to bad payload i.e. wrong `user` + `filepath` combination.
+  - `401` User is not in the list of admins.
+  - `500` Internal error due to DB or MQ failures.
 
     Example:
 
@@ -49,6 +61,12 @@ Admin endpoints are only available to a set of whitelisted users specified in th
   - accepts `POST` requests with JSON data with the format: `{"accession_ids": ["<FILE_ACCESSION_01>", "<FILE_ACCESSION_02>"], "dataset_id": "<DATASET_01>"}`
   - creates a datset from the list of accession IDs and the dataset ID.
 
+- Error codes
+  - `200` Query execute ok.
+  - `400` Error due to bad payload.
+  - `401` User is not in the list of admins.
+  - `500` Internal error due to DB or MQ failures.
+
     Example:
 
     ```bash
@@ -58,6 +76,12 @@ Admin endpoints are only available to a set of whitelisted users specified in th
 - `/dataset/release/*dataset`
   - accepts `POST` requests with the dataset name as last part of the path`
   - releases a dataset so that it can be downloaded.
+
+- Error codes
+  - `200` Query execute ok.
+  - `400` Error due to bad payload.
+  - `401` User is not in the list of admins.
+  - `500` Internal error due to DB or MQ failures.
 
     Example:
 

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -374,7 +374,6 @@ func (suite *TestSuite) SetupSuite() {
 }
 
 func (suite *TestSuite) SetupTest() {
-	log.Print("Setup DB for my test")
 	Conf.Database = database.DBConf{
 		Host:     "localhost",
 		Port:     dbPort,
@@ -591,7 +590,6 @@ func (suite *TestSuite) TestIsAdmin() {
 	_, router := gin.CreateTestContext(w)
 	router.GET("/", isAdmin(), testEndpoint)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -626,7 +624,6 @@ func (suite *TestSuite) TestIngestFile() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/ingest", ingestFile)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -676,7 +673,6 @@ func (suite *TestSuite) TestIngestFile_NoUser() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/ingest", ingestFile)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -708,7 +704,6 @@ func (suite *TestSuite) TestIngestFile_WrongUser() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/ingest", ingestFile)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -744,7 +739,6 @@ func (suite *TestSuite) TestIngestFile_WrongFilePath() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/ingest", isAdmin(), ingestFile)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -803,7 +797,6 @@ func (suite *TestSuite) TestSetAccession() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/accession", isAdmin(), setAccession)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -848,7 +841,6 @@ func (suite *TestSuite) TestSetAccession_WrongUser() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/accession", isAdmin(), setAccession)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -893,7 +885,6 @@ func (suite *TestSuite) TestSetAccession_WrongFormat() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/file/accession", isAdmin(), setAccession)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -968,7 +959,6 @@ func (suite *TestSuite) TestCreateDataset() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/dataset/create", isAdmin(), createDataset)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -1010,7 +1000,6 @@ func (suite *TestSuite) TestCreateDataset_BadFormat() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/dataset/create", isAdmin(), createDataset)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	response := w.Result()
 	defer response.Body.Close()
@@ -1041,7 +1030,6 @@ func (suite *TestSuite) TestReleaseDataset() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/dataset/release/*dataset", isAdmin(), releaseDataset)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
@@ -1087,7 +1075,6 @@ func (suite *TestSuite) TestReleaseDataset_NoDataset() {
 	_, router := gin.CreateTestContext(w)
 	router.POST("/dataset/release/*dataset", isAdmin(), releaseDataset)
 
-	// admin user should be allowed
 	router.ServeHTTP(w, r)
 	okResponse := w.Result()
 	defer okResponse.Body.Close()

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -271,29 +271,6 @@ func (suite *TestSuite) TestReadinessResponse() {
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
-	Conf = &config.Config{}
-	Conf.Broker = broker.MQConf{
-		Host:     "localhost",
-		Port:     mqPort,
-		User:     "guest",
-		Password: "guest",
-		Exchange: "amq.default",
-		Vhost:    "/sda",
-	}
-	Conf.API.MQ, err = broker.NewMQ(Conf.Broker)
-	assert.NoError(suite.T(), err)
-
-	Conf.Database = database.DBConf{
-		Host:     "localhost",
-		Port:     dbPort,
-		User:     "postgres",
-		Password: "rootpasswd",
-		Database: "sda",
-		SslMode:  "disable",
-	}
-	Conf.API.DB, err = database.NewSDAdb(Conf.Database)
-	assert.NoError(suite.T(), err)
-
 	res, err := http.Get(ts.URL + "/ready")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), http.StatusOK, res.StatusCode)
@@ -393,6 +370,31 @@ func (suite *TestSuite) SetupSuite() {
 	Conf.API.MQ, err = broker.NewMQ(Conf.Broker)
 	assert.NoError(suite.T(), err)
 
+}
+
+func (suite *TestSuite) SetupTest() {
+	log.Print("Setup DB for my test")
+	Conf.Database = database.DBConf{
+		Host:     "localhost",
+		Port:     dbPort,
+		User:     "postgres",
+		Password: "rootpasswd",
+		Database: "sda",
+		SslMode:  "disable",
+	}
+	Conf.API.DB, err = database.NewSDAdb(Conf.Database)
+	assert.NoError(suite.T(), err)
+
+	Conf.Broker = broker.MQConf{
+		Host:     "localhost",
+		Port:     mqPort,
+		User:     "guest",
+		Password: "guest",
+		Exchange: "sda",
+		Vhost:    "/sda",
+	}
+	Conf.API.MQ, err = broker.NewMQ(Conf.Broker)
+	assert.NoError(suite.T(), err)
 }
 
 func (suite *TestSuite) TestDatabasePingCheck() {

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -708,7 +708,7 @@ func (suite *TestSuite) TestIngestFile_WrongUser() {
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
 	b, _ := io.ReadAll(okResponse.Body)
-	assert.Equal(suite.T(), http.StatusInternalServerError, okResponse.StatusCode)
+	assert.Equal(suite.T(), http.StatusBadRequest, okResponse.StatusCode)
 	assert.Contains(suite.T(), string(b), "sql: no rows in result set")
 }
 
@@ -743,7 +743,7 @@ func (suite *TestSuite) TestIngestFile_WrongFilePath() {
 	okResponse := w.Result()
 	defer okResponse.Body.Close()
 	b, _ := io.ReadAll(okResponse.Body)
-	assert.Equal(suite.T(), http.StatusInternalServerError, okResponse.StatusCode)
+	assert.Equal(suite.T(), http.StatusBadRequest, okResponse.StatusCode)
 	assert.Contains(suite.T(), string(b), "sql: no rows in result set")
 }
 

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -916,3 +916,104 @@ func (suite *TestSuite) TestSetAccession_WrongFormat() {
 	assert.NoError(suite.T(), err, "failed to unmarshal response")
 	assert.Equal(suite.T(), 1, data.MessagesReady)
 }
+
+func (suite *TestSuite) TestCreateDataset() {
+	user := "dummy"
+	filePath := "/inbox/dummy/file12.c4gh"
+
+	fileID, err := Conf.API.DB.RegisterFile(filePath, user)
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	err = Conf.API.DB.UpdateFileEventLog(fileID, "uploaded", fileID, user, "{}", "{}")
+	assert.NoError(suite.T(), err, "failed to update satus of file in database")
+
+	encSha := sha256.New()
+	_, err = encSha.Write([]byte("Checksum"))
+	assert.NoError(suite.T(), err)
+
+	decSha := sha256.New()
+	_, err = decSha.Write([]byte("DecryptedChecksum"))
+	assert.NoError(suite.T(), err)
+
+	fileInfo := database.FileInfo{
+		Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
+		Size:              1000,
+		Path:              filePath,
+		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
+		DecryptedSize:     948,
+	}
+	err = Conf.API.DB.SetArchived(fileInfo, fileID, fileID)
+	assert.NoError(suite.T(), err, "failed to mark file as Archived")
+
+	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
+
+	err = Conf.API.DB.SetAccessionID("API:accession-id-11", fileID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
+
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(suite.T(), setupJwtAuth())
+	Conf.API.Admins = []string{"dummy"}
+	Conf.Broker.SchemasPath = "../../schemas/isolated"
+
+	type dataset struct {
+		AccessionIDs []string `json:"accession_ids"`
+		DatasetID    string   `json:"dataset_id"`
+	}
+	accessionMsg, _ := json.Marshal(dataset{AccessionIDs: []string{"API:accession-id-11", "API:accession-id-12", "API:accession-id-13"}, DatasetID: "API:dataset-01"})
+	// Mock request and response holders
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/dataset/create", bytes.NewBuffer(accessionMsg))
+	r.Header.Add("Authorization", "Bearer "+suite.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/dataset/create", isAdmin(), createDataset)
+
+	// admin user should be allowed
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(suite.T(), http.StatusOK, okResponse.StatusCode)
+
+	// verify that the message shows up in the queue
+	time.Sleep(10 * time.Second) // this is needed to ensure we don't get any false negatives
+	client := http.Client{Timeout: 5 * time.Second}
+	req, _ := http.NewRequest(http.MethodGet, "http://"+BrokerAPI+"/api/queues/sda/mappings", http.NoBody)
+	req.SetBasicAuth("guest", "guest")
+	res, err := client.Do(req)
+	assert.NoError(suite.T(), err, "failed to query broker")
+	var data struct {
+		MessagesReady int `json:"messages_ready"`
+	}
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	assert.NoError(suite.T(), err, "failed to read response from broker")
+	assert.NoError(suite.T(), json.Unmarshal(body, &data), "failed to unmarshal response")
+	assert.Equal(suite.T(), 1, data.MessagesReady)
+}
+
+func (suite *TestSuite) TestCreateDataset_BadFormat() {
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(suite.T(), setupJwtAuth())
+	Conf.API.Admins = []string{"dummy"}
+	Conf.Broker.SchemasPath = "../../schemas/federated"
+
+	type dataset struct {
+		AccessionIDs []string `json:"accession_ids"`
+		DatasetID    string   `json:"dataset_id"`
+	}
+	accessionMsg, _ := json.Marshal(dataset{AccessionIDs: []string{"API:accession-id-11", "API:accession-id-12", "API:accession-id-13"}, DatasetID: "API:dataset-01"})
+	// Mock request and response holders
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/dataset/create", bytes.NewBuffer(accessionMsg))
+	r.Header.Add("Authorization", "Bearer "+suite.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/dataset/create", isAdmin(), createDataset)
+
+	// admin user should be allowed
+	router.ServeHTTP(w, r)
+	response := w.Result()
+	defer response.Body.Close()
+
+	assert.Equal(suite.T(), http.StatusBadRequest, response.StatusCode)
+}

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -74,6 +74,7 @@ type SyncAPIConf struct {
 }
 
 type APIConf struct {
+	Admins     []string
 	CACert     string
 	ServerCert string
 	ServerKey  string

--- a/sda/schemas/federated/ingestion-trigger.json
+++ b/sda/schemas/federated/ingestion-trigger.json
@@ -99,6 +99,7 @@
             "type": "string",
             "title": "The username",
             "description": "The username",
+            "minLength": 2,
             "examples": [
                 "user.name@central-ega.eu"
             ]
@@ -108,6 +109,7 @@
             "type": "string",
             "title": "The new filepath",
             "description": "The new filepath",
+            "minLength": 2,
             "examples": [
                 "/ega/inbox/user.name@central-ega.eu/the-file.c4gh"
             ]

--- a/sda/schemas/isolated/dataset-deprecate.json
+++ b/sda/schemas/isolated/dataset-deprecate.json
@@ -1,1 +1,29 @@
-../federated/dataset-deprecate.json
+{
+    "title": "JSON schema for Local EGA dataset deprecation message interface",
+    "$id": "https://github.com/neicnordic/sensitive-data-archive/tree/master/sda/schemas/federated/dataset-deprecate.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "required": [
+        "type",
+        "dataset_id"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "The message type",
+            "description": "The message type",
+            "const": "deprecate"
+        },
+        "dataset_id": {
+            "$id": "#/properties/dataset_id",
+            "type": "string",
+            "title": "The Accession identifier for the dataset",
+            "description": "The Accession identifier for the dataset",
+            "examples": [
+                "anyidentifier"
+            ]
+        }
+    }
+}

--- a/sda/schemas/isolated/dataset-release.json
+++ b/sda/schemas/isolated/dataset-release.json
@@ -23,7 +23,8 @@
             "description": "The Accession identifier for the dataset",
             "examples": [
                 "anyidentifier"
-            ]
+            ],
+            "minLength": 2
         }
     }
 }

--- a/sda/schemas/isolated/dataset-release.json
+++ b/sda/schemas/isolated/dataset-release.json
@@ -1,1 +1,29 @@
-../federated/dataset-release.json
+{
+    "title": "JSON schema for Local EGA dataset release message interface",
+    "$id": "https://github.com/neicnordic/sensitive-data-archive/tree/master/sda/schemas/federated/dataset-release.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "required": [
+        "type",
+        "dataset_id"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "The message type",
+            "description": "The message type",
+            "const": "release"
+        },
+        "dataset_id": {
+            "$id": "#/properties/dataset_id",
+            "type": "string",
+            "title": "The Accession identifier for the dataset",
+            "description": "The Accession identifier for the dataset",
+            "examples": [
+                "anyidentifier"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
**Background**  
For standalone setups, like the one used in GDI, there are a need to be able to take care of the administrative tasks without the need to have direct access to the MQ or the PostgreSQL database.

This PR begins the process of simplifying these administrative tasks.
The first goal is to be able to handle the ingestion process i.e. trigger the ingestion of a file, assign a stable ID to the file and in the end create a dataset from a set of stable IDs.

**Description**
First take on the admin API
* Restricts endpoints to a set of whitelisted users
* Triggers ingestion of a file
* Assign accession ID to a file
* Create a dataset from a set of accession IDs
* Release the dataset

**How to test**
