### PR TITLE
[s3inbox] run healthchecks in main process

### DIFF
--- a/.github/integration/tests/sda/09_healthchecks.sh
+++ b/.github/integration/tests/sda/09_healthchecks.sh
@@ -22,7 +22,7 @@ if [ "$response" != "200" ]; then
 	exit 1
 fi
 
-response="$(curl -s -k -LI "http://s3inbox:8000/health" -o /dev/null -w "%{http_code}\n")"
+response="$(curl -s -k -L "http://s3inbox:8000/health" -o /dev/null -w "%{http_code}\n")"
 if [ "$response" != "200" ]; then
 	echo "Bad health response from /health, expected 200 got: $response"
 	exit 1

--- a/.github/integration/tests/sda/09_healthchecks.sh
+++ b/.github/integration/tests/sda/09_healthchecks.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# install tools if missing
+for t in curl  jq ; do
+    if [ ! "$(command -v $t)" ]; then
+        if [ "$(id -u)" != 0 ]; then
+            echo "$t is missing, unable to install it"
+            exit 1
+        fi
+
+        apt-get -o DPkg::Lock::Timeout=60 update >/dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y "$t" >/dev/null
+    fi
+done
+
+
+# Test the s3inbox's healthchecks, GET /health and HEAD /
+token="$(curl -s http://oidc:8080/tokens | jq -r '.[0]')"
+
+response="$(curl -s -k -LI "http://s3inbox:8000" -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token")"
+if [ "$response" != "200" ]; then
+	echo "Bad health response from HEAD /, expected 200 got: $response"
+	exit 1
+fi
+
+response="$(curl -s -k -LI "http://s3inbox:8000/health" -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token")"
+if [ "$response" != "200" ]; then
+	echo "Bad health response from /health, expected 200 got: $response"
+	exit 1
+fi
+
+echo "Healthcheck tests completed successfully"

--- a/.github/integration/tests/sda/09_healthchecks.sh
+++ b/.github/integration/tests/sda/09_healthchecks.sh
@@ -16,15 +16,13 @@ done
 
 
 # Test the s3inbox's healthchecks, GET /health and HEAD /
-token="$(curl -s http://oidc:8080/tokens | jq -r '.[0]')"
-
-response="$(curl -s -k -LI "http://s3inbox:8000" -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token")"
+response="$(curl -s -k -LI "http://s3inbox:8000" -o /dev/null -w "%{http_code}\n")"
 if [ "$response" != "200" ]; then
 	echo "Bad health response from HEAD /, expected 200 got: $response"
 	exit 1
 fi
 
-response="$(curl -s -k -LI "http://s3inbox:8000/health" -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token")"
+response="$(curl -s -k -LI "http://s3inbox:8000/health" -o /dev/null -w "%{http_code}\n")"
 if [ "$response" != "200" ]; then
 	echo "Bad health response from /health, expected 200 got: $response"
 	exit 1

--- a/charts/sda-svc/templates/inbox-service.yaml
+++ b/charts/sda-svc/templates/inbox-service.yaml
@@ -12,10 +12,6 @@ spec:
     port: {{ template "inboxServicePort" . }}
     targetPort: inbox
     protocol: TCP
-  - name: inbox-liveness
-    port: 8001
-    targetPort: liveness-port
-    protocol: TCP
   selector:
     app: {{ template "sda.fullname" . }}-inbox
 {{- end }}

--- a/charts/sda-svc/templates/s3-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/s3-inbox-deploy.yaml
@@ -210,20 +210,17 @@ spec:
         - name: inbox
           containerPort: 8000
           protocol: TCP
-        - name: liveness-port
-          containerPort: 8001
-          protocol: TCP
         livenessProbe:
           httpGet:
-            path: /live
-            port: liveness-port
+            path: /health
+            port: inbox
             scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
           failureThreshold: 1
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /ready
-            port: liveness-port
+            path: /health
+            port: inbox
             scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
           failureThreshold: 1
           periodSeconds: 5

--- a/charts/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/charts/sda-svc/templates/s3-inbox-ingress.yaml
@@ -44,13 +44,6 @@ spec:
             name: {{ template "sda.fullname" . }}-inbox
             port:
               number: {{ ternary 443 80 .Values.global.tls.enabled }}
-      - pathType: Exact
-        path: "/healthz"
-        backend:
-          service:
-            name: {{ template "sda.fullname" . }}-inbox
-            port:
-              number: {{ ternary 443 80 .Values.global.tls.enabled }}
 {{- if .Values.global.tls.enabled }}
   tls:
   - hosts:

