### PR TITLE
Update release_sda-admin.yaml

### DIFF
--- a/.github/workflows/release_sda-admin.yaml
+++ b/.github/workflows/release_sda-admin.yaml
@@ -4,7 +4,7 @@ on:
     merge_group:
     pull_request:
       paths:
-        - 'sda-admin/.version'
+        - "sda-admin/.version"
       types: [ closed ]
     workflow_dispatch:
 


### PR DESCRIPTION
Single and double quotes are handled differently on path parsing.

This action should *only* be run when the version file is updated.