### PR TITLE
[Test] Add NGINX to k3d

### DIFF
--- a/.github/integration/scripts/charts/dependencies.sh
+++ b/.github/integration/scripts/charts/dependencies.sh
@@ -9,7 +9,7 @@ random-string() {
 }
 
 if [ "$1" == "local" ]; then
-        if [ ! "$(command crypt4gh)" ]; then
+        if [ ! "$(command crypt4gh --version)" ]; then
                 echo "crypt4gh not installed, get it from here: https://github.com/neicnordic/crypt4gh/releases/latest"
                 exit 1
         elif [ "$(crypt4gh --version | cut -d ' ' -f1)" == "GA4GH" ]; then
@@ -18,8 +18,18 @@ if [ "$1" == "local" ]; then
                 exit 1
         fi
 
-        if [ ! "$(command yq)" ]; then
+        if [ ! "$(command yq --version)" ]; then
                 echo "yq not installed, get it from here: https://github.com/mikefarah/yq/releases/latest"
+                exit 1
+        fi
+
+        if [ ! "$(command jq --version)" ]; then
+                echo "jq not installed"
+                exit 1
+        fi
+
+        if [ ! "$(command xxd --version 2>&1)" ]; then
+                echo "xxd not installed"
                 exit 1
         fi
 else

--- a/.github/integration/scripts/charts/deploy_charts.sh
+++ b/.github/integration/scripts/charts/deploy_charts.sh
@@ -36,6 +36,7 @@ if [ "$1" == "sda-mq" ]; then
         --set image.pullPolicy=IfNotPresent \
         --set global.adminPassword="$ADMINPASS" \
         --set global.adminUser=admin \
+        --set global.ingress.hostName=broker.127.0.0.1.nip.io \
         --set global.tls.enabled="$3" \
         --set global.tls.clusterIssuer=cert-issuer \
         --set persistence.enabled=false \

--- a/.github/integration/scripts/charts/values.yaml
+++ b/.github/integration/scripts/charts/values.yaml
@@ -1,12 +1,13 @@
 global:
   schemaType: "isolated"
   ingress:
-    deploy: false
+    deploy: true
     hostName:
-      api: pipeline-sda-svc-api
-      auth: pipeline-sda-svc-auth
-      download: pipeline-sda-svc-download
-      s3Inbox: pipeline-sda-svc-inbox
+      api: api.127.0.0.1.nip.io
+      auth: auth.127.0.0.1.nip.io
+      download: download.127.0.0.1.nip.io
+      s3Inbox: inbox.127.0.0.1.nip.io
+      syncapi: sync-api.127.0.0.1.nip.io
   log:
     level: "debug"
   tls:

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,8 @@ k3d-version-check:
 		echo "kubectl is missing";\
 	fi
 k3d-create-cluster:
-	@k3d cluster create
+	@k3d cluster create --k3s-arg "--disable=traefik@server:0" --port "80:80@loadbalancer" --port "443:443@loadbalancer"; \
+	helm upgrade --install ingress-nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --namespace ingress-nginx --create-namespace
 k3d-delete-cluster:
 	@k3d cluster delete
 k3d-deploy-dependencies:

--- a/README.md
+++ b/README.md
@@ -176,19 +176,25 @@ wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 ```
 
-Once installed a cluster named `test-cluster` can be created as such:
+#### Create a cluster
 
-```sh
-k3d cluster create test-cluster
-```
-
-Or by using the `make k3d-create-cluster` command, you can create a cluster named `k3s-default`.
+Once installed a cluster can be created using the `make k3d-create-cluster` command, you can create a cluster named `k3s-default`.
 
 The new cluster's connection details will automatically be merged into your default kubeconfig and activated. The command below should show the created node.
 
 ```sh
 kubectl get nodes
 ```
+
+The Nginx ingress controller is deployed and will bind to ports 80 and 443 of the host system. A deployed service with an ingress definition can then be targeted by setting the `Host: HOSTNAME` header for that service.
+
+```sh
+curl -H "Host: test" http://localhost/
+```
+
+For testing ingress endpoints with other applications like a web browser, the hostname in the ingress definition should have the `.127.0.0.1.nip.io` ending in order to not have to modify the `/etc/hosts` file, ex. `app.127.0.0.1.nip.io`.
+
+#### Remove the cluster
 
 Removing the cluster can be done using the `make k3d-delete-cluster` command or as shown below if a specific name is used during creation.
 
@@ -220,7 +226,7 @@ Deployment of the charts can be done as describe below in more detail, or by usi
 
 #### Bootstrap the dependencies
 
-This script requires [yq](https://github.com/mikefarah/yq/releases/latest) and the GO version of [crypt4gh](https://github.com/neicnordic/crypt4gh/releases/latest)
+This script requires [yq](https://github.com/mikefarah/yq/releases/latest), the GO version of [crypt4gh](https://github.com/neicnordic/crypt4gh/releases/latest) as well as [xxd](https://manpages.org/xxd) and [jq](https://manpages.org/jq) to be installed.
 
 ```sh
 bash .github/integration/scripts/charts/dependencies.sh local

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 ```
 
+#### Install kubectl
+
+If `kubectl` is not installed, run the following command to download the latest stable version. (substitue `linux/amd64` with `darwin/arm64` if you are using a Mac).
+
+```sh
+curl -sLO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+```
+
 #### Create a cluster
 
 Once installed a cluster can be created using the `make k3d-create-cluster` command, you can create a cluster named `k3s-default`.
@@ -196,14 +204,6 @@ For testing ingress endpoints with other applications like a web browser, the ho
 #### Remove the cluster
 
 Removing the cluster can be done using the `make k3d-delete-cluster` command or as shown below if a specific name is used during creation.
-
-#### Install kubectl
-
-If `kubectl` is not installed, run the following command to download the latest stable version. (substitue `linux/amd64` with `darwin/arm64` if you are using a Mac).
-
-```sh
-curl -sLO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-```
 
 ### Deploy the components
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 #### Create a cluster
 
 Once installed a cluster can be created using the `make k3d-create-cluster` command, you can create a cluster named `k3s-default`.
-
 The new cluster's connection details will automatically be merged into your default kubeconfig and activated. The command below should show the created node.
 
 ```sh
