### PR TITLE
Grant select permission to role "download" on dataset_event_log table

### DIFF
--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -24,7 +24,8 @@ VALUES (0, now(), 'Created with version'),
        (7, now(), 'Add permissions to mapper to files'),
        (8, now(), 'Add ingestion functions'),
        (9, now(), 'Add dataset event log'),
-       (10, now(), 'Create Inbox user');
+       (10, now(), 'Create Inbox user'),
+       (11, now(), 'Grant select permission to download on dataset_event_log');
 
 -- Datasets are used to group files, and permissions are set on the dataset
 -- level

--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -147,6 +147,7 @@ GRANT SELECT ON sda.file_dataset TO download;
 GRANT SELECT ON sda.checksums TO download;
 GRANT SELECT ON sda.datasets TO download;
 GRANT SELECT ON sda.file_event_log TO download;
+GRANT SELECT ON sda.dataset_event_log TO download;
 
 -- legacy schema
 GRANT USAGE ON SCHEMA local_ega TO download;

--- a/postgresql/migratedb.d/11.sql
+++ b/postgresql/migratedb.d/11.sql
@@ -1,0 +1,20 @@
+DO
+$$
+DECLARE
+-- The version we know how to do migration from, at the end of a successful migration
+-- we will no longer be at this version.
+  sourcever INTEGER := 10;
+  changes VARCHAR := 'Grant select permission to download on dataset_event_log';
+BEGIN
+  IF (select max(version) from sda.dbschema_version) = sourcever then
+    RAISE NOTICE 'Doing migration from schema version % to %', sourcever, sourcever+1;
+    RAISE NOTICE 'Changes: %', changes;
+    INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
+
+    GRANT SELECT ON sda.dataset_event_log TO download;
+
+  ELSE
+    RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
+  END IF;
+END
+$$


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #866.


**Description**
Users with role download need select permission on dataset_event_log to check the events. This pr grants the permission with the migration script to db schema version 11.


**How to test**
