### PR TITLE
[auth] Serve both raw (for download) and resigned (for upload) tokens

### DIFF
--- a/.github/integration/sda-s3-integration.yml
+++ b/.github/integration/sda-s3-integration.yml
@@ -282,6 +282,9 @@ services:
       - AUTH_RESIGNJWT=true
       - AUTH_CEGA_ID=test
       - AUTH_CEGA_SECRET=test
+      - OIDC_REDIRECTURL=http://localhost:8888/oidc/login
+      - OIDC_ID=XC56EL11zz
+      - OIDC_SECRET=wHPVQaYXmdDHa
       - DB_PASSWORD=auth
       - DB_USER=auth
     extra_hosts:

--- a/.github/integration/sda/aai-mock/clients/aai-auth.yaml
+++ b/.github/integration/sda/aai-mock/clients/aai-auth.yaml
@@ -1,4 +1,4 @@
-client-name: "auth"
+client-name: "aai-auth"
 client-id: "XC56EL11xx"
 client-secret: "wHPVQaYXmdDHg"
 redirect-uris: ["http://localhost:8801/oidc/login"]

--- a/.github/integration/sda/aai-mock/clients/cega-auth.yaml
+++ b/.github/integration/sda/aai-mock/clients/cega-auth.yaml
@@ -1,0 +1,8 @@
+client-name: "cega-auth"
+client-id: "XC56EL11zz"
+client-secret: "wHPVQaYXmdDHa"
+redirect-uris: ["http://localhost:8888/oidc/login"]
+token-endpoint-auth-method: "client_secret_basic"
+scope: ["openid", "profile", "email", "ga4gh_passport_v1", "eduperson_entitlement"]
+grant-types: ["authorization_code"]
+post-logout-redirect-uris: ["http://localhost:8888/oidc/login"]

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,13 @@ buildNumber.properties
 # End of https://www.gitignore.io/api/java,maven,eclipse,intellij+all
 
 db/
+
+# MacOS desktop service store
+.DS_Store
+
+# crypt4gh key files
+*.pub.pem
+*.sec.pem
+
+# sda-admin binary
+sda-admin/sda-admin

--- a/sda-download/dev_utils/config-notls_local.yaml
+++ b/sda-download/dev_utils/config-notls_local.yaml
@@ -32,4 +32,4 @@ db:
 oidc:
   # oidc configuration API must have values for "userinfo_endpoint" and "jwks_uri"
   configuration:
-    url: "http://localhost:8080/.well-known/openid-configuration"
+    url: "http://localhost:8800/oidc/.well-known/openid-configuration"

--- a/sda/cmd/auth/frontend/static/custom.css
+++ b/sda/cmd/auth/frontend/static/custom.css
@@ -7,7 +7,7 @@
 }
 
 #loginbox1 {
-    max-width: 600px;
+    max-width: 800px;
 }
 
 #logintext {

--- a/sda/cmd/auth/frontend/templates/ega.html
+++ b/sda/cmd/auth/frontend/templates/ega.html
@@ -31,18 +31,12 @@
               Welcome, {{.User}}!
             </p>
             {{if .Token}}
-            <p class="text-center">
-              Your access token is:
-            </p>
-            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.Token}}</pre>
+              <p class="text-center">
+                For <strong>uploading</strong> to the Inbox, your access token {{if .ExpDate}}(expires at {{.ExpDate}} UTC){{end}} is:
+              </p>
+              <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.Token}}</pre>
             {{end}}
-            {{if .ExpDate}}
-            <p class="text-center">
-              Your access token expires (UTC):
-            </p>
-            <pre class="text-center" id="logintext">{{.ExpDate}}</pre>
-            {{end}}
-            <a href="/ega/s3conf" class="btn btn-primary btn-block">Download inbox s3cmd credentials</a>
+            <a href="/ega/s3conf" class="btn btn-primary btn-block mb-5">Download credentials to upload to the Inbox</a>
             <a href="/" class="btn btn-primary btn-block">Continue</a>
       </div>
     </div>

--- a/sda/cmd/auth/frontend/templates/oidc.html
+++ b/sda/cmd/auth/frontend/templates/oidc.html
@@ -32,18 +32,18 @@
             </p>
             {{if .ResignedToken}}
             <p class="text-center">
