### PR TITLE
docs: add missing configurations

### DIFF
--- a/sda/cmd/finalize/finalize.md
+++ b/sda/cmd/finalize/finalize.md
@@ -62,6 +62,7 @@ These settings control how `finalize` connects to the RabbitMQ message broker.
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
+- `BROKER_EXCHANGE`= the exchange name (i.e., `sda`)
 
 ### PostgreSQL Database settings
 
@@ -126,3 +127,30 @@ and if `*_TYPE` is `POSIX`:
 
 - `*_LOCATION`: POSIX path to use as storage root
 
+### Required settings (Example)
+
+The following configuration variables are essential for a successful setup.
+
+- `BROKER_HOST`=
+- `BROKER_PORT`=
+- `BROKER_USER`=
+- `BROKER_PASSWORD`=
+- `BROKER_VHOST`=
+- `BROKER_QUEUE`=
+- `BROKER_EXCHANGE`=
+- `BROKER_ROUTINGKEY`=
+- `BROKER_ROUTINGERROR`=
+- `BROKER_SSL`=
+- `BROKER_VERIFYPEER`=
+- `BROKER_CACERT`=
+- `BROKER_CLIENTCERT`=
+- `BROKER_CLIENTKEY`=
+- `DB_HOST`=
+- `DB_PORT`=
+- `DB_USER`=
+- `DB_PASSWORD`=
+- `DB_DATABASE`=
+- `DB_SSLMODE`=
+- `DB_CLIENTCERT`=
+- `DB_CLIENTKEY`=
+- `LOG_LEVEL`=

--- a/sda/cmd/ingest/ingest.md
+++ b/sda/cmd/ingest/ingest.md
@@ -77,6 +77,7 @@ These settings control how `ingest` connects to the RabbitMQ message broker.
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
+- `BROKER_EXCHANGE`= the exchange name (i.e., `sda`)
 
 ### PostgreSQL Database settings:
 
@@ -139,3 +140,37 @@ and if `*_TYPE` is `POSIX`:
     - `error`
     - `fatal`
     - `panic`
+
+### Required settings (Example)
+
+The following configuration variables are essential for a successful setup.
+
+- `ARCHIVE_TYPE`=
+- `ARCHIVE_LOCATION`=
+- `BROKER_HOST`=
+- `BROKER_PORT`=
+- `BROKER_USER`=
+- `BROKER_PASSWORD`=
+- `BROKER_VHOST`=
+- `BROKER_QUEUE`=
+- `BROKER_EXCHANGE`=
+- `BROKER_ROUTINGKEY`=
+- `BROKER_ROUTINGERROR`=
+- `BROKER_SSL`=
+- `BROKER_VERIFYPEER`=
+- `BROKER_CACERT`=
+- `BROKER_CLIENTCERT`=
+- `BROKER_CLIENTKEY`=
+- `C4GH_PASSPHRASE`=
+- `C4GH_FILEPATH`=
+- `DB_HOST`=
+- `DB_PORT`=
+- `DB_USER`=
+- `DB_PASSWORD`=
+- `DB_DATABASE`=
+- `DB_SSLMODE`=
+- `DB_CLIENTCERT`=
+- `DB_CLIENTKEY`=
+- `INBOX_TYPE`=
+- `INBOX_LOCATION`=
+- `LOG_LEVEL`=

--- a/sda/cmd/intercept/intercept.md
+++ b/sda/cmd/intercept/intercept.md
@@ -49,6 +49,23 @@ These settings control how `intercept` connects to the RabbitMQ message broker.
 - `BROKER_QUEUE`: message queue to read messages from (commonly: `from_cega`)
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
+- `BROKER_VHOST`= the virtual host of the exchange (i.e., `test`)
+- `BROKER_EXCHANGE`= the exchange name (i.e., `sda`)
+
+### PostgreSQL Database settings:
+
+- `DB_HOST`: hostname for the postgresql database
+- `DB_PORT`: database port (commonly: `5432`)
+- `DB_USER`: username for the database
+- `DB_PASSWORD`: password for the database
+- `DB_DATABASE`: database name (i.e., `sda`)
+- `DB_SSLMODE`: The TLS encryption policy to use for database connections ([See Docs](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)), valid options are:
+    - `disable`
+    - `allow`
+    - `prefer`
+    - `require`
+    - `verify-ca`
+    - `verify-full`
 
 ### Logging settings
 
@@ -61,3 +78,23 @@ These settings control how `intercept` connects to the RabbitMQ message broker.
     - `error`
     - `fatal`
     - `panic`
