### PR TITLE
Ingest adds keyhash to files db table

### DIFF
--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -71,7 +71,7 @@ done
 
 # check that the files have key hashes assigned
 key_hashes="$(psql -U postgres -h postgres -d sda -At -c "select distinct key_hash from sda.files" | wc -l)"
-if [ "$key_hashes" -lt 0 ]; then
+if [ "$key_hashes" -eq 0 ]; then
 	echo "::error::Ingested files did not have any key hashes."
 	exit 1
 fi

--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -69,4 +69,11 @@ until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ |
     sleep 2
 done
 
+# check that the files have key hashes assigned
+key_hashes="$(psql -U postgres -h postgres -d sda -At -c "select distinct key_hash from sda.files" | wc -l)"
+if [ "$key_hashes" -lt 0 ]; then
+	echo "::error::Ingested files did not have any key hashes."
+	exit 1
+fi
+
 echo "ingestion and verification test completed successfully"

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -397,6 +397,9 @@ func main() {
 						err = db.SetKeyHash(keyhash, fileID)
 						if err != nil {
 							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
+							if err = delivered.Nack(false, true); err != nil {
+								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
+							}
 
 							continue mainWorkLoop
 						}

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -397,6 +397,8 @@ func main() {
 						err = db.SetKeyHash(keyhash, fileID)
 						if err != nil {
 							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
+
+							continue mainWorkLoop
 						}
 
 						log.Debugln("store header")

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/crypt4gh/model/headers"
 	"github.com/neicnordic/crypt4gh/streaming"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
@@ -386,6 +388,15 @@ func main() {
 							}
 
 							continue mainWorkLoop
+						}
+
+						// Set the file's hex encoded public key
+						log.Debugln("Compute and set key hash")
+						publicKey := keys.DerivePublicKey(*key)
+						keyhash := hex.EncodeToString(publicKey[:])
+						err = db.SetKeyHash(keyhash, fileID)
+						if err != nil {
+							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
 						}
 
 						log.Debugln("store header")

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -5,7 +5,6 @@ package database
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -788,14 +787,8 @@ func (dbs *SDAdb) SetKeyHash(keyHash, fileID string) error {
 	dbs.checkAndReconnectIfNeeded()
 	db := dbs.DB
 
-	query := `SELECT key_hash FROM sda.encryption_keys WHERE key_hash = $1;`
-	var hashID string
-	err := db.QueryRow(query, keyHash).Scan(&hashID)
-	if err != nil {
-		return fmt.Errorf("keyhash not present in database: %v", err)
-	}
-	query = "UPDATE sda.files SET key_hash = $1 WHERE id = $2;"
-	result, err := db.Exec(query, hashID, fileID)
+	query := "UPDATE sda.files SET key_hash = $1 WHERE id = $2;"
+	result, err := db.Exec(query, keyHash, fileID)
 	if err != nil {
 
 		return err

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -657,3 +657,43 @@ func (suite *DatabaseTests) TestAddKeyHash() {
 	assert.NoError(suite.T(), err, "failed to verify key hash existence")
 	assert.True(suite.T(), exists, "key hash was not added to the database")
 }
+
+func (suite *DatabaseTests) TestSetKeyHash() {
+	// Test that using an unknown key hash produces an error
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+	// Register a new key and a new file
+	keyHex := `6af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc507`
+	keyDescription := "this is a test key"
+	err = db.addKeyHash(keyHex, keyDescription)
+	assert.NoError(suite.T(), err, "failed to register key in database")
+	fileID, err := db.RegisterFile("/testuser/file1.c4gh", "testuser")
+	assert.NoError(suite.T(), err, "failed to register file in database")
+
+	// Test that the key hash can be set in the files table
+	err = db.SetKeyHash(keyHex, fileID)
+	assert.NoError(suite.T(), err, "Could not set key hash")
+
+	// Verify that the key+file was added
+	var exists bool
+	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.files WHERE key_hash=$1 AND id=$2)", keyHex, fileID).Scan(&exists)
+	assert.NoError(suite.T(), err, "failed to verify key hash set for file")
+	assert.True(suite.T(), exists, "key hash was not set for file in the database")
+}
+
+func (suite *DatabaseTests) TestSetKeyHash_wrongHash() {
+	// Add key hash and file
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+	keyHex := "6af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc501"
+	keyDescription := "this is a test hash"
+	err = db.addKeyHash(keyHex, keyDescription)
+	assert.NoError(suite.T(), err, "failed to register key in database")
+	fileID, err := db.RegisterFile("/testuser/file2.c4gh", "testuser")
+	assert.NoError(suite.T(), err, "failed to register file in database")
+
+	// Ensure failure if a non existing hash is used
+	newKeyHex := "6af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc502"
+	err = db.SetKeyHash(newKeyHex, fileID)
+	assert.ErrorContains(suite.T(), err, "violates foreign key constraint")
+}


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #893.
It will be undrafted when #1036 is closed.

Commit [tmp: temporary fixes to api/hash](ceecb05)  will not be included in the final version of this PR.


**Description**
- ingest hex encodes the user's public key and adds it to the files info in the `sda.files` table
- if the keyhash is not in the `sda.encryption_keys`, an error is thrown and ingest stops
- code test and integration test are added

**How to test**
Add the hashed public key to `sda.encryption_keys` and then try to ingest a file. See the [integration test](28be1c) for details.