### PR TITLE
Run dependabot on release branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -102,3 +102,112 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+
+## release v1 branch
+### Docker
+  - package-ecosystem: docker
+    target-branch: release_v1
+    directory: "/postgresql"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+
+  - package-ecosystem: docker
+    target-branch: release_v1
+    directory: "/rabbitmq"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+
+  - package-ecosystem: docker
+    target-branch: release_v1
+    directory: "/sda"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+
+  - package-ecosystem: docker
+    target-branch: release_v1
+    directory: "/sda-doa"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+
+  - package-ecosystem: docker
+    target-branch: release_v1
+    directory: "/sda-download"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+
+  - package-ecosystem: docker
+    target-branch: release_v1
+    directory: "/sda-sftp-inbox"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+
+### JAVA
+  - package-ecosystem: maven
+    target-branch: release_v1
+    directory: "/sda-doa"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: maven
+    target-branch: release_v1
+    directory: "/sda-sftp-inbox"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: daily
+### GO
+  - package-ecosystem: gomod
+    target-branch: release_v1
+    directory: "/sda-download"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gomod
+    target-branch: release_v1
+    directory: "/sda"
+    groups:
+      all-modules:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "neicnordic/sensitive-data-development-collaboration"
+    schedule:
+      interval: daily


### PR DESCRIPTION
**Description**
There can only be one dependabot config file so in order to get dependabot to run on the release branches we need to duplicate some of the checks. 

**How to test**
Wait and see if we get updates for branch `release_v1` once this PR is merged