### PR TITLE
[API] enable re-verification of a file

### DIFF
--- a/.github/integration/sda/rbac.json
+++ b/.github/integration/sda/rbac.json
@@ -6,6 +6,11 @@
           "action": "(GET)|(POST)|(PUT)"
        },
        {
+         "role": "admin",
+         "path": "/file/verify/:accession",
+         "action": "PUT"
+      },
+       {
          "role": "submission",
          "path": "/datasets/*",
          "action": "GET"

--- a/.github/integration/tests/sda/60_api_admin_test.sh
+++ b/.github/integration/tests/sda/60_api_admin_test.sh
@@ -8,3 +8,17 @@ if [ "$result" -ne 2 ]; then
     echo "expected 4 got $result"
     exit 1
 fi
+
+## trigger re-verification of EGAF74900000001
+resp="$(curl -s -k -L -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token" -X PUT "http://api:8080/file/verify/EGAF74900000001")"
+if [ "$resp" != "200" ]; then
+	echo "Error when starting re-verification, expected 200 got: $resp"
+	exit 1
+fi
+
+## failure on wrong accession ID
+resp="$(curl -s -k -L -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token" -X PUT "http://api:8080/file/verify/EGAF74900054321")"
+if [ "$resp" != "404" ]; then
+	echo "Error when starting re-verification, expected 404 got: $resp"
+	exit 1
+fi

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -262,7 +262,7 @@ func ingestFile(c *gin.Context) {
 		return
 	}
 