-              Your access token {{if .ExpDateResigned}}(expires at {{.ExpDateResigned}} UTC){{end}} for uploading to the Inbox is:
+              For <strong>uploading</strong> to the Inbox, your access token {{if .ExpDateResigned}}(expires at {{.ExpDateResigned}} UTC){{end}} is:
             </p>
             <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.ResignedToken}}</pre>
             {{end}}
+            <a href="/oidc/s3conf-inbox" class="btn btn-primary btn-block mb-5">Download credentials to upload to the Inbox</a>
             {{if .RawToken}}
             <p class="text-center">
-              Your access token {{if .ExpDateRaw}}(expires at {{.ExpDateRaw}} UTC){{end}} for downloading from the Archive is:
+              For <strong>downloading</strong> from the Archive, your access token {{if .ExpDateRaw}}(expires at {{.ExpDateRaw}} UTC){{end}} is:
             </p>
             <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.RawToken}}</pre>
             {{end}}
-            <a href="/oidc/s3conf-inbox" class="btn btn-primary btn-block">Download credentials for uploading to the Inbox</a>
-            <a href="/oidc/s3conf-download" class="btn btn-primary btn-block">Download credentials for downloading from the Archive</a>
+            <a href="/oidc/s3conf-download" class="btn btn-primary btn-block mb-5">Download credentials to access the Archive</a>
             <a href="/" class="btn btn-primary btn-block">Continue</a>
       </div>
     </div>

--- a/sda/cmd/auth/frontend/templates/oidc.html
+++ b/sda/cmd/auth/frontend/templates/oidc.html
@@ -28,7 +28,7 @@
     <div class="jumbotron" role="region">
       <div class="container" id="loginbox1">
             <p class="lead text-center">
-              Welcome, {{.User}}!
+              Welcome, {{.Profile}}!
             </p>
             {{if .ResignedToken}}
             <p class="text-center">

--- a/sda/cmd/auth/frontend/templates/oidc.html
+++ b/sda/cmd/auth/frontend/templates/oidc.html
@@ -38,19 +38,20 @@
             <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.}}</pre>
             {{ end }}
             {{ end }}
-            {{if .Token}}
+            {{if .ResignedToken}}
             <p class="text-center">
-              Your access token is:
+              Your access token {{if .ExpDateResigned}}(expires at {{.ExpDateResigned}} UTC){{end}} for uploading to the Inbox is:
             </p>
-            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.Token}}</pre>
+            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.ResignedToken}}</pre>
             {{end}}
-            {{if .ExpDate}}
+            {{if .RawToken}}
             <p class="text-center">
-              Your access token expires (UTC):
+              Your access token {{if .ExpDateRaw}}(expires at {{.ExpDateRaw}} UTC){{end}} for downloading from the Archive is:
             </p>
-            <pre class="text-center" id="logintext">{{.ExpDate}}</pre>
+            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.RawToken}}</pre>
             {{end}}
-            <a href="/oidc/s3conf" class="btn btn-primary btn-block">Download inbox s3cmd credentials</a>
+            <a href="/oidc/s3conf-inbox" class="btn btn-primary btn-block">Download credentials for uploading to the Inbox</a>
+            <a href="/oidc/s3conf-download" class="btn btn-primary btn-block">Download credentials for downloading from the Archive</a>
             <a href="/" class="btn btn-primary btn-block">Continue</a>
       </div>
     </div>

--- a/sda/cmd/auth/frontend/templates/oidc.html
+++ b/sda/cmd/auth/frontend/templates/oidc.html
@@ -30,13 +30,15 @@
             <p class="lead text-center">
               Welcome, {{.Fullname}}!
             </p>
-            {{if .ResignedToken}}
-            <p class="text-center">
-              For <strong>uploading</strong> to the Inbox, your access token {{if .ExpDateResigned}}(expires at {{.ExpDateResigned}} UTC){{end}} is:
-            </p>
-            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.ResignedToken}}</pre>
+            {{if (not .cegaID)}}
+              {{if .ResignedToken}}
+              <p class="text-center">
+                For <strong>uploading</strong> to the Inbox, your access token {{if .ExpDateResigned}}(expires at {{.ExpDateResigned}} UTC){{end}} is:
+              </p>
+              <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.ResignedToken}}</pre>
+              {{end}}
+              <a href="/oidc/s3conf-inbox" class="btn btn-primary btn-block mb-5">Download credentials to upload to the Inbox</a>
             {{end}}
