### PR TITLE
[ingest] store keyhash for ingested files

### DIFF
--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -69,4 +69,11 @@ until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ |
     sleep 2
 done
 
+# check that the files have key hashes assigned
+key_hashes="$(psql -U postgres -h postgres -d sda -At -c "select distinct key_hash from sda.files" | wc -l)"
+if [ "$key_hashes" -eq 0 ]; then
+	echo "::error::Ingested files did not have any key hashes."
+	exit 1
+fi
+
 echo "ingestion and verification test completed successfully"

--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -70,7 +70,7 @@ until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ |
 done
 
 # check that the files have key hashes assigned
-key_hashes="$(psql -U postgres -h postgres -d sda -At -c "select distinct key_hash from sda.files" | wc -l)"
+key_hashes="$(psql -U postgres -h postgres -d sda -At -c "select count(distinct key_hash) from sda.files")"
 if [ "$key_hashes" -eq 0 ]; then
 	echo "::error::Ingested files did not have any key hashes."
 	exit 1

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -397,6 +397,9 @@ func main() {
 						err = db.SetKeyHash(keyhash, fileID)
 						if err != nil {
 							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
+							if err = delivered.Nack(false, true); err != nil {
+								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
+							}
 
 							continue mainWorkLoop
 						}

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -397,6 +397,8 @@ func main() {
 						err = db.SetKeyHash(keyhash, fileID)
 						if err != nil {
 							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
+
+							continue mainWorkLoop
 						}
 
 						log.Debugln("store header")

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -391,7 +391,6 @@ func main() {
 						}
 
 						// Set the file's hex encoded public key
-						log.Debugln("Compute and set key hash")
 						publicKey := keys.DerivePublicKey(*key)
 						keyhash := hex.EncodeToString(publicKey[:])
 						err = db.SetKeyHash(keyhash, fileID)

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/crypt4gh/model/headers"
 	"github.com/neicnordic/crypt4gh/streaming"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
@@ -386,6 +388,15 @@ func main() {
 							}
 
 							continue mainWorkLoop
+						}
+
+						// Set the file's hex encoded public key
+						log.Debugln("Compute and set key hash")
+						publicKey := keys.DerivePublicKey(*key)
+						keyhash := hex.EncodeToString(publicKey[:])
+						err = db.SetKeyHash(keyhash, fileID)
+						if err != nil {
+							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
 						}
 
 						log.Debugln("store header")

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -784,6 +784,24 @@ func (dbs *SDAdb) addKeyHash(keyHash, keyDescription string) error {
 	return nil
 }
 
+func (dbs *SDAdb) SetKeyHash(keyHash, fileID string) error {
+	dbs.checkAndReconnectIfNeeded()
+	db := dbs.DB
+
+	query := "UPDATE sda.files SET key_hash = $1 WHERE id = $2;"
+	result, err := db.Exec(query, keyHash, fileID)
+	if err != nil {
+
+		return err
+	}
+	if rowsAffected, _ := result.RowsAffected(); rowsAffected == 0 {
+		return errors.New("something went wrong with the query, zero rows were changed")
+	}
+	log.Debugf("Successfully set key hash for file %v", fileID)
+
+	return nil
+}
+
 type C4ghKeyHash struct {
 	Hash         string `json:"hash"`
 	Description  string `json:"description"`


### PR DESCRIPTION
> NOTE: This is a copy  of PR #1073,  created to make the test `Build PR container / Build PR image (java) (pull_request) ` rerun properly and pass.

**Related issue(s) and PR(s)**  
This PR closes #893.

**Description**
- ingest hex encodes the user's public key and adds it to the files info in the `sda.files` table
- if the keyhash is not in the `sda.encryption_keys`, an error is thrown and ingest stops
- code test and integration test are added

**How to test**
Add the hashed public key to `sda.encryption_keys` and then try to ingest a file. See the [integration test](28be1c) for details.