### PR TITLE
inbox: tls for the health endpoint

### DIFF
--- a/charts/sda-svc/templates/inbox-service.yaml
+++ b/charts/sda-svc/templates/inbox-service.yaml
@@ -12,6 +12,10 @@ spec:
     port: {{ template "inboxServicePort" . }}
     targetPort: inbox
     protocol: TCP
+  - name: inbox-liveness
+    port: 8001
+    targetPort: liveness-port
+    protocol: TCP
   selector:
     app: {{ template "sda.fullname" . }}-inbox
 {{- end }}

--- a/charts/sda-svc/templates/s3-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/s3-inbox-deploy.yaml
@@ -217,12 +217,14 @@ spec:
           httpGet:
             path: /live
             port: liveness-port
+            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
           failureThreshold: 1
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /ready
             port: liveness-port
+            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
           failureThreshold: 1
           periodSeconds: 5
         resources:

--- a/charts/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/charts/sda-svc/templates/s3-inbox-ingress.yaml
@@ -44,7 +44,7 @@ spec:
             name: {{ template "sda.fullname" . }}-inbox
             port:
               number: {{ ternary 443 80 .Values.global.tls.enabled }}
-      - pathType: Prefix
+      - pathType: Exact
         path: "/healthz"
         backend:
           service:

--- a/charts/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/charts/sda-svc/templates/s3-inbox-ingress.yaml
@@ -44,6 +44,13 @@ spec:
             name: {{ template "sda.fullname" . }}-inbox
             port:
               number: {{ ternary 443 80 .Values.global.tls.enabled }}
+      - pathType: Prefix
+        path: "/healthz"
+        backend:
+          service:
+            name: {{ template "sda.fullname" . }}-inbox
+            port:
+              number: 8001
 {{- if .Values.global.tls.enabled }}
   tls:
   - hosts:

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -14,11 +14,13 @@ import (
 
 // HealthCheck registers and endpoint for healthchecking the service
 type HealthCheck struct {
-	port      int
-	DB        *sql.DB
-	s3URL     string
-	brokerURL string
-	tlsConfig *tls.Config
+	port       int
+	DB         *sql.DB
+	s3URL      string
+	brokerURL  string
+	tlsConfig  *tls.Config
+	serverCert string
+	serverKey  string
 }
 
 // NewHealthCheck creates a new healthchecker. It needs to know where to find
@@ -34,7 +36,10 @@ func NewHealthCheck(port int, db *sql.DB, conf *config.Config, tlsConfig *tls.Co
 
 	brokerURL := fmt.Sprintf("%s:%d", conf.Broker.Host, conf.Broker.Port)
 
-	return &HealthCheck{port, db, s3URL, brokerURL, tlsConfig}
+	serverCert := conf.Server.Cert
+	serverKey := conf.Server.Key
+
+	return &HealthCheck{port, db, s3URL, brokerURL, tlsConfig, serverCert, serverKey}
 }
 
 // RunHealthChecks should be run as a go routine in the main app. It registers
@@ -70,8 +75,14 @@ func (h *HealthCheck) RunHealthChecks() {
 		IdleTimeout:       30 * time.Second,
 		ReadHeaderTimeout: 3 * time.Second,
 	}
-	if err := server.ListenAndServe(); err != nil {
-		panic(err)
+	if h.serverCert != "" && h.serverKey != "" {
+		if err := server.ListenAndServeTLS(h.serverCert, h.serverKey); err != nil {
+			panic(err)
+		}
+	} else {
+		if err := server.ListenAndServe(); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -47,7 +47,7 @@ func (h *HealthCheck) RunHealthChecks() {
 
 	health.AddReadinessCheck("S3-backend-http", h.httpsGetCheck(h.s3URL, 5000*time.Millisecond))
 
-	health.AddReadinessCheck("broker-tcp", healthcheck.TCPDialCheck(h.brokerURL, 50*time.Millisecond))
+	health.AddReadinessCheck("broker-tcp", healthcheck.TCPDialCheck(h.brokerURL, 5000*time.Millisecond))
 
 	health.AddReadinessCheck("database", healthcheck.DatabasePingCheck(h.DB, 1*time.Second))
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #459 .


**Description**
- healthcheck server uses tls, if configured to do so
- charts are updated to expose `/healthz` endpoint for inbox
- timeout for the `broker-tcp` health check of inbox is increased (from very short 5 ms)

**How to test**
Make sure all checks pass, specifically `Build PR container / chart (1.28, true, s3)`. The healthendpoint will be exposed at `GET inbox.../healthz`
