### PR TITLE
[ingest] Check for keyhash on startup

### DIFF
--- a/.github/integration/scripts/charts/dependencies.sh
+++ b/.github/integration/scripts/charts/dependencies.sh
@@ -33,7 +33,7 @@ fi
 # secret for the crypt4gh keypair
 C4GHPASSPHRASE="$(random-string)"
 export C4GHPASSPHRASE
-dir=$CWD
+dir=$PWD
 if [ -n "$1" ]; then
         dir=/tmp
 fi

--- a/.github/integration/scripts/charts/k3d.sh
+++ b/.github/integration/scripts/charts/k3d.sh
@@ -16,3 +16,6 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 k3d cluster create sda --image=rancher/k3s:"$k8s"-k3s1 --wait --timeout 10m
 k3d kubeconfig merge sda --kubeconfig-switch-context
 mkdir -p ~/.kube/ && cp ~/.config/kubeconfig-sda.yaml ~/.kube/config
+
+docker build -t ghcr.io/neicnordic/sensitive-data-archive:oidc -f .github/integration/scripts/charts/Dockerfile .
+k3d image import ghcr.io/neicnordic/sensitive-data-archive:oidc -c sda

--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -29,7 +29,8 @@ VALUES (0, now(), 'Created with version'),
        (12, now(), 'Add key hash'),
        (13, now(), 'Create API user'),
        (14, now(), 'Create Auth user'),
-       (15, now(), 'Give API user insert priviledge in logs table');
+       (15, now(), 'Give API user insert priviledge in logs table'),
+       (16, now(), 'Give ingest user select priviledge in encryption_keys table');
 
 -- Datasets are used to group files, and permissions are set on the dataset
 -- level

--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -43,6 +43,7 @@ GRANT USAGE, SELECT ON SEQUENCE sda.checksums_id_seq TO ingest;
 GRANT INSERT ON sda.file_event_log TO ingest;
 GRANT SELECT ON sda.file_event_log TO ingest;
 GRANT USAGE, SELECT ON SEQUENCE sda.file_event_log_id_seq TO ingest;
+GRANT SELECT ON sda.encryption_keys TO ingest;
 
 -- legacy schema
 GRANT USAGE ON SCHEMA local_ega TO ingest;

--- a/postgresql/migratedb.d/16.sql
+++ b/postgresql/migratedb.d/16.sql
@@ -1,0 +1,21 @@
+
+DO
+$$
+DECLARE
+-- The version we know how to do migration from, at the end of a successful migration
+-- we will no longer be at this version.
+  sourcever INTEGER := 15;
+  changes VARCHAR := 'Give ingest user select priviledge in encryption_keys table';
+BEGIN
+  IF (select max(version) from sda.dbschema_version) = sourcever then
+    RAISE NOTICE 'Doing migration from schema version % to %', sourcever, sourcever+1;
+    RAISE NOTICE 'Changes: %', changes;
+    INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
+
+    GRANT SELECT ON sda.encryption_keys TO ingest;
+
+  ELSE
+    RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
+  END IF;
+END
+$$


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1164 .

## Description
Check that a keyhash exists in the database before start processing any messages. A timer counts down for 5 minutes and if no keyhash exists by then an error will be logged and ingest will restart.

No messages will be processed before this check completes.

## How to test
make build-all
make sda-s3-up
docker logs -f ingest

"no crypt4gh key hash registered" will be printed every 30 seconds and after 5 minutes the container will restart.


If `make integrationtest-sda` is used ingest will Print the same message a few times until the tests reaches `11_api_test`. Then it will process the messages as normal for the ingestion test.