-            <a href="/oidc/s3conf-inbox" class="btn btn-primary btn-block mb-5">Download credentials to upload to the Inbox</a>
             {{if .RawToken}}
             <p class="text-center">
               For <strong>downloading</strong> from the Archive, your access token {{if .ExpDateRaw}}(expires at {{.ExpDateRaw}} UTC){{end}} is:

--- a/sda/cmd/auth/frontend/templates/oidc.html
+++ b/sda/cmd/auth/frontend/templates/oidc.html
@@ -28,7 +28,7 @@
     <div class="jumbotron" role="region">
       <div class="container" id="loginbox1">
             <p class="lead text-center">
-              Welcome, {{.Profile}}!
+              Welcome, {{.Fullname}}!
             </p>
             {{if .ResignedToken}}
             <p class="text-center">

--- a/sda/cmd/auth/frontend/templates/oidc.html
+++ b/sda/cmd/auth/frontend/templates/oidc.html
@@ -30,14 +30,6 @@
             <p class="lead text-center">
               Welcome, {{.User}}!
             </p>
-            {{if .Passport}}
-            <p class="text-center">
-              Your visas are the following:
-            </p>
-            {{ range .Passport }}
-            <pre class="border border-secondary rounded py-2 px-3 my-4" id="logintext">{{.}}</pre>
-            {{ end }}
-            {{ end }}
             {{if .ResignedToken}}
             <p class="text-center">
               Your access token {{if .ExpDateResigned}}(expires at {{.ExpDateResigned}} UTC){{end}} for uploading to the Inbox is:

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -280,7 +280,7 @@ func (auth AuthHandler) elixirLogin(ctx iris.Context) *OIDCData {
 			jwt.ExpirationKey: time.Now().UTC().Add(time.Duration(auth.Config.JwtTTL) * time.Hour),
 			jwt.IssuedAtKey:   time.Now().UTC(),
 			jwt.IssuerKey:     auth.Config.JwtIssuer,
-			jwt.SubjectKey:    idStruct.Profile,
+			jwt.SubjectKey:    idStruct.User,
 		}
 		token, expDate, err := generateJwtToken(claims, auth.Config.JwtPrivateKey, auth.Config.JwtSignatureAlg)
 		if err != nil {
@@ -311,6 +311,7 @@ func (auth AuthHandler) getOIDCLogin(ctx iris.Context) {
 	ctx.ViewData("infoUrl", auth.Config.InfoURL)
 	ctx.ViewData("infoText", auth.Config.InfoText)
 	ctx.ViewData("User", oidcData.OIDCID.User)
+	ctx.ViewData("Profile", oidcData.OIDCID.Profile)
 	ctx.ViewData("Passport", oidcData.OIDCID.Passport)
 	ctx.ViewData("RawToken", oidcData.OIDCID.RawToken)
 	ctx.ViewData("ResignedToken", oidcData.OIDCID.ResignedToken)

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -269,7 +269,7 @@ func (auth AuthHandler) elixirLogin(ctx iris.Context) *OIDCData {
 
 		return nil
 	}
-	err = auth.Config.DB.UpdateUserInfo(idStruct.User, idStruct.Profile, idStruct.Email, idStruct.EdupersonEntitlement)
+	err = auth.Config.DB.UpdateUserInfo(idStruct.User, idStruct.Fullname, idStruct.Email, idStruct.EdupersonEntitlement)
 	if err != nil {
 		log.Warn("Could not log user info.")
 	}
@@ -311,7 +311,7 @@ func (auth AuthHandler) getOIDCLogin(ctx iris.Context) {
 	ctx.ViewData("infoUrl", auth.Config.InfoURL)
 	ctx.ViewData("infoText", auth.Config.InfoText)
 	ctx.ViewData("User", oidcData.OIDCID.User)
-	ctx.ViewData("Profile", oidcData.OIDCID.Profile)
+	ctx.ViewData("Fullname", oidcData.OIDCID.Fullname)
 	ctx.ViewData("Passport", oidcData.OIDCID.Passport)
 	ctx.ViewData("RawToken", oidcData.OIDCID.RawToken)
 	ctx.ViewData("ResignedToken", oidcData.OIDCID.ResignedToken)

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -220,7 +220,7 @@ func (auth AuthHandler) getEGALogin(ctx iris.Context) {
 
 // getEGAConf returns an s3config file for an oidc login
 func (auth AuthHandler) getEGAConf(ctx iris.Context) {
-	auth.getS3Config(ctx, "ega", "s3cmd.conf")
+	auth.getS3Config(ctx, "ega", "s3cmd-inbox.conf")
 }
 
 // getOIDC redirects to the oidc page defined in auth.Config

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -27,9 +27,9 @@ type LoginOption struct {
 }
 
 type OIDCData struct {
-	S3ConfInbox map[string]string
+	S3ConfInbox    map[string]string
 	S3ConfDownload map[string]string
-	OIDCID OIDCIdentity
+	OIDCID         OIDCIdentity
 }
 
 type AuthHandler struct {
@@ -341,12 +341,12 @@ func (auth AuthHandler) getOIDCCORSLogin(ctx iris.Context) {
 	}
 }
 
-// getOIDCConfInbox returns an s3config file for uploading to the Inbox 
+// getOIDCConfInbox returns an s3config file for uploading to the Inbox
 func (auth AuthHandler) getOIDCConfInbox(ctx iris.Context) {
 	auth.getS3Config(ctx, "oidcInbox", "s3cmd-inbox.conf")
 }
 
-// getOIDCConfDownload returns an s3config file for downloading from the Archive 
+// getOIDCConfDownload returns an s3config file for downloading from the Archive
 func (auth AuthHandler) getOIDCConfDownload(ctx iris.Context) {
 	auth.getS3Config(ctx, "oidcDownload", "s3cmd-download.conf")
 }

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -308,6 +308,7 @@ func (auth AuthHandler) getOIDCLogin(ctx iris.Context) {
 	s := sessions.Get(ctx)
 	s.SetFlash("oidcInbox", oidcData.S3ConfInbox)
 	s.SetFlash("oidcDownload", oidcData.S3ConfDownload)
+	ctx.ViewData("cegaID", auth.Config.Cega.ID)
 	ctx.ViewData("infoUrl", auth.Config.InfoURL)
 	ctx.ViewData("infoText", auth.Config.InfoText)
 	ctx.ViewData("User", oidcData.OIDCID.User)

--- a/sda/cmd/auth/oidc.go
+++ b/sda/cmd/auth/oidc.go
@@ -20,7 +20,7 @@ type OIDCIdentity struct {
 	Passport             []string
 	RawToken             string
 	ResignedToken        string
-	Profile              string
+	Fullname             string
 	Email                string
 	EdupersonEntitlement []string
 	ExpDateRaw           string
@@ -94,7 +94,7 @@ func authenticateWithOidc(oauth2Config oauth2.Config, provider *oidc.Provider, c
 	// Extract custom passports, name and email claims
 	var claims struct {
 		PassportClaim        []string `json:"ga4gh_passport_v1"`
-		ProfileClaim         string   `json:"name"`
+		FullnameClaim        string   `json:"name"`
 		EmailClaim           string   `json:"email"`
 		EdupersonEntitlement []string `json:"eduperson_entitlement"`
 	}
@@ -109,7 +109,7 @@ func authenticateWithOidc(oauth2Config oauth2.Config, provider *oidc.Provider, c
 		RawToken:             rawAccessToken,
 		ResignedToken:        rawAccessToken,
 		Passport:             claims.PassportClaim,
-		Profile:              claims.ProfileClaim,
+		Fullname:             claims.FullnameClaim,
 		Email:                claims.EmailClaim,
 		EdupersonEntitlement: claims.EdupersonEntitlement,
 		ExpDateRaw:           rawExpDate,

--- a/sda/cmd/auth/oidc.go
+++ b/sda/cmd/auth/oidc.go
@@ -107,7 +107,7 @@ func authenticateWithOidc(oauth2Config oauth2.Config, provider *oidc.Provider, c
 	idStruct = OIDCIdentity{
 		User:                 userInfo.Subject,
 		RawToken:             rawAccessToken,
-		ResignedToken: 	      rawAccessToken,
+		ResignedToken:        rawAccessToken,
 		Passport:             claims.PassportClaim,
 		Profile:              claims.ProfileClaim,
 		Email:                claims.EmailClaim,

--- a/sda/cmd/auth/oidc.go
+++ b/sda/cmd/auth/oidc.go
@@ -18,11 +18,13 @@ import (
 type OIDCIdentity struct {
 	User                 string
 	Passport             []string
-	Token                string
+	RawToken             string
+	ResignedToken        string
 	Profile              string
 	Email                string
 	EdupersonEntitlement []string
-	ExpDate              string
+	ExpDateRaw           string
+	ExpDateResigned      string
 }
 
 // Configure an OpenID Connect aware OAuth2 client.
@@ -104,12 +106,14 @@ func authenticateWithOidc(oauth2Config oauth2.Config, provider *oidc.Provider, c
 
 	idStruct = OIDCIdentity{
 		User:                 userInfo.Subject,
-		Token:                rawAccessToken,
+		RawToken:             rawAccessToken,
+		ResignedToken: 	      rawAccessToken,
 		Passport:             claims.PassportClaim,
 		Profile:              claims.ProfileClaim,
 		Email:                claims.EmailClaim,
 		EdupersonEntitlement: claims.EdupersonEntitlement,
-		ExpDate:              rawExpDate,
+		ExpDateRaw:           rawExpDate,
+		ExpDateResigned:      rawExpDate,
 	}
 
 	return idStruct, err


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1337 


## Description
This PR allows `auth` to serve both raw and resigned tokens as well as their corresponding s3 config files.
This PR is based on the branch `tests/mock-aai` in which the service `mock-aai` is implemented. Nevertheless, the changes of this PR and the changes in the branch `tests/mock-aai` are in different folders of code so there's no conflict when merging to the main branch.

## How to test
1. Start the SDA services with resignJWT enabled by 
setting `AUTH_RESIGNJWT=true` in the file `.github/integration/sda-s3-integration.yml`
and `server.jwtpubkeypath : "/shared/keys/pub/"` in the config file `.github/integration/sda/config.yaml`.


then run 
```sh
make sda-s3-up
```

2. When the services are up, visit http://localhost:8801 and login with the `Test User`, check that there are two different tokens and also click the download buttons for two different S3 config files, that is, `s3cmd-inbox.conf` and `s3cmd-download.conf`.

3. Modify bucket base and use_https for local testing.
For Mac:
```sh
sed -i '' '/host_/s/inbox:8000/localhost:18000/g' s3cmd-inbox.conf
sed -i '' '/host_/s/inbox:8000/localhost:18000/g' s3cmd-download.conf
sed -i '' 's/use_https = True/use_https = False/g' s3cmd-inbox.conf
sed -i '' 's/use_https = True/use_https = False/g' s3cmd-download.conf
```
For Linux:
```sh
sed -i  '/host_/s/inbox:8000/localhost:18000/g' s3cmd-inbox.conf 
sed -i  '/host_/s/inbox:8000/localhost:18000/g' s3cmd-download.conf
sed -i  's/use_https = True/use_https = False/g' s3cmd-inbox.conf
sed -i  's/use_https = True/use_https = False/g' s3cmd-download.conf
```

4. create test files
```sh
for i in $(seq 2); do seq $i > /tmp/t$i.txt; done
```
**Test uploading**
5. Test uploading with the config file `s3cmd-inbox.conf` and it should work.
```sh
sda-cli -config s3cmd-inbox.conf upload -encrypt-with-key mykey.pub.pem /tmp/t1.txt
```

6. Test uploading with the config file `s3cmd-download.conf` and it should fail.
```sh
sda-cli -config s3cmd-download.conf upload -encrypt-with-key mykey.pub.pem /tmp/t3.txt  

Consider renewing the token.
Error: listing uploaded files: failed to list objects, reason: Unauthorized: not authorized
	status code: 401, request id: , host id: 
```

**Test downloading**
7. Start the download service by running the following command in the folder `sda-download`
```sh
 CONFIGFILE=dev_utils/config-notls_local.yaml go run cmd/main.go 
 ```
8. Test accessing the download endpoint with the resigned token and it should fail with `get visas failed`
```sh
token=$(grep token s3cmd-inbox.conf | awk '{print $3}')
curl  -H "Authorization: Bearer $token" http://localhost:18080/metadata/datasets    
```

9. Test accessing the download endpoint with the raw token and it should work (return an empty list) 
```sh
token=$(grep token s3cmd-download.conf | awk '{print $3}')
curl  -H "Authorization: Bearer $token" http://localhost:18080/metadata/datasets  
```


