### PR TITLE
Add key hash to the files table

### DIFF
--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -25,7 +25,8 @@ VALUES (0, now(), 'Created with version'),
        (8, now(), 'Add ingestion functions'),
        (9, now(), 'Add dataset event log'),
        (10, now(), 'Create Inbox user'),
-       (11, now(), 'Grant select permission to download on dataset_event_log');
+       (11, now(), 'Grant select permission to download on dataset_event_log'),
+       (12, now(), 'Add key hash');
 
 -- Datasets are used to group files, and permissions are set on the dataset
 -- level
@@ -35,6 +36,14 @@ CREATE TABLE datasets (
     title               TEXT,
     description         TEXT,
     created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
+
+-- the keys table is used to store the information of the encryption keys
+CREATE TABLE encryption_keys (
+    key_hash          TEXT PRIMARY KEY,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+    deprecated_at     TIMESTAMP WITH TIME ZONE,
+    description       TEXT
 );
 
 -- `files` is the main table of the schema, holding the file paths, encryption
@@ -53,6 +62,7 @@ CREATE TABLE files (
 
     header               TEXT,
     encryption_method    TEXT,
+    key_hash             TEXT REFERENCES encryption_keys(key_hash),
 
     -- Table Audit / Logs
     created_by           NAME DEFAULT CURRENT_USER, -- Postgres users

--- a/postgresql/migratedb.d/12.sql
+++ b/postgresql/migratedb.d/12.sql
@@ -1,0 +1,28 @@
+DO
+$$
+DECLARE
+-- The version we know how to do migration from, at the end of a successful migration
+-- we will no longer be at this version.
+  sourcever INTEGER := 11;
+  changes VARCHAR := 'Add key hash';
+BEGIN
+  IF (select max(version) from sda.dbschema_version) = sourcever then
+    RAISE NOTICE 'Doing migration from schema version % to %', sourcever, sourcever+1;
+    RAISE NOTICE 'Changes: %', changes;
+    INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
+
+    CREATE TABLE IF NOT EXISTS sda.encryption_keys (
+        key_hash          TEXT PRIMARY KEY,
+        created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+        deprecated_at     TIMESTAMP WITH TIME ZONE,
+        description       TEXT
+    );
+
+    ALTER TABLE sda.files ADD COLUMN IF NOT EXISTS key_hash TEXT,
+    ADD CONSTRAINT fk_files_key_hash FOREIGN KEY (key_hash) REFERENCES sda.encryption_keys(key_hash);
+
+  ELSE
+    RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
+  END IF;
+END
+$$


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #788 

**Description**
**Changes made**
1. Added a new column `key_hash` into the `files` table
2. Added a new table `encryption_keys` for storing the detailed information of the encryption keys
3. Added the migration script for these changes and updated the dbschema_version

**How to test**
1. Build the images locally by running the following command in the root folder of the repo
```
make build-sda build-postgresql 
```
2. Start the docker setup by 
```
docker compose -f .github/integration/sda-s3-integration.yml up -d
```
3. Check in the database if `key_hash` exists in the `files` table and the new table `encryption_keys` exists.
4. Insert a record to the table `encryption_keys` by e.g. 

```
INSERT INTO sda.encryption_keys (key_hash, description) VALUES ('example_key_hash', 'Example encryption key description'); 
```
and then try to insert a record to the `files` table with the `key_hash` matching `example_key_hash` and that does not match `example_key_hash`.
The former should work and the latter should fail.

**Additional note**
To test if the migration scripts works on the existing database, one can first start the docker setup with the code from the main branch and then turn down the docker setup without removing the database volume. After that, build the images with this branch and start the docker setup again. 