### PR TITLE
[internal/database] GetCorrID needs to accept multiple rows as result

### DIFF
--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -732,9 +732,6 @@ func (dbs *SDAdb) getCorrID(user, path, accession string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if rows.Err() != nil {
-		return "", rows.Err()
-	}
 	defer rows.Close()
 
 	var corrID sql.NullString
@@ -746,6 +743,9 @@ func (dbs *SDAdb) getCorrID(user, path, accession string) (string, error) {
 		if corrID.Valid {
 			return corrID.String, nil
 		}
+	}
+	if rows.Err() != nil {
+		return "", rows.Err()
 	}
 
 	return "", fmt.Errorf("sql: no rows in result set")

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -539,7 +539,7 @@ func (suite *DatabaseTests) TestGetCorrID_wrongFilePath() {
 	fileID, err := db.RegisterFile(filePath, user)
 	assert.NoError(suite.T(), err, "failed to register file in database")
 	err = db.UpdateFileEventLog(fileID, "uploaded", fileID, user, "{}", "{}")
-	assert.NoError(suite.T(), err, "failed to update satus of file in database")
+	assert.NoError(suite.T(), err, "failed to update status of file in database")
 
 	corrID, err := db.GetCorrID(user, "/testuser/file20.c4gh", "")
 	assert.EqualError(suite.T(), err, "sql: no rows in result set")

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -529,6 +529,23 @@ func (suite *DatabaseTests) TestGetCorrID_sameFilePath() {
 
 }
 
+func (suite *DatabaseTests) TestGetCorrID_wrongFilePath() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)
+
+	filePath := "/testuser/file10.c4gh"
+	user := "testuser"
+
+	fileID, err := db.RegisterFile(filePath, user)
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	err = db.UpdateFileEventLog(fileID, "uploaded", fileID, user, "{}", "{}")
+	assert.NoError(suite.T(), err, "failed to update satus of file in database")
+
+	corrID, err := db.GetCorrID(user, "/testuser/file20.c4gh", "")
+	assert.EqualError(suite.T(), err, "sql: no rows in result set")
+	assert.Equal(suite.T(), "", corrID)
+}
+
 func (suite *DatabaseTests) TestGetCorrID_fileWithAccessionID() {
 	db, err := NewSDAdb(suite.dbConf)
 	assert.NoError(suite.T(), err, "got (%v) when creating new connection", err)


### PR DESCRIPTION
## Description

QueryRow selects the first result returned, but the file_event_log always will return multiple rows. This is due to the `register_file` function  in our DB schema that stores the first log event without any correlation ID.
Combine that with the quasi randomness that Postgres returns if no sorting is applied and we have the current state.

Running the commands below on master failed 5 out of 6 times on average.

## How to test

The following execution should not fail.
```cmd
make build-all
make integrationtest-sda-s3-run
sda-admin/sda-admin file ingest -filepath requester_demo.org/data/file1.c4gh -user requester@demo.org
```