### PR TITLE
Hotfix `Release sda-admin`

### DIFF
--- a/.github/workflows/release_sda-admin.yaml
+++ b/.github/workflows/release_sda-admin.yaml
@@ -1,12 +1,10 @@
 name: Release sda-admin
 
 on:
-    merge_group:
     pull_request:
       paths:
         - "sda-admin/.version"
       types: [ closed ]
-    workflow_dispatch:
 
 jobs:
   release_sda_admin:


### PR DESCRIPTION
**Description**
Seems like the is running when it shouldn't, let's see if it is fixable.

**How to test**
On any PR merge this should not run unless the version file in the sda-admin folder is updated