### PR TITLE
[auth] save userinfo to db

### DIFF
--- a/.github/integration/scripts/make_db_credentials.sh
+++ b/.github/integration/scripts/make_db_credentials.sh
@@ -4,7 +4,7 @@ set -e
 apt-get -o DPkg::Lock::Timeout=60 update > /dev/null
 apt-get -o DPkg::Lock::Timeout=60 install -y postgresql-client >/dev/null
 
-for n in api download finalize inbox ingest mapper sync verify; do
+for n in api auth download finalize inbox ingest mapper sync verify; do
     echo "creating credentials for: $n"
     psql -U postgres -h migrate -d sda -c "ALTER ROLE $n LOGIN PASSWORD '$n';"
     psql -U postgres -h postgres -d sda -c "ALTER ROLE $n LOGIN PASSWORD '$n';"

--- a/.github/integration/scripts/make_sda_credentials.sh
+++ b/.github/integration/scripts/make_sda_credentials.sh
@@ -14,7 +14,7 @@ apt-get -o DPkg::Lock::Timeout=60 install -y curl jq openssh-client openssl post
 pip install --upgrade pip > /dev/null
 pip install aiohttp Authlib joserfc requests > /dev/null
 
-for n in api download finalize inbox ingest mapper sync verify; do
+for n in api auth download finalize inbox ingest mapper sync verify; do
     echo "creating credentials for: $n"
     psql -U postgres -h postgres -d sda -c "ALTER ROLE $n LOGIN PASSWORD '$n';"
     psql -U postgres -h postgres -d sda -c "GRANT base TO $n;"

--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -302,10 +302,14 @@ services:
     depends_on:
       cega-nss:
         condition: service_started
+      postgres:
+        condition: service_healthy
     environment:
       - AUTH_RESIGNJWT=true
       - AUTH_CEGA_ID=test
       - AUTH_CEGA_SECRET=test
+      - DB_PASSWORD=auth
+      - DB_USER=auth
     image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
     ports:
       - "8888:8080"
@@ -318,12 +322,16 @@ services:
     command: [ sda-auth ]
     container_name: auth-oidc
     depends_on:
+      postgres:
+        condition: service_healthy
       oidc:
         condition: service_healthy
     environment:
       - AUTH_RESIGNJWT=false
       - OIDC_ID=XC56EL11xx
       - OIDC_SECRET=wHPVQaYXmdDHg
+      - DB_PASSWORD=api
+      - DB_USER=api
     image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
     ports:
       - "8889:8080"

--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -330,8 +330,8 @@ services:
       - AUTH_RESIGNJWT=false
       - OIDC_ID=XC56EL11xx
       - OIDC_SECRET=wHPVQaYXmdDHg
-      - DB_PASSWORD=api
-      - DB_USER=api
+      - DB_PASSWORD=auth
+      - DB_USER=auth
     image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
     ports:
       - "8889:8080"

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -177,6 +177,8 @@ Parameter | Description | Default
 `credentials.api.dbUser` | Database user for api | `""`
 `credentials.api.dbPassword` | Database password for api | `""`
 `credentials.api.mqUser` | Broker user for api | `""`
+`credentials.auth.dbUser` | Database user for auth | `""`
+`credentials.auth.dbPassword` | Database password for auth | `""`
 `credentials.api.mqPassword` | Broker password for api | `""`
 `credentials.doa.dbUser` | Database user for doa | `""`
 `credentials.doa.dbPassword` | Database password for doa| `""`

--- a/charts/sda-svc/templates/_helpers.yaml
+++ b/charts/sda-svc/templates/_helpers.yaml
@@ -148,6 +148,14 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/**/}}
+{{- define "dbUserAuth" -}}
+{{- ternary .Values.global.db.user .Values.credentials.auth.dbUser (empty .Values.credentials.auth.dbUser) -}}
+{{- end -}}
+{{- define "dbPassAuth" -}}
+{{- ternary .Values.global.db.password .Values.credentials.auth.dbPassword (empty .Values.credentials.auth.dbPassword) -}}
+{{- end -}}
+
+{{/**/}}
 {{- define "dbUserSync" -}}
 {{- ternary .Values.global.db.user .Values.credentials.sync.dbUser (empty .Values.credentials.sync.dbUser) -}}
 {{- end -}}