+
+### Required settings (Example)
+
+The following configuration variables are essential for a successful setup.
+
+- `BROKER_HOST`=
+- `BROKER_PORT`=
+- `BROKER_USER`=
+- `BROKER_PASSWORD`=
+- `BROKER_QUEUE`=
+- `BROKER_VHOST`=
+- `BROKER_EXCHANGE`=
+- `DB_HOST`=
+- `DB_PORT`=
+- `DB_USER`=
+- `DB_PASSWORD`=
+- `DB_DATABASE`=
+- `DB_SSLMODE`=
+- `LOG_LEVEL`=
+

--- a/sda/cmd/mapper/mapper.md
+++ b/sda/cmd/mapper/mapper.md
@@ -56,6 +56,7 @@ These settings control how `mapper` connects to the RabbitMQ message broker.
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
+- `BROKER_EXCHANGE`= the exchange name (i.e., `sda`)
 
 ### PostgreSQL Database settings
 
@@ -116,3 +117,31 @@ and if `*_TYPE` is `POSIX`:
     - `error`
     - `fatal`
     - `panic`
+
+### Required settings (Example)
+
+The following configuration variables are essential for a successful setup.
+
+- `BROKER_HOST`=
+- `BROKER_PORT`=
+- `BROKER_USER`=
+- `BROKER_PASSWORD`=
+- `BROKER_VHOST`=
+- `BROKER_QUEUE`=
+- `BROKER_EXCHANGE`=
+- `BROKER_ROUTINGERROR`=
+- `BROKER_SSL`=
+- `BROKER_VERIFYPEER`=
+- `BROKER_CACERT`=
+- `BROKER_CLIENTCERT`=
+- `BROKER_CLIENTKEY`=
+- `DB_HOST`=
+- `DB_PORT`=
+- `DB_USER`=
+- `DB_PASSWORD`=
+- `DB_DATABASE`=
+- `DB_SSLMODE`=
+- `DB_CLIENTCERT`=
+- `DB_CLIENTKEY`=
+- `LOG_LEVEL`=
+- `INBOX_LOCATION`=

--- a/sda/cmd/verify/verify.md
+++ b/sda/cmd/verify/verify.md
@@ -79,6 +79,7 @@ These settings control how `verify` connects to the RabbitMQ message broker.
 - `BROKER_USER`: username to connect to RabbitMQ
 - `BROKER_PASSWORD`: password to connect to RabbitMQ
 - `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
+- `BROKER_EXCHANGE`= the exchange name (i.e., `sda`)
 
 ### PostgreSQL Database settings
 
@@ -142,3 +143,36 @@ and if `*_TYPE` is `POSIX`:
     - `error`
     - `fatal`
     - `panic`
+
+### Required settings (Example)
+
+The following configuration variables are essential for a successful setup.
+
+- `ARCHIVE_TYPE`=
+- `ARCHIVE_LOCATION`=
+- `BROKER_HOST`=
+- `BROKER_PORT`=
+- `BROKER_USER`=
+- `BROKER_PASSWORD`=
+- `BROKER_VHOST`=
+- `BROKER_QUEUE`=
+- `BROKER_EXCHANGE`=
+- `BROKER_ROUTINGKEY`=
+- `BROKER_ROUTINGERROR`=
+- `BROKER_SSL`=
+- `BROKER_VERIFYPEER`=
+- `BROKER_CACERT`=
+- `BROKER_CLIENTCERT`=
+- `BROKER_CLIENTKEY`=
+- `C4GH_PASSPHRASE`=
+- `C4GH_FILEPATH`=
+- `DB_HOST`=
+- `DB_PORT`=
+- `DB_USER`=
+- `DB_PASSWORD`=
+- `DB_DATABASE`=
+- `DB_SSLMODE`=
+- `DB_CLIENTCERT`=
+- `DB_CLIENTKEY`=
+- `INBOX_LOCATION`=
+- `LOG_LEVEL`=


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
(None)

**Description**
The `BROKER_EXCHANGE` was not explicitly defined. This missing configuration leads service(s) to fall back to the default exchange (an empty string `""`), and messages are ignored. Since the default exchange is a simple direct exchange, we dont get advanced routing features like those provided by topic or fanout exchanges. 

We had trouble running the setup because of this missing configuration. Rabbitmq does not complaint anything without it. Hence,no routing. If no queue name matches the routing key, the message is discarded (unless a dead-letter exchange is configured)

**How to test**
N/A