### PR TITLE
Rework integration-test setup

### DIFF
--- a/.github/integration/sda-sync-integration.yml
+++ b/.github/integration/sda-sync-integration.yml
@@ -208,6 +208,49 @@ services:
       - ./sda/config.yaml:/config.yaml
       - shared:/shared
 
+  sync:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
+    command: [ sda-sync ]
+    container_name: sync
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=sync
+      - BROKER_USER=sync
+      - BROKER_QUEUE=mapping_stream
+      - DB_PASSWORD=sync
+      - DB_USER=sync
+    restart: always
+    volumes:
+      - ./sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  sync-api:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
+    command: [ sda-syncapi ]
+    container_name: sync-api
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=sync
+      - BROKER_USER=sync
+      - BROKER_EXCHANGE=sda.dead
+    ports:
+      - "18080:8080"
+    restart: always
+    volumes:
+      - ./sda/config.yaml:/config.yaml
+
   oidc:
     container_name: oidc
     command:
@@ -273,65 +316,6 @@ services:
       - ./sda/config.yaml:/config.yaml
       - shared:/shared
 
-  cega-nss:
-    container_name: cega-nss
-    depends_on:
-      credentials:
-        condition: service_completed_successfully
-    command:
-      [
-        "python",
-        "/cega/users.py",
-        "0.0.0.0",
-        "8443",
-        "/shared/users.json"
-      ]
-    environment:
-      - CEGA_USERS_PASSWORD=test
-      - CEGA_USERS_USER=test
-    image: "egarchive/lega-base:release.v0.2.0"
-    ports:
-      - "8443:8443"
-    volumes:
-      - ./sda/users.py:/cega/users.py
-      - shared:/shared
-
-  auth-cega:
-    command: [ sda-auth ]
-    container_name: auth-cega
-    depends_on:
-      cega-nss:
-        condition: service_started
-    environment:
-      - AUTH_RESIGNJWT=true
-      - AUTH_CEGA_ID=test
-      - AUTH_CEGA_SECRET=test
-    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
-    ports:
-      - "8888:8080"
-    restart: always
-    volumes:
-      - ./sda/config.yaml:/config.yaml
-      - shared:/shared
-
-  auth-oidc:
-    command: [ sda-auth ]
-    container_name: auth-oidc
-    depends_on:
-      oidc:
-        condition: service_healthy
-    environment:
-      - AUTH_RESIGNJWT=false
-      - OIDC_ID=XC56EL11xx
-      - OIDC_SECRET=wHPVQaYXmdDHg
-    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
-    ports:
-      - "8889:8080"
-    restart: always
-    volumes:
-      - ./sda/config.yaml:/config.yaml
-      - shared:/shared
-
   integration_test:
     container_name: tester
     command:
@@ -339,12 +323,6 @@ services:
       - "/tests/run_scripts.sh"
       - "/tests/sda"
     depends_on:
-      auth-cega:
-        condition: service_started
-      auth-oidc:
-        condition: service_started
-      cega-nss:
-        condition: service_started
       credentials:
         condition: service_completed_successfully
       finalize:
@@ -355,6 +333,10 @@ services:
         condition: service_started
       s3inbox:
         condition: service_started
+      sync:
+        condition: service_started
+      sync-api:
+        condition: service_started
       verify:
          condition: service_started
       api:
@@ -364,6 +346,7 @@ services:
     environment:
       - PGPASSWORD=rootpasswd
       - STORAGETYPE=s3
+      - SYNCTEST=true
     image: python:3.11-slim-bullseye
     profiles:
       - tests

--- a/.github/integration/tests/sda/45_sync_test.sh
+++ b/.github/integration/tests/sda/45_sync_test.sh
@@ -3,7 +3,8 @@ set -e
 
 cd shared || true
 
-if [ "$STORAGETYPE" = "posix" ]; then
+if [ -z "$SYNCTEST" ]; then
+    echo "sync not tested"
     exit 0
 fi
 

--- a/.github/integration/tests/sda/99_auth_test.sh
+++ b/.github/integration/tests/sda/99_auth_test.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+if [ -n "$SYNCTEST" ]; then
+    exit 0
+fi
+
 python -m pip install --upgrade pip
 pip install tox
 

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -229,6 +229,25 @@ jobs:
       - name: Test sensitive-data-archive
         run: docker compose -f .github/integration/sda-${{matrix.storage}}-integration.yml run integration_test
 
+  sda-sync:
+    needs:
+      - build_go_images
+      - build_server_images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            sync:
+              - "sda/cmd/sync/*"
+            sync-api:
+              - "sda/cmd/syncapi/*"
+      - name: Test sda-sync
+        run: docker compose -f .github/integration/sda-sync-integration.yml run integration_test
+        if: steps.changes.outputs.sync == 'true' || steps.changes.outputs.sync-api == 'true'
+
   chart:
     needs:
       - build_go_images

--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,30 @@ integrationtest-postgres: build-postgresql
 integrationtest-rabbitmq: build-rabbitmq build-sda
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/rabbitmq-federation.yml run federation_test
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/rabbitmq-federation.yml down -v --remove-orphans
-integrationtest-sda: build-all
-	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml run integration_test
-	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml down -v --remove-orphans
+
+integrationtest-sda-posix: build-all
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml run integration_test
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml down -v --remove-orphans
+integrationtest-sda-posix-run:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml run integration_test
+integrationtest-sda-posix-down:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml down -v --remove-orphans
+
+integrationtest-sda-s3:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml run integration_test
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml down -v --remove-orphans
+integrationtest-sda-s3-run:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml run integration_test
+integrationtest-sda-s3-down:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml down -v --remove-orphans
+
+integrationtest-sda-sync: build-all
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-sync-integration.yml run integration_test
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-sync-integration.yml down -v --remove-orphans
+integrationtest-sda-sync-run:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-sync-integration.yml run integration_test
+integrationtest-sda-sync-down:
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-sync-integration.yml down -v --remove-orphans
 
 # lint go code
 lint-all: lint-sda lint-sda-download lint-sda-admin

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ integrationtest-rabbitmq: build-rabbitmq build-sda
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/rabbitmq-federation.yml run federation_test
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/rabbitmq-federation.yml down -v --remove-orphans
 
+integrationtest-sda: build_all
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml run integration_test
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml down -v --remove-orphans
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml run integration_test
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml down -v --remove-orphans
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-sync-integration.yml run integration_test
+	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-sync-integration.yml down -v --remove-orphans
+
 integrationtest-sda-posix: build-all
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml run integration_test
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml down -v --remove-orphans
@@ -85,7 +93,7 @@ integrationtest-sda-posix-run:
 integrationtest-sda-posix-down:
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-posix-integration.yml down -v --remove-orphans
 
-integrationtest-sda-s3:
+integrationtest-sda-s3: build-all
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml run integration_test
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-s3-integration.yml down -v --remove-orphans
 integrationtest-sda-s3-run:


### PR DESCRIPTION
**Description**
Given the ongoing work with the admin API and the fact that the sync service needs a full rework some changes to the tests are required.

* Split out sync test to a separate docker compose file
* Only run the sync test if the code in the `cmd/sync*` subfolders change
* Expand the `Makefile` so that it will be easier to run the tests without having to rebuild the containers or run tests not related to the ongoing work (posix, s3, sync)

**Notice**
As part of this the release of version tagged artifacts, containers and charts are disabled, so we don't release anything that is not working properly.
This will be resolved when we move over to using release branches.