--- a/charts/sda-svc/templates/auth-certificate.yaml
+++ b/charts/sda-svc/templates/auth-certificate.yaml
@@ -20,6 +20,7 @@ spec:
     size: 256
   usages:
     - server auth
+    - client auth
   # At least one of a DNS Name, URI, or IP address is required.
   dnsNames:
     - {{ template "sda.fullname" . }}-auth

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -159,6 +159,37 @@ spec:
         - name: SERVER_KEY
           value: {{ template "tlsPath" . }}/tls.key
         {{- end }}
+    {{- if .Values.global.tls.enabled }}
+        - name: DB_CACERT
+          value: {{ include "tlsPath" . }}/ca.crt
+        {{- if ne "verify-none" .Values.global.db.sslMode }}
+        - name: DB_CLIENTCERT
+          value: {{ include "tlsPath" . }}/tls.crt
+        - name: DB_CLIENTKEY
+          value: {{ include "tlsPath" . }}/tls.key
+        {{- end }}
+        - name: DB_SSLMODE
+          value: {{ .Values.global.db.sslMode | quote }}
+    {{- else }}
+        - name: DB_SSLMODE
+          value: "disable"
+    {{- end }}
+        - name: DB_PASSWORD
+          valueFrom:
+              secretKeyRef:
+                name: {{ template "sda.fullname" . }}-api
+                key: dbPassword
+        - name: DB_USER
+          valueFrom:
+              secretKeyRef:
+                name: {{ template "sda.fullname" . }}-api
+                key: dbUser
+        - name: DB_DATABASE
+          value: {{ default "lega" .Values.global.db.name | quote }}
+        - name: DB_HOST
+          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
+        - name: DB_PORT
+          value: {{ .Values.global.db.port | quote }}
         ports:
         - name: auth
           containerPort: 8080

--- a/charts/sda-svc/templates/auth-secrets.yaml
+++ b/charts/sda-svc/templates/auth-secrets.yaml
@@ -15,6 +15,8 @@ data:
   cegaID: {{ .Values.global.cega.user | quote | trimall "\"" | b64enc }}
   cegaSecret: {{ .Values.global.cega.password | quote | trimall "\"" | b64enc }}
   {{- end }}
