### PR TITLE
docker compose instead of docker-compose

### DIFF
--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           cd sda-sftp-inbox/dev_utils
           bash ./make_certs.sh
-          docker-compose up certfixer
-          docker-compose up -d
+          docker compose up certfixer
+          docker compose up -d
           sleep 20
 
       - name: Run test for sftp ssh connection

--- a/sda-download/.github/integration/setup/common/10_services.sh
+++ b/sda-download/.github/integration/setup/common/10_services.sh
@@ -9,7 +9,7 @@ bash ./make_certs.sh
 
 if [ "$STORAGETYPE" = s3notls ]; then
 
-    docker-compose -f compose-no-tls.yml up -d
+    docker compose -f compose-no-tls.yml up -d
 
     RETRY_TIMES=0
     for p in db s3 download; do
@@ -34,7 +34,7 @@ else
 
     # We need to leave the $tostart variable unquoted here since we want it to split
     # shellcheck disable=SC2086
-    docker-compose -f compose.yml up -d $tostart
+    docker compose -f compose.yml up -d $tostart
 
     for p in $tostart; do
         RETRY_TIMES=0
@@ -54,7 +54,7 @@ else
         done
     done
 
-    docker-compose -f compose.yml up -d
+    docker compose -f compose.yml up -d
 
     RETRY_TIMES=0
     until docker ps -f name="download" --format "{{.Status}}" | grep "Up"

--- a/sda-download/dev_utils/README.md
+++ b/sda-download/dev_utils/README.md
@@ -19,7 +19,7 @@ sh make_certs.sh
 ## Getting up and running fast with docker compose
 
 ```command
-docker-compose -f compose-no-tls.yml up -d
+docker compose -f compose-no-tls.yml up -d
 ```
 
 For testing the API

--- a/sda-sftp-inbox/.github/workflows/integration.yml
+++ b/sda-sftp-inbox/.github/workflows/integration.yml
@@ -16,8 +16,8 @@ jobs:
         run: |
           cd dev_utils
           bash ./make_certs.sh
-          docker-compose up certfixer
-          docker-compose up -d
+          docker compose up certfixer
+          docker compose up -d
           sleep 20
 
       - name: Run test for sftp ssh connection

--- a/sda-sftp-inbox/dev_utils/README.md
+++ b/sda-sftp-inbox/dev_utils/README.md
@@ -10,13 +10,13 @@ sh make_certs.sh
 Start creating the certificates, java is picky and we need to create them first
 
 ```command
-docker-compose up -d certfixer
+docker compose up -d certfixer
 ```
 
 To start all the other services using docker compose.
 
 ```command
-docker-compose up -d
+docker compose up -d
 ```
 
 For a test example use:


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This should fix the `docker-compose: command not found` errors in some of the integration tests, e.g. #976 .

