### PR TITLE
bugfix/persist fileID over changes of the service instance

### DIFF
--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -177,6 +177,7 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request, token jw
 	}
 
 	// Send message to upstream and set file as uploaded in the database
+	// nolint: nestif // We need a nested if statement for checking whether fileId is persisted during possible reconnections
 	if p.uploadFinishedSuccessfully(r, s3response) {
 		log.Debug("create message")
 		message, err := p.CreateMessageFromRequest(r, token)

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -203,7 +203,6 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request, token jw
 		// The following block is for treating the case when the client loses connection to the server and then it reconnects to a
 		// different instance of s3inbox. For more details see #1358.
 		if p.fileIds[r.URL.Path] == "" {
-
 			p.fileIds[r.URL.Path], err = p.database.GetFileIDByUserPathAndStatus(username, filepath, "registered")
 			if err != nil {
 				p.internalServerError(w, r, fmt.Sprintf("failed to retrieve fileID from database: %v", err))

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -204,14 +204,7 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request, token jw
 		// different instance of s3inbox. For more details see #1358.
 		if p.fileIds[r.URL.Path] == "" {
 
-			corrID, err := p.database.GetCorrID(username, filepath, "")
-			if err != nil {
-				p.internalServerError(w, r, fmt.Sprintf("failed to retrieve corrID from database: %v", err))
-
-				return
-			}
-
-			p.fileIds[r.URL.Path], err = p.database.GetFileID(corrID)
+			p.fileIds[r.URL.Path], err = p.database.GetFileIDByUserPathAndStatus(username, filepath, "registered")
 			if err != nil {
 				p.internalServerError(w, r, fmt.Sprintf("failed to retrieve fileID from database: %v", err))
 

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -201,7 +201,7 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request, token jw
 		}
 
 		// The following block is for treating the case when the client loses connection to the server and then it reconnects to a
-		// different instance of s3inbox. For more details see https://github.com/NBISweden/BigPicture-Deployment/issues/283.
+		// different instance of s3inbox. For more details see #1358.
 		if p.fileIds[r.URL.Path] == "" {
 
 			corrID, err := p.database.GetCorrID(username, filepath, "")

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -110,7 +110,7 @@ func (dbs *SDAdb) GetFileIDByUserPathAndStatus(submissionUser, filePath, status 
 	// 2, 4, 8, 16, 32 seconds between each retry event.
 	for count := 1; count <= RetryTimes; count++ {
 		fileID, err = dbs.getFileIDByUserPathAndStatus(submissionUser, filePath, status)
-		if err == nil {
+		if err == nil || strings.Contains(err.Error(), "sql: no rows in result set") {
 			break
 		}
 		time.Sleep(time.Duration(math.Pow(2, float64(count))) * time.Second)

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -100,6 +100,45 @@ func (dbs *SDAdb) getInboxFilePathFromID(submissionUser, fileID string) (string,
 	return filePath, nil
 }
 
+// GetFileIDByUserPathAndStatus checks if a file exists in the database for a given user and submission filepath
+// and returns its fileID for the latest specified status
+func (dbs *SDAdb) GetFileIDByUserPathAndStatus(submissionUser, filePath, status string) (string, error) {
+	var (
+		err    error
+		fileID string
+	)
+	// 2, 4, 8, 16, 32 seconds between each retry event.
+	for count := 1; count <= RetryTimes; count++ {
+		fileID, err = dbs.getFileIDByUserPathAndStatus(submissionUser, filePath, status)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Duration(math.Pow(2, float64(count))) * time.Second)
+	}
+
+	return fileID, err
+}
+
+func (dbs *SDAdb) getFileIDByUserPathAndStatus(submissionUser, filePath, status string) (string, error) {
+	dbs.checkAndReconnectIfNeeded()
+	db := dbs.DB
+
+	const getFileID = "SELECT id from sda.files " +
+		"WHERE submission_user=$1 and submission_file_path =$2 and stable_id IS null " +
+		"AND EXISTS (SELECT 1 FROM " +
+		"(SELECT event from sda.file_event_log JOIN sda.files ON sda.files.id=sda.file_event_log.file_id " +
+		"WHERE submission_user=$1 and submission_file_path =$2 order by started_at desc limit 1) " +
+		"AS subquery WHERE event = $3)"
+
+	var fileID string
+	err := db.QueryRow(getFileID, submissionUser, filePath, status).Scan(&fileID)
+	if err != nil {
+		return "", err
+	}
+
+	return fileID, nil
+}
+
 // UpdateFileEventLog updates the status in of the file in the database.
 // The message parameter is the rabbitmq message sent on file upload.
 func (dbs *SDAdb) UpdateFileEventLog(fileUUID, event, corrID, user, details, message string) error {

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -1239,6 +1239,9 @@ func (suite *DatabaseTests) TestGetFileIDByUserPathAndStatus() {
 	if err != nil {
 		suite.FailNow("Failed to register file")
 	}
+	// sanity check - should fail
+	_, err = db.GetFileIDByUserPathAndStatus("wrong-user", filePath, "registered")
+	assert.EqualError(suite.T(), err, "sql: no rows in result set")
 
 	// check happy path
 	fileID2, err := db.getFileIDByUserPathAndStatus(user, filePath, "registered")


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes a bug first reported by our endusers: #1358.

## Description
It provides a fix for the case when for example a client loses connection to the server while uploading a file and when connection is re-established the upload continues through a different s3inbox instance.  In such a case, the registered `fileID` for the file in question would not have been persisted on the new instance, but now it does.

## How to test
I found it somewhat difficult to come up with an automated test for this without a heavy refactoring of the code into small batches of separate functions (that would otherwise not serve any purpose) . Any ideas welcome!

I tested it locally by temporarily adding `p.fileIds[r.URL.Path] = ""` in line 202, building the image and bringing the sda stack up using the `make` commands, uploading a file to the inbox and seeing that the logs show no errors. Without the fix of the PR the previous procedure will reproduce the error seen on the cluster. Make sure to upload a file from scratch because otherwise the state of the database will render this test obsolete (as it happened when testing my initial fix..).

This should be fixed now. So PR open again.


Note: the failing test is not related to this PR per se.