### PR TITLE
`verify` supports multiple private keys

### DIFF
--- a/sda/cmd/verify/verify.go
+++ b/sda/cmd/verify/verify.go
@@ -206,19 +206,17 @@ func main() {
 			}
 
 			var key *[32]byte
-			var foundKey bool
-			for _, key = range archiveKeyList {
-				size, err := headers.EncryptedSegmentSize(header, *key)
+			for _, k := range archiveKeyList {
+				size, err := headers.EncryptedSegmentSize(header, *k)
 				if (err == nil) && (size != 0) {
-					foundKey = true
+					key = k
 
 					break
 				}
-				log.Warnf("Failed to get encrypted segment size with key: %v, trying next key. Reason: %s", *key, err.Error())
 			}
 
-			if !foundKey {
-				log.Errorf("Failed to get encrypted segment size with all available key(s).")
+			if key == nil {
+				log.Errorf("no matching key found for file: %s.", message.ArchivePath)
 
 				continue
 			}
@@ -226,7 +224,7 @@ func main() {
 			mr := io.MultiReader(bytes.NewReader(header), io.TeeReader(f, archiveFileHash))
 			c4ghr, err := streaming.NewCrypt4GHReader(mr, *key, nil)
 			if err != nil {
-				log.Errorf("Failed to open C4GH decryptor stream with key: %v", *key)
+				log.Errorf("failed to open c4gh decryptor stream, reson: %s", err.Error())
 
 				continue
 			}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1087 


## Description
Verify reads a list of key files and their corresponding passphrases provided in the config file under `c4gh.keys`, for example
```yaml
c4gh:
   privateKeys:
   - filePath: /shared/c4gh.sec.pem
     passphrase: "c4ghpass"
   - filePath: /shared/c4gh1.sec.pem
     passphrase: "c4ghpass"
```

The old method, which provides only one key file and its corresponding passphrase, is still retained for components other than `ingest` and `verify`. This method should be removed once all components have been updated to support multiple keys. 

In addition, setting multiple keys and passphrases via environmental variables is not supported for the moment. This will be addressed when all components are updated. The README for each service should be updated accordingly at last. 

## How to test
Verify that the integration tests pass.

If you want to test manually, do as follows
- Start the docker stack:
```
make build-all && make sda-s3-up
```
- Prepare data
```
for i in $(seq 2); do seq $i > /tmp/t$i.txt; done
docker cp verify:/shared /tmp/
user=test@dummy.org
export API_HOST=http://localhost:8090
export ACCESS_TOKEN=$(curl -s -k http://localhost:8080/tokens | jq -r '.[0]')
token=$ACCESS_TOKEN
sed -i '/host_/s/s3inbox:8000/localhost:18000/g' /tmp/shared/s3cfg
rm -f /tmp/t*.c4gh
```
- Upload a file encrypted with one of the keys under `c4gh.privateKeys` and then ingest it.
Note that the status of the file should be changed from `uploaded` to `verified`.
```sh
sda-cli -config /tmp/shared/s3cfg upload -encrypt-with-key /tmp/shared/c4gh.pub.pem /tmp/t1.txt
sda-admin file list -user test@dummy.org
curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"pubkey": "'"$( base64 -w0 /tmp/shared/c4gh.pub.pem)"'", "description": "c4gh pub key 0"}' http://localhost:8090/c4gh-keys/add
sda-admin file ingest -filepath test_dummy.org/t1.txt.c4gh -user test@dummy.org
```

- Upload another file encrypted with the other key under `c4gh.privateKeys` and then ingest it.
Note that the status of the file should also be changed from `uploaded` to `verified`.
 
```sh 
curl -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d '{"pubkey": "'"$( base64 -w0 /tmp/shared/c4gh1.pub.pem)"'", "description": "c4gh pub key 1"}' http://localhost:8090/c4gh-keys/add  
sda-cli -config /tmp/shared/s3cfg upload -encrypt-with-key /tmp/shared/c4gh1.pub.pem /tmp/t2.txt
sda-admin file ingest -filepath test_dummy.org/t2.txt.c4gh -user test@dummy.org 
```
