### PR TITLE
[Actions] Cache Trivy DBs in the repo

### DIFF
--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -106,6 +106,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner on postgres
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
         with:
           image-ref: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}-postgres
           format: "sarif"
@@ -121,6 +124,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner on rabbitmq
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
         with:
           image-ref: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}-rabbitmq
           format: "sarif"
@@ -167,6 +173,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner on sftp-inbox
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
         with:
           image-ref: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}-sftp-inbox
           format: "sarif"

--- a/.github/workflows/update_trivy_cache.yml
+++ b/.github/workflows/update_trivy_cache.yml
@@ -1,0 +1,37 @@
+name: Update Trivy Cache
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
**Description**
There is an issue with rate limiting that generates false failures in the actions because the vulnerability database can not be downloaded.
This PR caches the databases in the repo so they doesn't have to be downloaded on every run.
The vulnerability databases are updated daily at midnight.