### PR TITLE
Disallow reserved characters

### DIFF
--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -512,9 +512,9 @@ func formatUploadFilePath(filePath string) (string, error) {
 	// [\x00-\x1F\x7F] is the control character set
 	re := regexp.MustCompile(`[\\<>"\|\x00-\x1F\x7F\!\*\'\(\)\;\:\@\&\=\+\$\,\?\%\#\[\]]`)
 
-	dissallowedChars := re.FindAllString(outPath, -1)
-	if dissallowedChars != nil {
-		return outPath, fmt.Errorf("filepath contains disallowed characters: %+v", strings.Join(dissallowedChars, ", "))
+	disallowedChars := re.FindAllString(outPath, -1)
+	if disallowedChars != nil {
+		return outPath, fmt.Errorf("filepath contains disallowed characters: %+v", strings.Join(disallowedChars, ", "))
 	}
 
 	return outPath, nil

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -510,7 +510,7 @@ func formatUploadFilePath(filePath string) (string, error) {
 	outPath := strings.ReplaceAll(filePath, "\\", "/")
 
 	// [\x00-\x1F\x7F] is the control character set
-	re := regexp.MustCompile(`[\\:\*\?"<>\|\x00-\x1F\x7F]`)
+	re := regexp.MustCompile(`[\\<>"\|\x00-\x1F\x7F\!\*\'\(\)\;\:\@\&\=\+\$\,\?\%\#\[\]]`)
 
 	dissallowedChars := re.FindAllString(outPath, -1)
 	if dissallowedChars != nil {

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -499,7 +499,7 @@ func (suite *ProxyTests) TestFormatUploadFilePath() {
 	assert.EqualError(suite.T(), err, "filepath contains mixed '\\' and '/' characters")
 
 	// no mixed "\" and "/" but not allowed
-	weirdPath = `dq\sw:*?"<>|\t\sdf.c4gh`
+	weirdPath = `dq\sw:*?"<>|\t\sdf!s'(a);w@4&f=+e$,g#[]d%.c4gh`
 	_, err = formatUploadFilePath(weirdPath)
-	assert.EqualError(suite.T(), err, "filepath contains disallowed characters: :, *, ?, \", <, >, |")
+	assert.EqualError(suite.T(), err, "filepath contains disallowed characters: :, *, ?, \", <, >, |, !, ', (, ), ;, @, &, =, +, $, ,, #, [, ], %")
 }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #396 

**Description**
- Checks upload filepath for reserved characters and throws an informative error  message if any is found.
- The testsuite is expanded to check all disallowed character cases.

**How to test**
`go test`