### PR TITLE
add checks for integer overflows

### DIFF
--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -677,7 +678,7 @@ func (f *fakeGRPC) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write([]byte{0})
 	assert.NoError(f.t, err, "Could not write response flag")
 
-	assert.Less(f.t, len(response), int(^uint32(0)), "Response too long")
+	assert.LessOrEqual(f.t, len(response), math.MaxInt32, "Response too long")
 	err = binary.Write(w, binary.BigEndian, int32(len(response))) //nolint:gosec // we're checking the length above
 	assert.NoError(f.t, err, "Could not write response length")
 

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -677,7 +677,8 @@ func (f *fakeGRPC) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err = w.Write([]byte{0})
 	assert.NoError(f.t, err, "Could not write response flag")
 
-	err = binary.Write(w, binary.BigEndian, int32(len(response)))
+	assert.Less(f.t, len(response), int(^uint32(0)), "Response too long")
+	err = binary.Write(w, binary.BigEndian, int32(len(response))) //nolint:gosec // we're checking the length above
 	assert.NoError(f.t, err, "Could not write response length")
 
 	_, err = w.Write(response)

--- a/sda/cmd/reencrypt/reencrypt.go
+++ b/sda/cmd/reencrypt/reencrypt.go
@@ -55,10 +55,15 @@ func (s *server) ReencryptHeader(_ context.Context, in *re.ReencryptRequest) (*r
 
 	if len(dataEditList) > 0 { // linter doesn't like checking for nil before len
 
-		// Only do this if we're passed a data edit list
+		// Check that G115: integer overflow conversion int -> uint32 is satisfied
+		if len(dataEditList) > int(^uint32(0)) {
+			return nil, status.Error(400, "data edit list too long")
+		}
+
+		// Only do this if we're passed a data edit whose length fits in a uint32
 		dataEditListPacket := headers.DataEditListHeaderPacket{
 			PacketType:    headers.PacketType{PacketType: headers.DataEditList},
-			NumberLengths: uint32(len(dataEditList)),
+			NumberLengths: uint32(len(dataEditList)), //nolint:gosec // we're checking the length above
 			Lengths:       dataEditList,
 		}
 		extraHeaderPackets = append(extraHeaderPackets, dataEditListPacket)

--- a/sda/cmd/reencrypt/reencrypt.go
+++ b/sda/cmd/reencrypt/reencrypt.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"os/signal"
@@ -56,7 +57,7 @@ func (s *server) ReencryptHeader(_ context.Context, in *re.ReencryptRequest) (*r
 	if len(dataEditList) > 0 { // linter doesn't like checking for nil before len
 
 		// Check that G115: integer overflow conversion int -> uint32 is satisfied
-		if len(dataEditList) > int(^uint32(0)) {
+		if len(dataEditList) > int(math.MaxUint32) {
 			return nil, status.Error(400, "data edit list too long")
 		}
 


### PR DESCRIPTION
**Description**
This PR addresses errors of the latest version of the go linter, see e.g.
https://github.com/neicnordic/sensitive-data-archive/actions/runs/10488098518/job/29049848758#step:4:27
https://github.com/neicnordic/sensitive-data-archive/actions/runs/10488098518/job/29049848067#step:4:27

that have to do with unsafe integer conversions. Manual safe checks are added and the linter is silenced.

**How to test**
Linter tests pass.