### PR TITLE
[ingest] fix: prevent endless logging from finalize

### DIFF
--- a/sda/cmd/finalize/finalize.go
+++ b/sda/cmd/finalize/finalize.go
@@ -110,6 +110,11 @@ func main() {
 			case "enabled":
 			case "ready":
 				log.Infof("File with correlation ID %s is already marked as ready.", delivered.CorrelationId)
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("Failed acking message, reason: %v", err)
+				}
+
+				continue
 			default:
 				log.Warnf("file with correlation ID: %s is not verified yet, stopping work", delivered.CorrelationId)
 				if err := delivered.Nack(false, true); err != nil {

--- a/sda/cmd/finalize/finalize.go
+++ b/sda/cmd/finalize/finalize.go
@@ -108,6 +108,8 @@ func main() {
 
 			case "verified":
 			case "enabled":
+			case "ready":
+				log.Infof("File with correlation ID %s is already marked as ready.", delivered.CorrelationId)
 			default:
 				log.Warnf("file with correlation ID: %s is not verified yet, stopping work", delivered.CorrelationId)
 				if err := delivered.Nack(false, true); err != nil {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1027 .

**Description**
Added missing case in switch, to make the second call to `set-accession` finish and not loop infinitely. The fact that the accession id is already set, will later be caught by [another check](https://github.com/neicnordic/sensitive-data-archive/blob/cc203cf1f9ba647c75f83b2be818047023880544/sda/cmd/finalize/finalize.go#L177) and (hopefully) handled as intended there.



**How to test**
1. At the root of the repo, start the stack by running 
```
make build-all
PR_NUMBER=$(/usr/bin/date '+%F')  docker compose -f .github/integration/sda-s3-integration.yml run integration_test
```
2. Set the ENVs by 
```
export ACCESS_TOKEN=$(curl -s -k http://localhost:8080/tokens | jq -r '.[0]')
export API_HOST=http://localhost:8090
```
3 . Ingest a file and set the accession id twice
```
./sda-admin file ingest --filepath requester_demo.org/data/file1.c4gh --user requester@demo.org
./sda-admin file set-accession --filepath requester_demo.org/data/file1.c4gh  --user requester@demo.org   --accession-id my-id1 
./sda-admin file set-accession --filepath requester_demo.org/data/file1.c4gh  --user requester@demo.org   --accession-id my-id1 
```
4. Make sure the logs look ok and that the file's status in the db is good.