### PR TITLE
[postgres] add missing entry from dbschema_version

### DIFF
--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -26,7 +26,8 @@ VALUES (0, now(), 'Created with version'),
        (9, now(), 'Add dataset event log'),
        (10, now(), 'Create Inbox user'),
        (11, now(), 'Grant select permission to download on dataset_event_log'),
-       (12, now(), 'Add key hash');
+       (12, now(), 'Add key hash'),
+       (13, now(), 'Create API user');
 
 -- Datasets are used to group files, and permissions are set on the dataset
 -- level


### PR DESCRIPTION
**Description**
This PR adds a missing entry from the `dbschema_version` table.
This should have been part of PR #1084 