+  dbPassword: {{ required "DB password is required" (include "dbPassAuth" .) | b64enc }}
+  dbUser: {{ required "DB user is required" (include "dbUserAuth" .) | b64enc }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -300,6 +300,10 @@ credentials:
     mqUser: ""
     mqPassword: ""
 
+  auth:
+    dbUser: ""
+    dbPassword: ""
+
   doa:
     dbUser: ""
     dbPassword: ""

--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -27,7 +27,8 @@ VALUES (0, now(), 'Created with version'),
        (10, now(), 'Create Inbox user'),
        (11, now(), 'Grant select permission to download on dataset_event_log'),
        (12, now(), 'Add key hash'),
-       (13, now(), 'Create API user');
+       (13, now(), 'Create API user'),
+       (14, now(), 'Create Auth user');
 
 -- Datasets are used to group files, and permissions are set on the dataset
 -- level

--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -74,6 +74,14 @@ CREATE TABLE files (
     CONSTRAINT unique_ingested UNIQUE(submission_file_path, archive_file_path)
 );
 
+-- The user info is used by auth to be able to link users to their name and email
+CREATE TABLE userinfo (
+    id                  TEXT PRIMARY KEY,
+    name                TEXT,
+    email               TEXT,
+    groups              TEXT[]
+);
+
 -- To allow for multiple checksums per file, we use a dedicated table for it
 CREATE TABLE checksums (
     id                  SERIAL PRIMARY KEY,

--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -170,6 +170,7 @@ GRANT SELECT ON sda.datasets TO api;
 GRANT SELECT ON sda.dataset_event_log TO api;
 GRANT INSERT ON sda.encryption_keys TO api;
 GRANT UPDATE ON sda.encryption_keys TO api;
+GRANT SELECT, INSERT, UPDATE ON sda.userinfo TO download;
 
 -- legacy schema
 GRANT USAGE ON SCHEMA local_ega TO api;

--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -180,7 +180,7 @@ GRANT SELECT ON local_ega_ebi.file_dataset TO api;
 
 --------------------------------------------------------------------------------
 CREATE ROLE auth;
-GRANT USAGE ON SCHEMA sda TO api;
+GRANT USAGE ON SCHEMA sda TO auth;
 GRANT SELECT, INSERT, UPDATE ON sda.userinfo TO auth;
 --------------------------------------------------------------------------------
 

--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -170,7 +170,6 @@ GRANT SELECT ON sda.datasets TO api;
 GRANT SELECT ON sda.dataset_event_log TO api;
 GRANT INSERT ON sda.encryption_keys TO api;
 GRANT UPDATE ON sda.encryption_keys TO api;
-GRANT SELECT, INSERT, UPDATE ON sda.userinfo TO download;
 
 -- legacy schema
 GRANT USAGE ON SCHEMA local_ega TO api;
@@ -180,10 +179,15 @@ GRANT SELECT ON local_ega_ebi.file TO api;
 GRANT SELECT ON local_ega_ebi.file_dataset TO api;
 
 --------------------------------------------------------------------------------
+CREATE ROLE auth;
+GRANT USAGE ON SCHEMA sda TO api;
+GRANT SELECT, INSERT, UPDATE ON sda.userinfo TO auth;
+--------------------------------------------------------------------------------
+
 -- lega_in permissions
 GRANT base, ingest, verify, finalize, sync, api TO lega_in;
 
 -- lega_out permissions
 GRANT mapper, download, api TO lega_out;
 
-GRANT base TO api, download, inbox, ingest, finalize, mapper, verify
+GRANT base TO api, download, inbox, ingest, finalize, mapper, verify, auth;

--- a/postgresql/migratedb.d/14.sql
+++ b/postgresql/migratedb.d/14.sql
@@ -40,7 +40,7 @@ BEGIN
     GRANT USAGE ON SCHEMA sda TO auth;
     GRANT SELECT, INSERT, UPDATE ON sda.userinfo TO auth;
 
-    GRANT base TO api, download, inbox, ingest, finalize, mapper, verify, auth;
+    GRANT base TO auth;
   ELSE
     RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
   END IF;

--- a/postgresql/migratedb.d/14.sql
+++ b/postgresql/migratedb.d/14.sql
@@ -36,6 +36,11 @@ BEGIN
         groups      TEXT[]
     );
 
+    PERFORM create_role_if_not_exists('auth');
+    GRANT USAGE ON SCHEMA sda TO auth;
+    GRANT SELECT, INSERT, UPDATE ON sda.userinfo TO auth;
+
+    GRANT base TO api, download, inbox, ingest, finalize, mapper, verify, auth;
   ELSE
     RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
   END IF;

--- a/postgresql/migratedb.d/14.sql
+++ b/postgresql/migratedb.d/14.sql
@@ -1,0 +1,43 @@
+DO
+$$
+DECLARE
+-- The version we know how to do migration from, at the end of a successful migration
+-- we will no longer be at this version.
+  sourcever INTEGER := 13;
+  changes VARCHAR := 'Add userinfo and create AUTH user';
+BEGIN
+  IF (select max(version) from sda.dbschema_version) = sourcever then
+    RAISE NOTICE 'Doing migration from schema version % to %', sourcever, sourcever+1;
+    RAISE NOTICE 'Changes: %', changes;
+    INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
+
+    -- Temporary function for creating roles if they do not already exist.
+    CREATE FUNCTION create_role_if_not_exists(role_name NAME) RETURNS void AS $created$
+    BEGIN
+        IF EXISTS (
+            SELECT FROM pg_catalog.pg_roles
+            WHERE  rolname = role_name) THEN
+                RAISE NOTICE 'Role "%" already exists. Skipping.', role_name;
+        ELSE
+            BEGIN
+                EXECUTE format('CREATE ROLE %I', role_name);
+            EXCEPTION
+                WHEN duplicate_object THEN
+                    RAISE NOTICE 'Role "%" was just created by a concurrent transaction. Skipping.', role_name;
+            END;
+        END IF;
+    END;
+    $created$ LANGUAGE plpgsql;
+
+    CREATE TABLE IF NOT EXISTS sda.userinfo (
+        id          TEXT PRIMARY KEY,
+        name        TEXT,
+        email       TEXT,
+        groups      TEXT[]
+    );
+
+  ELSE
+    RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
+  END IF;
+END
+$$

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kataras/iris/v12/sessions"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
@@ -263,13 +264,17 @@ func (auth AuthHandler) elixirLogin(ctx iris.Context) *OIDCData {
 
 		return nil
 	}
+	err = auth.Config.DB.UpdateUserInfo(idStruct.User, idStruct.Profile, idStruct.Email, idStruct.EdupersonEntitlement)
+	if err != nil {
+		log.Warnf("Could not log user info for %s (%s, %s)", idStruct.User, idStruct.Name, idStruct.Email)
+	}
 
 	if auth.Config.ResignJwt {
 		claims := map[string]interface{}{
 			jwt.ExpirationKey: time.Now().UTC().Add(time.Duration(auth.Config.JwtTTL) * time.Hour),
 			jwt.IssuedAtKey:   time.Now().UTC(),
 			jwt.IssuerKey:     auth.Config.JwtIssuer,
-			jwt.SubjectKey:    idStruct.User,
+			jwt.SubjectKey:    idStruct.Profile,
 		}
 		token, expDate, err := generateJwtToken(claims, auth.Config.JwtPrivateKey, auth.Config.JwtSignatureAlg)
 		if err != nil {
@@ -418,6 +423,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to read public key: %s", err.Error())
 	}
+
+	// Connect to DB
+	config.Auth.DB, err = database.NewSDAdb(config.Database)
+	if err != nil {
+		log.Error(err)
+		panic(err)
+	}
+	if config.Auth.DB.Version < 8 {
+		log.Error("database schema v8 is required")
+		panic(err)
+	}
+	defer config.Auth.DB.Close()
 
 	// Endpoint for client login info
 	app.Get("/info", authHandler.getInfo)

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -412,7 +412,6 @@ func main() {
 		log.Error("database schema v14 is required")
 		panic(err)
 	}
-	defer authHandler.Config.DB.Close()
 
 	app.RegisterView(iris.HTML(authHandler.htmlDir, ".html"))
 	app.HandleDir("/public", iris.Dir(authHandler.staticDir))
@@ -438,6 +437,8 @@ func main() {
 
 	// Endpoint for client login info
 	app.Get("/info", authHandler.getInfo)
+
+	defer authHandler.Config.DB.Close() // needs to be after Fatalf
 
 	app.UseGlobal(globalHeaders)
 

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -266,7 +266,7 @@ func (auth AuthHandler) elixirLogin(ctx iris.Context) *OIDCData {
 	}
 	err = auth.Config.DB.UpdateUserInfo(idStruct.User, idStruct.Profile, idStruct.Email, idStruct.EdupersonEntitlement)
 	if err != nil {
-		log.Warnf("Could not log user info for %s (%s, %s)", idStruct.User, idStruct.Name, idStruct.Email)
+		log.Warn("Could not log user info.")
 	}
 
 	if auth.Config.ResignJwt {
@@ -412,6 +412,7 @@ func main() {
 		log.Error("database schema v14 is required")
 		panic(err)
 	}
+	defer authHandler.Config.DB.Close()
 
 	app.RegisterView(iris.HTML(authHandler.htmlDir, ".html"))
 	app.HandleDir("/public", iris.Dir(authHandler.staticDir))
@@ -432,13 +433,11 @@ func main() {
 
 	authHandler.pubKey, err = readPublicKeyFile(authHandler.Config.PublicFile)
 	if err != nil {
-		log.Fatalf("Failed to read public key: %s", err.Error())
+		log.Panicf("Failed to read public key: %s", err.Error())
 	}
 
 	// Endpoint for client login info
 	app.Get("/info", authHandler.getInfo)
-
-	defer authHandler.Config.DB.Close() // needs to be after Fatalf
 
 	app.UseGlobal(globalHeaders)
 

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -402,6 +402,18 @@ func main() {
 
 	app.Use(sess.Handler())
 
+	// Connect to DB
+	authHandler.Config.DB, err = database.NewSDAdb(config.Database)
+	if err != nil {
+		log.Error(err)
+		panic(err)
+	}
+	if authHandler.Config.DB.Version < 14 {
+		log.Error("database schema v14 is required")
+		panic(err)
+	}
+	defer authHandler.Config.DB.Close()
+
 	app.RegisterView(iris.HTML(authHandler.htmlDir, ".html"))
 	app.HandleDir("/public", iris.Dir(authHandler.staticDir))
 
@@ -423,18 +435,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to read public key: %s", err.Error())
 	}
-
-	// Connect to DB
-	config.Auth.DB, err = database.NewSDAdb(config.Database)
-	if err != nil {
-		log.Error(err)
-		panic(err)
-	}
-	if config.Auth.DB.Version < 14 {
-		log.Error("database schema v14 is required")
-		panic(err)
-	}
-	defer config.Auth.DB.Close()
 
 	// Endpoint for client login info
 	app.Get("/info", authHandler.getInfo)

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -430,8 +430,8 @@ func main() {
 		log.Error(err)
 		panic(err)
 	}
-	if config.Auth.DB.Version < 8 {
-		log.Error("database schema v8 is required")
+	if config.Auth.DB.Version < 14 {
+		log.Error("database schema v14 is required")
 		panic(err)
 	}
 	defer config.Auth.DB.Close()

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -114,6 +114,7 @@ type OrchestratorConf struct {
 
 type AuthConf struct {
 	OIDC            OIDCConfig
+	DB              *database.SDAdb
 	Cega            CegaConfig
 	JwtIssuer       string
 	JwtPrivateKey   string
@@ -218,6 +219,11 @@ func NewConfig(app string) (*Config, error) {
 		requiredConfVars = []string{
 			"auth.s3Inbox",
 			"auth.publicFile",
+			"db.host",
+			"db.port",
+			"db.user",
+			"db.password",
+			"db.database",
 		}
 
 		if viper.GetString("auth.cega.id") != "" && viper.GetString("auth.cega.secret") != "" {
@@ -531,6 +537,10 @@ func NewConfig(app string) (*Config, error) {
 		}
 
 		c.Auth.S3Inbox = viper.GetString("auth.s3Inbox")
+		err := c.configDatabase()
+		if err != nil {
+			return nil, err
+		}
 	case "finalize":
 		if viper.GetString("archive.type") != "" && viper.GetString("backup.type") != "" {
 			c.configArchive()

--- a/sda/internal/database/database.go
+++ b/sda/internal/database/database.go
@@ -8,9 +8,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	// Needed implicitly to enable Postgres driver
-	_ "github.com/lib/pq"
 )
 
 // DBConf stores information about how to connect to the database backend

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -926,4 +927,36 @@ func (dbs *SDAdb) ListUserDatasets(submissionUser string) ([]DatasetInfo, error)
 	rows.Close()
 
 	return datasets, nil
+}
+
+func (dbs *SDAdb) UpdateUserInfo(userID, name, email string, groups []string) error {
+	var (
+		err   error
+		count int
+	)
+
+	for count == 0 || (err != nil && count < RetryTimes) {
+		err = dbs.updateUserInfo(userID, name, email, groups)
+		count++
+	}
+
+	return err
+}
+func (dbs *SDAdb) updateUserInfo(userID, name, email string, groups []string) error {
+	dbs.checkAndReconnectIfNeeded()
+
+	db := dbs.DB
+	const query = "INSERT INTO sda.userinfo(id, name, email, groups) VALUES($1, $2, $3, $4)" +
+		"ON CONFLICT (id)" +
+		"DO UPDATE SET name = excluded.name, email = excluded.email, groups = excluded.groups;"
+
+	result, err := db.Exec(query, userID, name, email, pq.Array(groups))
+	if err != nil {
+		return err
+	}
+	if rowsAffected, _ := result.RowsAffected(); rowsAffected == 0 {
+		return errors.New("something went wrong with the query zero rows were changed")
+	}
+
+	return nil
 }

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -932,27 +932,6 @@ func (suite *DatabaseTests) TestListUserDatasets() {
 	assert.Equal(suite.T(), "test-user-dataset-01", datasets[0].DatasetID)
 }
 
-func (suite *DatabaseTests) TestInsertUserInfo() {
-	db, err := NewSDAdb(suite.dbConf)
-	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
-
-	// Verify that a user can be inserted
-	var groups []string
-	userID, name, email := "12334556testuser@lifescience.ru", "Test User", "test.user@example.org"
-	err = db.UpdateUserInfo(userID, name, email, groups)
-	assert.NoError(suite.T(), err, "could not insert user info: %v", err)
-	var exists bool
-	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.userinfo WHERE id=$1)", userID).Scan(&exists)
-	assert.NoError(suite.T(), err, "failed to verify user info existence")
-	assert.True(suite.T(), exists, "user info was not added to the database")
-
-	// Insert new information about the user
-	groups = append(groups, "appleGroup", "bananaGroup")
-	name = "newName"
-	err = db.UpdateUserInfo(userID, name, email, groups)
-	assert.NoError(suite.T(), err, "could not insert updated user info: %v", err)
-}
-
 func (suite *DatabaseTests) TestUpdateUserInfo() {
 	db, err := NewSDAdb(suite.dbConf)
 	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
@@ -962,15 +941,43 @@ func (suite *DatabaseTests) TestUpdateUserInfo() {
 	userID, name, email := "12334556testuser@lifescience.ru", "Test User", "test.user@example.org"
 	err = db.UpdateUserInfo(userID, name, email, groups)
 	assert.NoError(suite.T(), err, "could not insert user info: %v", err)
-	// Verify that the userID is connected to the new details
+	// Verify that the userID is connected to the details
 	var numRows int
 	err = db.DB.QueryRow("SELECT COUNT(*) FROM sda.userinfo WHERE id=$1", userID).Scan(&numRows)
 	assert.NoError(suite.T(), err, "could select user info: %v", err)
 	assert.Equal(suite.T(), 1, numRows, "there should be exactly 1 row about %v in userinfo table", userID)
 	var name2 string
-	var groups2 []string
-	err = db.DB.QueryRow("SELECT name, groups FROM sda.userinfo WHERE id=$1", userID).Scan(&name2, pq.Array(&groups2))
-	assert.NoError(suite.T(), err, "could select user info: %v", err)
+	err = db.DB.QueryRow("SELECT name FROM sda.userinfo WHERE id=$1", userID).Scan(&name2)
+	assert.NoError(suite.T(), err, "could not select user info: %v", err)
 	assert.Equal(suite.T(), name, name2, "user info table did not update correctly")
-	assert.Equal(suite.T(), groups, groups2, "user info table did not update correctly")
+}
+
+func (suite *DatabaseTests) TestUpdateUserInfo_newInfo() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	// Insert a user
+	var groups []string
+	userID, name, email := "12334556testuser@lifescience.ru", "Test User", "test.user@example.org"
+	err = db.UpdateUserInfo(userID, name, email, groups)
+	assert.NoError(suite.T(), err, "could not insert user info: %v", err)
+	var exists bool
+	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.userinfo WHERE id=$1)", userID).Scan(&exists)
+	assert.NoError(suite.T(), err, "failed to verify user info existence")
+	assert.True(suite.T(), exists, "user info was not added to the database")
+
+	// Insert new information about the user and verify that there is still only 1 row,
+	// and that this row is updated
+	var numRows int
+	err = db.DB.QueryRow("SELECT COUNT(*) FROM sda.userinfo WHERE id=$1", userID).Scan(&numRows)
+	assert.NoError(suite.T(), err, "could not verify db count", err)
+	assert.Equal(suite.T(), 1, numRows, "there should be exactly one row in userinfo")
+	var dbgroups []string
+	groups = append(groups, "appleGroup", "bananaGroup")
+	name = "newName"
+	err = db.UpdateUserInfo(userID, name, email, groups)
+	assert.NoError(suite.T(), err, "could not insert updated user info: %v", err)
+	err = db.DB.QueryRow("SELECT groups FROM sda.userinfo WHERE id=$1", userID).Scan(pq.Array(&dbgroups))
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), groups, dbgroups)
 }

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -929,4 +930,47 @@ func (suite *DatabaseTests) TestListUserDatasets() {
 	assert.NoError(suite.T(), err, "got (%v) when listing datasets for a user", err)
 	assert.Equal(suite.T(), 2, len(datasets))
 	assert.Equal(suite.T(), "test-user-dataset-01", datasets[0].DatasetID)
+}
+
+func (suite *DatabaseTests) TestInsertUserInfo() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	// Verify that a user can be inserted
+	var groups []string
+	userID, name, email := "12334556testuser@lifescience.ru", "Test User", "test.user@example.org"
+	err = db.UpdateUserInfo(userID, name, email, groups)
+	assert.NoError(suite.T(), err, "could not insert user info: %v", err)
+	var exists bool
+	err = db.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.userinfo WHERE id=$1)", userID).Scan(&exists)
+	assert.NoError(suite.T(), err, "failed to verify user info existence")
+	assert.True(suite.T(), exists, "user info was not added to the database")
+
+	// Insert new information about the user
+	groups = append(groups, "appleGroup", "bananaGroup")
+	name = "newName"
+	err = db.UpdateUserInfo(userID, name, email, groups)
+	assert.NoError(suite.T(), err, "could not insert updated user info: %v", err)
+}
+
+func (suite *DatabaseTests) TestUpdateUserInfo() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	// Insert a userID
+	var groups []string
+	userID, name, email := "12334556testuser@lifescience.ru", "Test User", "test.user@example.org"
+	err = db.UpdateUserInfo(userID, name, email, groups)
+	assert.NoError(suite.T(), err, "could not insert user info: %v", err)
+	// Verify that the userID is connected to the new details
+	var numRows int
+	err = db.DB.QueryRow("SELECT COUNT(*) FROM sda.userinfo WHERE id=$1", userID).Scan(&numRows)
+	assert.NoError(suite.T(), err, "could select user info: %v", err)
+	assert.Equal(suite.T(), 1, numRows, "there should be exactly 1 row about %v in userinfo table", userID)
+	var name2 string
+	var groups2 []string
+	err = db.DB.QueryRow("SELECT name, groups FROM sda.userinfo WHERE id=$1", userID).Scan(&name2, pq.Array(&groups2))
+	assert.NoError(suite.T(), err, "could select user info: %v", err)
+	assert.Equal(suite.T(), name, name2, "user info table did not update correctly")
+	assert.Equal(suite.T(), groups, groups2, "user info table did not update correctly")
 }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes https://github.com/NBISweden/LocalEGA-SE-Deployment/issues/525.


**Description**
- a db user for auth is added
- auth connects to the db
- auth saves information about the user on oidc logins
- if the user logs in again, the old info is overwritten

**How to test**
- Use `starter-kit-storage-and-interfaces`, branch `feature/auth-add-userinfo-to-db` together with `starter-kit-lsaai-mock`, as described in the [Readme](https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces/tree/feature/auth-add-userinfo-to-db?tab=readme-ov-file#starter-kit-storage-and-interfaces).
- Visit http://localhost:8085/ from your browser and log in.
- Check that the logged in user's info is added to the db: `docker exec -it postgres psql postgresql://postgres:rootpass@postgres/sda -At -c "select * from sda.userinfo"`

**Extra info**
I will be away next week, so I put the code here, in case someone wants to take care of it. It's working when tested manually with lsaai-mock, but there are no integration tests and also no unit tests for auth. Adding integration tests is not very straight forward, though, so it might be out of scope for this issue.
Also the chart tests fail, but that might be unrelated to this PR.