@@ -197,10 +196,6 @@ For testing ingress endpoints with other applications like a web browser, the ho
 #### Remove the cluster
 
 Removing the cluster can be done using the `make k3d-delete-cluster` command or as shown below if a specific name is used during creation.
-
-```sh
-k3d cluster delete test-cluster
-```
 
 #### Install kubectl
 
@@ -228,30 +223,15 @@ Deployment of the charts can be done as describe below in more detail, or by usi
 
 This script requires [yq](https://github.com/mikefarah/yq/releases/latest), the GO version of [crypt4gh](https://github.com/neicnordic/crypt4gh/releases/latest) as well as [xxd](https://manpages.org/xxd) and [jq](https://manpages.org/jq) to be installed.
 
-```sh
-bash .github/integration/scripts/charts/dependencies.sh local
-```
+Bootstrap the dependencies with the command: `make k3d-deploy-dependencies`.
 
 #### Deploy the Sensitive Data Archive components
 
-Start by building the required containers using the `make build-all` command, once that has completed the images can be imported to the cluster.
+Start by building and importing the required containers using the `make k3d-import-images`.
 
-```sh
-bash .github/integration/scripts/charts/import_local_images.sh <CLUTER_NAME>
-```
+The Postgres and RabbitMQ Needs to be deployed first using the following commands: `make k3d-deplploy-postgres` and `make k3d-deploy-rabbitmq`.
 
-The Postgres and RabbitMQ Needs to be deployed first, the bool at the end specifies if TLS should be enabled or not for the deployes services.  
-Replace `sda-db` in the example below with the helmc hart that shuld be installed. (`sda-db` or `sda-mq`)
-
-```sh
-bash .github/integration/scripts/charts/deploy_charts.sh sda-db "$(date +%F)" false
-```
-
-Once the DB and MQ are installed the SDA stack can be installed, here the desired storage backend needs to specified as well (`posix` or `s3`)
-
-```sh
-bash .github/integration/scripts/charts/deploy_charts.sh sda-svc "$(date +%F)" false s3
-```
+Once the DB and MQ are installed the SDA stack can be installed, here the desired storage backend needs to specified as well (`posix` or `s3`), `make k3d-deplpoy-sda-posix` or `make k3d-deplpoy-sda-s3`.
 
 #### Testing with ingress
 
@@ -265,8 +245,4 @@ Once everything is deployed it is posible to interact with the services using th
 
 #### Cleanup all deployed components
 
-Once the testing is concluded all deployed components can be removed.
-
-```sh
-bash .github/integration/scripts/charts/cleanup.sh
-```
+Once the testing is concluded all deployed components can be removed with the command `make k3d-cleanup-all-deployments`

--- a/README.md
+++ b/README.md
@@ -253,6 +253,16 @@ Once the DB and MQ are installed the SDA stack can be installed, here the desire
 bash .github/integration/scripts/charts/deploy_charts.sh sda-svc "$(date +%F)" false s3
 ```
 
+#### Testing with ingress
+
+Once everything is deployed it is posible to interact with the services using the following hostnames:
+
+- api.127.0.0.1.nip.io
+- auth.127.0.0.1.nip.io
+- broker.127.0.0.1.nip.io
+- download.127.0.0.1.nip.io
+- inbox.127.0.0.1.nip.io
+
 #### Cleanup all deployed components
 
 Once the testing is concluded all deployed components can be removed.


### PR DESCRIPTION
## Description
This PR adds an NGINX ingress controller to the k3d setup so that it will be possible to test ingress routing on a local setup.

## How to test

When using cURL it's possible to add the hosts header like this:

```
curl -H "Host: test" http://localhost/
```

If a browser is needed the `/etc/hosts` file needs to be modified to contain lines like this for each endpoint that are needed.

```
127.0.0.1 HOSTNAME
```

Or it is possible to use host names like this when deploying the stack `login.127.0.0.1.nip.io`, this will then resolve to localhost when used, both by cURL and any browser.