--- a/charts/sda-svc/templates/s3-inbox-ingress.yaml
+++ b/charts/sda-svc/templates/s3-inbox-ingress.yaml
@@ -50,7 +50,7 @@ spec:
           service:
             name: {{ template "sda.fullname" . }}-inbox
             port:
-              number: 8001
+              number: {{ ternary 443 80 .Values.global.tls.enabled }}
 {{- if .Values.global.tls.enabled }}
   tls:
   - hosts:

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -57,6 +57,8 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusServiceUnavailable)
+
+		return
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"path"
+	"strconv"
 
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	log "github.com/sirupsen/logrus"
@@ -52,8 +54,7 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Check that s3 backend responds
-	s3URL := p.getS3ReadyPath()
-	err = p.httpsGetCheck(s3URL)
+	err = p.httpsGetCheck(p.getS3ReadyPath())
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -65,7 +66,6 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, _ *http.Request) {
 
 // httpsGetCheck sends a request to the S3 backend and makes sure it is healthy
 func (p *Proxy) httpsGetCheck(url string) error {
-
 	resp, e := p.client.Get(url)
 	if e != nil {
 		return e
@@ -81,10 +81,10 @@ func (p *Proxy) httpsGetCheck(url string) error {
 func (p *Proxy) getS3ReadyPath() string {
 	s3URL := p.s3.URL
 	if p.s3.Port != 0 {
-		s3URL = fmt.Sprintf("%s:%d", s3URL, p.s3.Port)
+		s3URL = path.Join(s3URL, strconv.Itoa(p.s3.Port))
 	}
 	if p.s3.Readypath != "" {
-		s3URL += p.s3.Readypath
+		s3URL += path.Join(s3URL, p.s3.Readypath)
 	}
 
 	return s3URL

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -1,114 +1,89 @@
 package main
 
 import (
-	"crypto/tls"
-	"database/sql"
 	"fmt"
 	"net/http"
-	"strconv"
-	"time"
 
-	"github.com/heptiolabs/healthcheck"
-	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	"github.com/neicnordic/sensitive-data-archive/internal/broker"
+	log "github.com/sirupsen/logrus"
 )
 
-// HealthCheck registers and endpoint for healthchecking the service
-type HealthCheck struct {
-	port       int
-	DB         *sql.DB
-	s3URL      string
-	brokerURL  string
-	tlsConfig  *tls.Config
-	serverCert string
-	serverKey  string
+// CheckHealth checks and tries to repair the connections to MQ, DB and S3
+func (p *Proxy) CheckHealth(w http.ResponseWriter, _ *http.Request) {
+
+	// try to connect to mq, check connection and channel
+	var err error
+	if p.messenger == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+
+		return
+	}
+	if p.messenger.IsConnClosed() {
+		log.Warning("connection is closed, reconnecting...")
+		p.messenger, err = broker.NewMQ(p.messenger.Conf)
+		if err != nil {
+			log.Warning(err)
+			w.WriteHeader(http.StatusServiceUnavailable)
+
+			return
+		}
+	}
+
+	if p.messenger.Channel.IsClosed() {
+		log.Warning("channel is closed, recreating...")
+		err := p.messenger.CreateNewChannel()
+		if err != nil {
+			log.Warning(err)
+			w.WriteHeader(http.StatusServiceUnavailable)
+
+			return
+		}
+	}
+	// Ping database, reconnect if there was a connection problem
+	err = p.database.DB.Ping()
+	if err != nil {
+		log.Errorf("Database connection problem: %v", err)
+		err = p.database.Connect()
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+
+			return
+		}
+	}
+
+	// Check that s3 backend responds
+	s3URL := p.getS3ReadyPath()
+	err = p.httpsGetCheck(s3URL)
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
-// NewHealthCheck creates a new healthchecker. It needs to know where to find
-// the backend S3 storage and the Message Broker so it can report readiness.
-func NewHealthCheck(port int, db *sql.DB, conf *config.Config, tlsConfig *tls.Config) *HealthCheck {
-	s3URL := conf.Inbox.S3.URL
-	if conf.Inbox.S3.Port != 0 {
-		s3URL = fmt.Sprintf("%s:%d", s3URL, conf.Inbox.S3.Port)
+// httpsGetCheck sends a request to the S3 backend and makes sure it is healthy
+func (p *Proxy) httpsGetCheck(url string) error {
+
+	resp, e := p.client.Get(url)
+	if e != nil {
+		return e
 	}
-	if conf.Inbox.S3.Readypath != "" {
-		s3URL += conf.Inbox.S3.Readypath
+	_ = resp.Body.Close() // ignoring error
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("returned status %d", resp.StatusCode)
 	}
 
-	brokerURL := fmt.Sprintf("%s:%d", conf.Broker.Host, conf.Broker.Port)
-
-	serverCert := conf.Server.Cert
-	serverKey := conf.Server.Key
-
-	return &HealthCheck{port, db, s3URL, brokerURL, tlsConfig, serverCert, serverKey}
+	return nil
 }
 
-// RunHealthChecks should be run as a go routine in the main app. It registers
-// the healthcheck handler on the port specified in when creating a new
-// healthcheck.
-func (h *HealthCheck) RunHealthChecks() {
-	health := healthcheck.NewHandler()
-
-	health.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(100))
-
-	health.AddReadinessCheck("S3-backend-http", h.httpsGetCheck(h.s3URL, 5000*time.Millisecond))
-
-	health.AddReadinessCheck("broker-tcp", healthcheck.TCPDialCheck(h.brokerURL, 5000*time.Millisecond))
-
-	health.AddReadinessCheck("database", healthcheck.DatabasePingCheck(h.DB, 1*time.Second))
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodHead {
-			// readyEndpoint does not accept method head
-			r.Method = http.MethodGet
-			health.ReadyEndpoint(w, r)
-		}
-	})
-	mux.HandleFunc("/health", health.ReadyEndpoint)
-
-	addr := ":" + strconv.Itoa(h.port)
-	server := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      5 * time.Second,
-		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 3 * time.Second,
+func (p *Proxy) getS3ReadyPath() string {
+	s3URL := p.s3.URL
+	if p.s3.Port != 0 {
+		s3URL = fmt.Sprintf("%s:%d", s3URL, p.s3.Port)
 	}
-	if h.serverCert != "" && h.serverKey != "" {
-		if err := server.ListenAndServeTLS(h.serverCert, h.serverKey); err != nil {
-			panic(err)
-		}
-	} else {
-		if err := server.ListenAndServe(); err != nil {
-			panic(err)
-		}
-	}
-}
-
-func (h *HealthCheck) httpsGetCheck(url string, timeout time.Duration) healthcheck.Check {
-	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
-	cfg.RootCAs = h.tlsConfig.RootCAs
-	tr := &http.Transport{TLSClientConfig: cfg}
-	client := http.Client{
-		Transport: tr,
-		Timeout:   timeout,
-		// never follow redirects
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	if p.s3.Readypath != "" {
+		s3URL += p.s3.Readypath
 	}
 
-	return func() error {
-		resp, e := client.Get(url)
-		if e != nil {
-			return e
-		}
-		_ = resp.Body.Close() // ignoring error
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("returned status %d", resp.StatusCode)
-		}
-
-		return nil
-	}
+	return s3URL
 }

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -35,9 +35,21 @@ func (suite *HealthcheckTestSuite) TearDownTest() {
 func (suite *HealthcheckTestSuite) TestHttpsGetCheck() {
 	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
 
-	url := p.getS3ReadyPath()
+	url, _ := p.getS3ReadyPath()
 	assert.NoError(suite.T(), p.httpsGetCheck(url))
 	assert.Error(suite.T(), p.httpsGetCheck("http://127.0.0.1:8888/nonexistent"), "404 should fail")
+}
+
+func (suite *HealthcheckTestSuite) TestS3URL() {
+	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
+
+	_, err := p.getS3ReadyPath()
+	assert.NoError(suite.T(), err)
+
+	p.s3.URL = "://badurl"
+	url, err := p.getS3ReadyPath()
+	assert.Empty(suite.T(), url)
+	assert.Error(suite.T(), err)
 }
 
 func (suite *HealthcheckTestSuite) TestHealthchecks() {

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -2,183 +2,112 @@ package main
 
 import (
 	"crypto/tls"
-	"fmt"
-	"io"
-	"log"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
-	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	"github.com/neicnordic/sensitive-data-archive/internal/broker"
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
+	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
 type HealthcheckTestSuite struct {
-	suite.Suite
+	ProxyTests
 }
 
-func TestHealthcheckTestSuite(t *testing.T) {
+func TestHealthTestSuite(t *testing.T) {
 	suite.Run(t, new(HealthcheckTestSuite))
 }
 
 func (suite *HealthcheckTestSuite) SetupTest() {
-	viper.Set("broker.host", "localhost")
-	viper.Set("broker.port", "8080")
-	viper.Set("broker.user", "guest")
-	viper.Set("broker.password", "guest")
-	viper.Set("broker.routingkey", "ingest")
-	viper.Set("broker.exchange", "sda")
-	viper.Set("broker.vhost", "sda")
-	viper.Set("inbox.url", "http://localhost:8080")
-	viper.Set("inbox.accesskey", "testaccess")
-	viper.Set("inbox.secretkey", "testsecret")
-	viper.Set("inbox.bucket", "testbucket")
-	viper.Set("server.jwtpubkeypath", "testpath")
+	// Reuse the setup from Proxy
+	suite.ProxyTests.SetupTest()
+}
+
+func (suite *HealthcheckTestSuite) TearDownTest() {
+	// Reuse the teardown from Proxy
+	suite.ProxyTests.TearDownTest()
 }
 
 func (suite *HealthcheckTestSuite) TestHttpsGetCheck() {
-	l, err := net.Listen("tcp", "127.0.0.1:9999")
-	if err != nil {
-		log.Fatal(err)
-	}
-	foo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	ts := httptest.NewUnstartedServer(foo)
-	ts.Listener.Close()
-	ts.Listener = l
-	ts.Start()
-	db, _, _ := sqlmock.New()
-	conf, err := config.NewConfig("s3inbox")
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), conf)
-	h := NewHealthCheck(8888,
-		db,
-		conf,
-		new(tls.Config))
+	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
 
-	assert.NoError(suite.T(), h.httpsGetCheck("http://127.0.0.1:9999", 10*time.Second)())
-	assert.Error(suite.T(), h.httpsGetCheck("http://127.0.0.1:8888/nonexistent", 5*time.Second)(), "404 should fail")
+	url := p.getS3ReadyPath()
+	assert.NoError(suite.T(), p.httpsGetCheck(url))
+	assert.Error(suite.T(), p.httpsGetCheck("http://127.0.0.1:8888/nonexistent"), "404 should fail")
 }
 
 func (suite *HealthcheckTestSuite) TestHealthchecks() {
-	l, err := net.Listen("tcp", "127.0.0.1:8080")
-	if err != nil {
-		log.Fatal(err)
-	}
-	foo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	ts := httptest.NewUnstartedServer(foo)
-	ts.Listener.Close()
-	ts.Listener = l
-	ts.Start()
-
-	db, mock, _ := sqlmock.New(sqlmock.MonitorPingsOption(true))
-	mock.ExpectPing()
-	conf, err := config.NewConfig("s3inbox")
+	// Setup
+	database, _ := database.NewSDAdb(suite.DBConf)
+	messenger, err := broker.NewMQ(suite.MQConf)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), conf)
-	h := NewHealthCheck(5555,
-		db,
-		conf,
-		new(tls.Config))
+	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
-	go h.RunHealthChecks()
+	w := httptest.NewRecorder()
+	p.CheckHealth(w, httptest.NewRequest(http.MethodGet, "https://dummy/health", nil))
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(suite.T(), 200, resp.StatusCode)
 
-	time.Sleep(100 * time.Millisecond)
-
-	res, err := http.Get("http://localhost:5555/ready?full=1")
-	if err != nil {
-		log.Fatal(err)
-	}
-	b, err := io.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		suite.T().Errorf("Response code was %v; want 200", res.StatusCode)
-		suite.T().Errorf("Response: %s", b)
-	}
-
-	// test head request
-	res, err = http.Head("http://localhost:5555")
-	res.Body.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		suite.T().Errorf("Response code was %v; want 200", res.StatusCode)
-	}
-
-	ts.Close()
 }
 
-func (suite *HealthcheckTestSuite) TestBadHealthchecks() {
-	l, err := net.Listen("tcp", "127.0.0.1:8080")
-	if err != nil {
-		log.Fatal(err)
-	}
-	foo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	ts := httptest.NewUnstartedServer(foo)
-	ts.Listener.Close()
-	ts.Listener = l
-	ts.Start()
-
-	db, mock, _ := sqlmock.New(sqlmock.MonitorPingsOption(true))
-	conf, err := config.NewConfig("s3inbox")
+func (suite *HealthcheckTestSuite) TestClosedDBHealthchecks() {
+	// Setup
+	database, _ := database.NewSDAdb(suite.DBConf)
+	messenger, err := broker.NewMQ(suite.MQConf)
 	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), conf)
-	h := NewHealthCheck(7777,
-		db,
-		conf,
-		new(tls.Config))
+	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
-	go h.RunHealthChecks()
+	// Check that 200 is reported
+	w := httptest.NewRecorder()
+	p.CheckHealth(w, httptest.NewRequest(http.MethodGet, "https://dummy/health", nil))
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(suite.T(), 200, resp.StatusCode)
 
-	time.Sleep(100 * time.Millisecond)
+	// Close connection to DB, check that connection is restored and 200 returned
+	w = httptest.NewRecorder()
+	p.database.Close()
+	p.CheckHealth(w, httptest.NewRequest(http.MethodGet, "https://dummy/health", nil))
+	resp = w.Result()
+	defer resp.Body.Close()
+	assert.Equal(suite.T(), 200, resp.StatusCode)
+}
 
-	// Mock DB failure, check that 503 is reported
-	mock.ExpectPing().WillReturnError(fmt.Errorf("dbDown"))
-	res, err := http.Head("http://localhost:7777")
-	res.Body.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
+func (suite *HealthcheckTestSuite) TestNoS3Healthchecks() {
+	// Setup
+	database, _ := database.NewSDAdb(suite.DBConf)
+	messenger, err := broker.NewMQ(suite.MQConf)
+	assert.NoError(suite.T(), err)
+	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
-	if res.StatusCode != http.StatusServiceUnavailable {
-		suite.T().Errorf("Response code was %v; want 503", res.StatusCode)
-	}
+	// S3 unavailable, check that 503 is reported
+	w := httptest.NewRecorder()
+	p.s3.URL = "http://badurl"
+	p.CheckHealth(w, httptest.NewRequest(http.MethodGet, "https://dummy/health", nil))
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(suite.T(), 503, resp.StatusCode)
+}
 
-	// DB fixed, check that 200 is reported
-	mock.ExpectPing()
+func (suite *HealthcheckTestSuite) TestNoMQHealthchecks() {
+	// Setup
+	database, _ := database.NewSDAdb(suite.DBConf)
+	messenger, err := broker.NewMQ(suite.MQConf)
+	assert.NoError(suite.T(), err)
+	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
-	res, err = http.Head("http://localhost:7777")
-	res.Body.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		suite.T().Errorf("Response code was %v; want 200", res.StatusCode)
-	}
-
-	// DB ok, s3 and broker down, check that 503 is reported
-	mock.ExpectPing()
-	ts.Close()
-
-	res, err = http.Head("http://localhost:7777")
-	res.Body.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-	if res.StatusCode != http.StatusServiceUnavailable {
-		suite.T().Errorf("Response code was %v; want 503", res.StatusCode)
-	}
-
+	// Messenger unavailable, check that 503 is reported
+	p.messenger.Conf.Port = 123456
+	p.messenger.Connection.Close()
+	assert.True(suite.T(), p.messenger.Connection.IsClosed())
+	w := httptest.NewRecorder()
+	p.CheckHealth(w, httptest.NewRequest(http.MethodGet, "https://dummy/health", nil))
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(suite.T(), 503, resp.StatusCode)
 }

--- a/sda/cmd/s3inbox/s3inbox.go
+++ b/sda/cmd/s3inbox/s3inbox.go
@@ -29,6 +29,7 @@ func main() {
 	// Create a function to handle panic and exit gracefully
 	defer func() {
 		if err := recover(); err != nil {
+			log.Errorf("Could not recover from %v", err)
 			log.Fatal("Could not recover, exiting")
 		}
 	}()

--- a/sda/cmd/s3inbox/s3inbox.go
+++ b/sda/cmd/s3inbox/s3inbox.go
@@ -99,12 +99,12 @@ func main() {
 			log.Panicf("Error while getting key %s: %v", Conf.Server.Jwtpubkeypath, err)
 		}
 	}
+	mux := http.NewServeMux()
 	proxy := NewProxy(Conf.Inbox.S3, auth, messenger, sdaDB, tlsProxy)
-
-	http.Handle("/", proxy)
-
-	hc := NewHealthCheck(8001, sdaDB.DB, Conf, tlsProxy)
-	go hc.RunHealthChecks()
+	//hc := NewHealthCheck(sdaDB.DB, Conf, messenger, tlsProxy)
+	mux.HandleFunc("HEAD /", proxy.CheckHealth)
+	mux.HandleFunc("/health", proxy.CheckHealth)
+	mux.Handle("/", proxy)
 
 	server := &http.Server{
 		Addr:              ":8000",


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR addresses #992.


**Description**
- The `/health` endpoint is put on the same port as s3inbox (ie. is run on the server started in `s3inbox.go`).
- Also a `HEAD` request to s3inbox will return the health status.
- If there are problems with the connection to MQ or DB while checking the health, `CheckHealth` attempts to restore it.
- Go tests updated
- Integration tests added
- The `/ready` and `/live` endpoints are removed
- The `/healthz` enpoint (provided by the charts) is removed 

If this is to be continue: create issues for updating charts etc reflect this change.

**How to test**
```curl 'localhost:18000' -H 'Authorization: Bearer $token' -I```
```curl 'localhost:18000/health' -H 'Authorization: Bearer $token'```