-	corrID, err := Conf.API.DB.GetCorrID(ingest.User, ingest.FilePath)
+	corrID, err := Conf.API.DB.GetCorrID(ingest.User, ingest.FilePath, "")
 	if err != nil {
 		switch {
 		case corrID == "":
@@ -298,7 +298,7 @@ func setAccession(c *gin.Context) {
 		return
 	}
 
-	corrID, err := Conf.API.DB.GetCorrID(accession.User, accession.FilePath)
+	corrID, err := Conf.API.DB.GetCorrID(accession.User, accession.FilePath, "")
 	if err != nil {
 		switch {
 		case corrID == "":
@@ -364,28 +364,27 @@ func createDataset(c *gin.Context) {
 		if err != nil {
 			switch {
 			case err.Error() == "sql: no rows in result set":
-				log.Debugln(err.Error())
+				log.Errorln(err.Error())
 				c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("accession ID not found: %s", stableID))
 
 				return
 			default:
-				log.Debugln(err.Error())
+				log.Errorln(err.Error())
 				c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 
 				return
 			}
 		}
-
-		_, err = Conf.API.DB.GetCorrID(dataset.User, inboxPath)
+		_, err = Conf.API.DB.GetCorrID(dataset.User, inboxPath, stableID)
 		if err != nil {
 			switch {
 			case err.Error() == "sql: no rows in result set":
-				log.Debugln(err.Error())
+				log.Errorln(err.Error())
 				c.AbortWithStatusJSON(http.StatusBadRequest, "accession ID owned by other user")
 
 				return
 			default:
-				log.Debugln(err.Error())
+				log.Errorln(err.Error())
 				c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 
 				return
@@ -658,7 +657,7 @@ func reVerify(c *gin.Context) {
 
 		return
 	}
-	corrID, err := Conf.API.DB.GetCorrID(reVerify.User, reVerify.FilePath)
+	corrID, err := Conf.API.DB.GetCorrID(reVerify.User, reVerify.FilePath, accessionID)
 	if err != nil {
 		log.Errorf("failed to get CorrID for %s, %s", reVerify.User, reVerify.FilePath)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -74,6 +74,22 @@ Admin endpoints are only available to a set of whitelisted users specified in th
     curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"accession_id": "my-id-01", "filepath": "/uploads/file.c4gh", "user": "testuser"}' https://HOSTNAME/file/accession
     ```
 
+- `/file/verify/:accession`
+  - accepts `PUT` requests with an accession ID as the last element in the query
+  - triggers re-verification of the file with the specific accession ID.
+
+  - Error codes
+    - `200` Query execute ok.
+    - `404` Error due to non existing accession ID.
+    - `401` Token user is not in the list of admins.
+    - `500` Internal error due to DB or MQ failures.
+
+    Example:
+
+    ```bash
+    curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X PUT -d '{"accession_id": "my-id-01", "filepath": "/uploads/file.c4gh", "user": "testuser"}' https://HOSTNAME/file/accession
+    ```
+
 - `/dataset/create`
   - accepts `POST` requests with JSON data with the format: `{"accession_ids": ["<FILE_ACCESSION_01>", "<FILE_ACCESSION_02>"], "dataset_id": "<DATASET_01>", "user": "<SUBMISSION_USER>"}`
   - creates a dataset from the list of accession IDs and the dataset ID.

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -1941,3 +1941,122 @@ func (suite *TestSuite) TestListDatasetsAsUser() {
 	assert.Equal(suite.T(), "released", datasets[1].Status)
 	assert.Equal(suite.T(), "API:dataset-01|registered", fmt.Sprintf("%s|%s", datasets[0].DatasetID, datasets[0].Status))
 }
+
+func (suite *TestSuite) TestReVerify() {
+	// purge the queue so that the test passes when all tests are run as well as when run standalone.
+	client := http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodDelete, "http://"+BrokerAPI+"/api/queues/sda/archived/contents", http.NoBody)
+	assert.NoError(suite.T(), err, "failed to generate query")
+	req.SetBasicAuth("guest", "guest")
+	res, err := client.Do(req)
+	assert.NoError(suite.T(), err, "failed to query broker")
+	res.Body.Close()
+
+	user := "TestReVerify"
+	for i := 0; i < 3; i++ {
+		filePath := fmt.Sprintf("/%v/TestReVerify-00%d.c4gh", user, i)
+		fileID, err := Conf.API.DB.RegisterFile(filePath, user)
+		if err != nil {
+			suite.FailNow("failed to register file in database")
+		}
+
+		if err := Conf.API.DB.UpdateFileEventLog(fileID, "uploaded", fileID, user, "{}", "{}"); err != nil {
+			suite.FailNow("failed to update satus of file in database")
+		}
+		encSha := sha256.New()
+		_, err = encSha.Write([]byte("Checksum"))
+		if err != nil {
+			suite.FailNow("failed to calculate Checksum")
+		}
+
+		decSha := sha256.New()
+		_, err = decSha.Write([]byte("DecryptedChecksum"))
+		if err != nil {
+			suite.FailNow("failed to calculate DecryptedChecksum")
+		}
+
+		fileInfo := database.FileInfo{
+			Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
+			Size:              1000,
+			Path:              filePath,
+			DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
+			DecryptedSize:     948,
+		}
+		if err := Conf.API.DB.SetArchived(fileInfo, fileID, fileID); err != nil {
+			suite.FailNow("failed to mark file as Archived")
+		}
+
+		if err := Conf.API.DB.SetVerified(fileInfo, fileID, fileID); err != nil {
+			suite.FailNow("failed to mark file as Verified")
+		}
+
+		stableID := fmt.Sprintf("accession_%s_0%d", user, i)
+		if err := Conf.API.DB.SetAccessionID(stableID, fileID); err != nil {
+			suite.FailNowf("got (%s) when setting stable ID: %s, %s", err.Error(), stableID, fileID)
+		}
+		if err := Conf.API.DB.UpdateFileEventLog(fileID, "ready", fileID, "finalize", "{}", "{}"); err != nil {
+			suite.FailNowf("got (%s) when updating file status: %s", err.Error(), filePath)
+		}
+	}
+
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(suite.T(), setupJwtAuth())
+	Conf.Broker.SchemasPath = "../../schemas/isolated"
+
+	// Mock request and response holders
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/file/verify/accession_TestReVerify_01", http.NoBody)
+	r.Header.Add("Authorization", "Bearer "+suite.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.PUT("/file/verify/:accession", reVerify)
+
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(suite.T(), http.StatusOK, okResponse.StatusCode)
+
+	// verify that the message shows up in the queue
+	time.Sleep(10 * time.Second) // this is needed to ensure we don't get any false negatives
+	req, _ = http.NewRequest(http.MethodGet, "http://"+BrokerAPI+"/api/queues/sda/archived", http.NoBody)
+	req.SetBasicAuth("guest", "guest")
+	res, err = client.Do(req)
+	assert.NoError(suite.T(), err, "failed to query broker")
+	var data struct {
+		MessagesReady int `json:"messages_ready"`
+	}
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	assert.NoError(suite.T(), err, "failed to read response from broker")
+	err = json.Unmarshal(body, &data)
+	assert.NoError(suite.T(), err, "failed to unmarshal response")
+	assert.Equal(suite.T(), 1, data.MessagesReady)
+}
+
+func (suite *TestSuite) TestReVerify_wrongAccession() {
+	// purge the queue so that the test passes when all tests are run as well as when run standalone.
+	client := http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodDelete, "http://"+BrokerAPI+"/api/queues/sda/archived/contents", http.NoBody)
+	assert.NoError(suite.T(), err, "failed to generate query")
+	req.SetBasicAuth("guest", "guest")
+	res, err := client.Do(req)
+	assert.NoError(suite.T(), err, "failed to query broker")
+	res.Body.Close()
+
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(suite.T(), setupJwtAuth())
+	Conf.Broker.SchemasPath = "../../schemas/isolated"
+
+	// Mock request and response holders
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/file/verify/accession_TestReVerify_99", http.NoBody)
+	r.Header.Add("Authorization", "Bearer "+suite.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/file/verify/:accession", reVerify)
+
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(suite.T(), http.StatusNotFound, okResponse.StatusCode)
+}

--- a/sda/cmd/verify/verify.go
+++ b/sda/cmd/verify/verify.go
@@ -246,8 +246,53 @@ func main() {
 			file.Checksum = fmt.Sprintf("%x", archiveFileHash.Sum(nil))
 			file.DecryptedChecksum = fmt.Sprintf("%x", sha256hash.Sum(nil))
 
-			//nolint:nestif
-			if !message.ReVerify {
+			switch {
+			case message.ReVerify:
+				decrypted, err := db.GetDecryptedChecksum(message.FileID)
+				if err != nil {
+					log.Errorf("failed to get unencrypted checksum for file: %s, reson: %s", message.FilePath, err.Error())
+					if err := delivered.Nack(false, true); err != nil {
+						log.Errorf("failed to Nack message, reason: (%s)", err.Error())
+					}
+
+					continue
+				}
+
+				if file.DecryptedChecksum != decrypted {
+					log.Errorf("encrypted checksum don't match for file: %s", message.FilePath)
+					if err := db.UpdateFileEventLog(message.FileID, "error", delivered.CorrelationId, "verify", `{"error":"decrypted checksum don't match"}`, string(delivered.Body)); err != nil {
+						log.Errorf("set status ready failed, reason: (%v)", err)
+						if err := delivered.Nack(false, true); err != nil {
+							log.Errorf("failed to Nack message, reason: (%v)", err)
+						}
+
+						continue
+					}
+					if err := delivered.Ack(false); err != nil {
+						log.Errorf("Failed to ack message: (%s)", err.Error())
+					}
+
+					continue
+				}
+
+				if file.Checksum != message.EncryptedChecksums[0].Value {
+					log.Errorf("encrypted checksum don't match for file: %s, expected %s, got %s", message.FilePath, message.EncryptedChecksums[0].Value, file.Checksum)
+					if err := db.UpdateFileEventLog(message.FileID, "error", delivered.CorrelationId, "verify", `{"error":"encrypted checksum don't match"}`, string(delivered.Body)); err != nil {
+						log.Errorf("set status ready failed, reason: (%v)", err)
+						if err := delivered.Nack(false, true); err != nil {
+							log.Errorf("failed to Nack message, reason: (%v)", err)
+						}
+
+						continue
+					}
+				}
+
+				if err := delivered.Ack(false); err != nil {
+					log.Errorf("Failed to ack message: (%s)", err.Error())
+				}
+
+				continue
+			default:
 				c := schema.IngestionAccessionRequest{
 					User:     message.User,
 					FilePath: message.FilePath,

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -986,3 +986,14 @@ func (dbs *SDAdb) GetReVerificationData(accessionID string) (schema.IngestionVer
 	return reVerify, nil
 }
 
+func (dbs *SDAdb) GetDecryptedChecksum(id string) (string, error) {
+	dbs.checkAndReconnectIfNeeded()
+	db := dbs.DB
+
+	var unencryptedChecksum string
+	if err := db.QueryRow("SELECT checksum from sda.checksums WHERE file_id = $1 AND source = 'UNENCRYPTED';", id).Scan(&unencryptedChecksum); err != nil {
+		return "", err
+	}
+
+	return unencryptedChecksum, nil
+}

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -686,7 +686,7 @@ func (dbs *SDAdb) GetCorrID(user, path string) (string, error) {
 func (dbs *SDAdb) getCorrID(user, path string) (string, error) {
 	dbs.checkAndReconnectIfNeeded()
 	db := dbs.DB
-	const query = "SELECT DISTINCT correlation_id FROM sda.file_event_log e RIGHT JOIN sda.files f ON e.file_id = f.id WHERE f.submission_file_path = $1 and f.submission_user = $2 AND NOT EXISTS (SELECT file_id FROM sda.file_dataset WHERE file_id = f.id)"
+	const query = "SELECT DISTINCT correlation_id FROM sda.file_event_log e RIGHT JOIN sda.files f ON e.file_id = f.id WHERE f.submission_file_path = $1 and f.submission_user = $2"
 
 	var corrID string
 	err := db.QueryRow(query, path, user).Scan(&corrID)

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -1035,3 +1035,38 @@ func (suite *DatabaseTests) TestGetReVerificationData_wrongAccessionID() {
 	assert.EqualError(suite.T(), err, "sql: no rows in result set")
 	assert.Equal(suite.T(), schema.IngestionVerification{}, data)
 }
+
+func (suite *DatabaseTests) TestGetDecryptedChecksum() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	fileID, err := db.RegisterFile("/testuser/TestGetDecryptedChecksum.c4gh", "testuser")
+	if err != nil {
+		suite.FailNow("failed to register file in database")
+	}
+
+	encSha := sha256.New()
+	_, err = encSha.Write([]byte("Checksum"))
+	if err != nil {
+		suite.FailNow("failed to generate checksum")
+	}
+
+	decSha := sha256.New()
+	_, err = decSha.Write([]byte("DecryptedChecksum"))
+	if err != nil {
+		suite.FailNow("failed to generate checksum")
+	}
+
+	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetDecryptedChecksum.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
+	corrID := uuid.New().String()
+	if err = db.SetArchived(fileInfo, fileID, corrID); err != nil {
+		suite.FailNow("failed to archive file")
+	}
+	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
+		suite.FailNow("failed to mark file as verified")
+	}
+
+	checksum, err := db.GetDecryptedChecksum(fileID)
+	assert.NoError(suite.T(), err, "failed to get verification data")
+	assert.Equal(suite.T(), fmt.Sprintf("%x", decSha.Sum(nil)), checksum)
+}

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -487,31 +487,6 @@ func (suite *DatabaseTests) TestGetCorrID() {
 	corrID, err := db.GetCorrID(user, filePath)
 	assert.NoError(suite.T(), err, "failed to get correlation ID of file in database")
 	assert.Equal(suite.T(), fileID, corrID)
-
-	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, "/testuser/file10.c4gh", checksum, 999}
-	err = db.SetArchived(fileInfo, fileID, corrID)
-	assert.NoError(suite.T(), err, "failed to mark file as Archived")
-
-	err = db.SetVerified(fileInfo, fileID, corrID)
-	assert.NoError(suite.T(), err, "failed to mark file as Verified")
-
-	stableID := "TEST:get-corr-id"
-	err = db.SetAccessionID(stableID, fileID)
-	assert.NoError(suite.T(), err, "got (%v) when setting stable ID: %s, %s", err, stableID, fileID)
-
-	diSet := map[string][]string{
-		"dataset-corr-id": {"TEST:get-corr-id"},
-	}
-
-	for di, acs := range diSet {
-		err := db.MapFilesToDataset(di, acs)
-		assert.NoError(suite.T(), err, "failed to map file to dataset")
-	}
-
-	corrID2, err := db.GetCorrID(user, filePath)
-	assert.Error(suite.T(), err, "failed to get correlation ID of file in database")
-	assert.Equal(suite.T(), "", corrID2)
 }
 
 func (suite *DatabaseTests) TestListActiveUsers() {


### PR DESCRIPTION
**Description**
This PR adds an endpoint to the API that will trigger re-verification of a single file.
* Changes include having `verify` do the actual re-check, on failure the `file_event_log` will be updated with the state `error`
* Integration test step added as well.

**How to test**
```
make integrationtest-sda
```

In the logs for verify you will se a message with `re_verify: true`