### PR TITLE
-change sftp-inbox path to sda-sftp-inbox

### DIFF
--- a/.github/workflows/functionality.yml
+++ b/.github/workflows/functionality.yml
@@ -16,12 +16,10 @@ jobs:
         id: changes
         with:
           filters: |
-            sda-auth:
-              - 'sda-auth/**'
             sda-download:
               - 'sda-download/**'
             sftp-inbox:
-            - 'sftp-inbox/**'
+            - 'sda-sftp-inbox/**'
 
   sda-download:
     needs: check_changes


### PR DESCRIPTION
Set the path for detecting changes for sda-sftp-inbox to "sda-sftp-inbox" so changes can be detected to trigger the tests for it.
The unused filter for sda-auth is removed.

**Related issue(s) and PR(s)**  
This PR closes [#1014].

