### PR TITLE
Add Download API specification

### DIFF
--- a/sda/cmd/download/download.go
+++ b/sda/cmd/download/download.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -13,12 +13,6 @@ paths:
           required: true
           schema:
             type: string
-        - in: header
-          description: "The JWT used to authenticate the user"
-          name: token
-          required: true
-          schema:
-            type: string
         - in: query
           name: dataset
           schema:
@@ -90,12 +84,6 @@ paths:
           required: true
           schema:
             type: string
-        - in: header
-          description: "The JWT used to authenticate the user"
-          name: token
-          required: true
-          schema:
-            type: string
         - in: path
           name: fileId
           schema:
@@ -107,7 +95,8 @@ paths:
           required: false
           schema:
             type: string
-          description: Byte range of the file that is to be delivered
+          description: 0-indexed byte range of the file that is to be delivered.
+          example: "Range: bytes=20-200, 300-400"
       responses:
         "200":
           content:
@@ -230,7 +219,7 @@ paths:
         - bearerAuth: []
   /ready:
     get:
-      description: Returns the status of the application, used by the kubernets API to decide if traffic should be routed to the app
+      description: Returns the status of the application, used by the Kubernets API to decide if traffic should be routed to the app
       responses:
         "200":
           description: The service is operational

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -59,14 +59,21 @@ paths:
                 type: string
                 format: binary
           description: successful operation
+        "206":
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: successful partial file delivery
         "400":
-          description: Invalid file reference
+          description: Bad request i.e start larger than end
         "401":
           description: Authentication failure
         "403":
           description: The user does not have access to the dataset
         "416":
-          description: Range Not Satisfiable
+          description: Unsatisfiable range i.e. end larger than file size
         "500":
           description: Internal application error
       security:
@@ -93,20 +100,11 @@ paths:
             type: string
           required: true
           description: Stable ID of the file to download
-        - in: query
-          name: end
+        - in: header
+          name: Range
           required: false
           schema:
-            default: 0
-            minimum: 0
-            type: integer
-        - in: query
-          name: start
-          required: false
-          schema:
-            default: 0
-            minimum: 0
-            type: integer
+            type: string
       responses:
         "200":
           content:
@@ -115,12 +113,21 @@ paths:
                 type: string
                 format: binary
           description: successful operation
+        "206":
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: successful partial file delivery
         "400":
-          description: Invalid file reference
+          description: Bad request i.e start larger than end
         "401":
           description: Authentication failure
         "403":
           description: The user does not have access to the dataset
+        "416":
+          description: Unsatisfiable range i.e. end larger than file size
         "500":
           description: Internal application error
       security:
@@ -138,6 +145,8 @@ paths:
                 type: array
         "401":
           description: Authentication failure
+        "500":
+          description: Internal application error
       security:
         - bearerAuth: []
   /info/datasets/{datasetId}:

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -8,7 +8,7 @@ paths:
       description: Returns the requested file to the user
       parameters:
         - in: header
-          description: "Public key used to re-encrypt the file header with"
+          description: "Public key used to re-encrypt the file (header) with. This should be supplied as the base64 encoding of the PEM (RFC 7468) encoding of the public key"
           name: public_key
           required: true
           schema:
@@ -30,18 +30,20 @@ paths:
           schema:
             type: string
           required: false
-          description: Stable ID of the file to download
+          description: Stable ID of the file to download. It is an error to supply both filePath and fileId
         - in: query
           name: filePath
           schema:
             type: string
           required: false
-          description: File path of the file to download
+          description: File path of the file to download. It is an error to supply both filePath and fileId
         - in: query
           name: end
+          description: 'End of requested data in the form of the 0-index of the first octet not included in the
+                                 response. That is, data delivered will have octet indices in the closed-open set
+                                 [start,end). Defaults to end of file if not set'
           required: false
           schema:
-            default: 0
             minimum: 0
             type: integer
         - in: query

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -60,14 +60,14 @@ paths:
               schema:
                 type: string
                 format: binary
-          description: successful operation
+          description: Successful operation
         "206":
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-          description: successful partial file delivery
+          description: Successful partial file delivery
         "400":
           description: Bad request i.e start larger than end
         "401":
@@ -107,6 +107,7 @@ paths:
           required: false
           schema:
             type: string
+          description: Byte range of the file that is to be delivered
       responses:
         "200":
           content:
@@ -114,14 +115,14 @@ paths:
               schema:
                 type: string
                 format: binary
-          description: successful operation
+          description: Successful operation
         "206":
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-          description: successful partial file delivery
+          description: Successful partial file delivery
         "400":
           description: Bad request i.e start larger than end
         "401":
@@ -139,7 +140,7 @@ paths:
       description: Returns a list of the datasets the user has access to, an empty list is a valid response.
       responses:
         "200":
-          description: successful operation
+          description: Successful operation
           content:
             application/json:
               example: ["aa-dataset-123456-asdfgh", "bb-dataset-123456-asdfgh"]
@@ -179,7 +180,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DatasetInfo"
-          description: successful operation
+          description: Successful operation
         "401":
           description: Authentication failure
         "403":
@@ -218,7 +219,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/FileInfo"
-          description: successful operation
+          description: Successful operation
         "401":
           description: Authentication failure
         "403":

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -20,6 +20,12 @@ paths:
           schema:
             type: string
         - in: query
+          name: dataset
+          schema:
+            type: string
+          required: true
+          description: Stable ID of the dataset
+        - in: query
           name: fileId
           schema:
             type: string

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -1,0 +1,258 @@
+openapi: 3.0.3
+info:
+  title: SDA file download API
+  version: "1.0"
+paths:
+  /file:
+    get:
+      description: Returns the requested file to the user
+      parameters:
+        - in: header
+          description: "Public key used to re-encrypt the file header with"
+          name: public_key
+          required: true
+          schema:
+            type: string
+        - in: header
+          description: "The JWT used to authenticate the user"
+          name: token
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: fileId
+          schema:
+            type: string
+          required: false
+          description: Stable ID of the file to download
+        - in: query
+          name: filePath
+          schema:
+            type: string
+          required: false
+          description: File path of the file to download
+        - in: query
+          name: end
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: query
+          name: start
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: successful operation
+        "400":
+          description: Invalid file reference
+        "401":
+          description: Authentication failure
+        "403":
+          description: The user does not have access to the dataset
+        "416":
+          description: Range Not Satisfiable
+        "500":
+          description: Internal application error
+      security:
+        - bearerAuth: []
+  /file/{fileId}:
+    get:
+      description: Returns the requested file to the user
+      parameters:
+        - in: header
+          description: "Public key used to re-encrypt the file header with"
+          name: public_key
+          required: true
+          schema:
+            type: string
+        - in: header
+          description: "The JWT used to authenticate the user"
+          name: token
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: fileId
+          schema:
+            type: string
+          required: true
+          description: Stable ID of the file to download
+        - in: query
+          name: end
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - in: query
+          name: start
+          required: false
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: successful operation
+        "400":
+          description: Invalid file reference
+        "401":
+          description: Authentication failure
+        "403":
+          description: The user does not have access to the dataset
+        "500":
+          description: Internal application error
+      security:
+        - bearerAuth: []
+  /info/datasets:
+    get:
+      description: Returns a list of the datasets the user has access to, an empty list is a valid response.
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              example: ["aa-dataset-123456-asdfgh", "bb-dataset-123456-asdfgh"]
+              schema:
+                type: array
+        "401":
+          description: Authentication failure
+      security:
+        - bearerAuth: []
+  /info/datasets/{datasetId}:
+    get:
+      description: Returns an array with metadata about the dataset
+      parameters:
+        - in: header
+          description: "Public key used to re-encrypt the file header with"
+          name: public_key
+          required: true
+          schema:
+            type: string
+        - in: header
+          description: "The JWT used to authenticate the user"
+          name: token
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: datasetId
+          schema:
+            type: string
+          required: true
+          description: Stable ID of the dataset of interest
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatasetInfo"
+          description: successful operation
+        "401":
+          description: Authentication failure
+        "403":
+          description: The user does not have access to the dataset
+        "500":
+          description: Internal application error
+      security:
+        - bearerAuth: []
+  /info/datasets/{datasetId}/files:
+    get:
+      description: Returns an array with metadata about all files in a dataset
+      parameters:
+        - in: header
+          description: "Public key used to re-encrypt the file header with"
+          name: public_key
+          required: true
+          schema:
+            type: string
+        - in: header
+          description: "The JWT used to authenticate the user"
+          name: token
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: datasetId
+          schema:
+            type: string
+          required: true
+          description: Stable ID of the dataset of interest
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/FileInfo"
+          description: successful operation
+        "401":
+          description: Authentication failure
+        "403":
+          description: The user does not have access to the dataset
+        "500":
+          description: Internal application error
+      security:
+        - bearerAuth: []
+  /ready:
+    get:
+      description: Returns the status of the application, used by the kubernets API to decide if traffic should be routed to the app
+      responses:
+        "200":
+          description: The service is operational
+        "503":
+          description: Unhealthy service
+components:
+  schemas:
+    DatasetInfo:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date-time
+          example: "2025-02-14T14:51:26.639Z"
+        files:
+          type: integer
+          format: int32
+          example: 1234
+        name:
+          type: string
+          example: aa-dataset-123456-asdfgh
+        size:
+          type: integer
+          format: int64
+          example: 6597069766656
+    FileInfo:
+      type: object
+      properties:
+        filePath:
+          type: string
+          example: "samples/controls/sample1.cram.c4gh"
+        size:
+          type: integer
+          format: int64
+          example: 56623104
+        stableId:
+          type: string
+          example: aa-file-123456-asdfgh
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -95,7 +95,7 @@ paths:
           required: false
           schema:
             type: string
-          description: 0-indexed byte range of the file that is to be delivered.
+          description: 0-indexed byte range of the file that is to be delivered as per RFC7233.
           example: "Range: bytes=20-200, 300-400"
       responses:
         "200":

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -2,13 +2,14 @@ openapi: 3.0.3
 info:
   title: SDA file download API
   version: "1.0"
+  description: This is the external data out API for the Sensitive Data Archive. Data is delivered encrypted with a user supplied crypth4gh public key.
 paths:
   /file:
     get:
-      description: Returns the requested file to the user
+      description: Returns the requested file to the user. Uses query parameters in order to handle files requested by the `filePath` entity.
       parameters:
         - in: header
-          description: "Public key used to re-encrypt the file (header) with. This should be supplied as the base64 encoding of the PEM (RFC 7468) encoding of the public key"
+          description: Public key used to re-encrypt the file (header) with. This should be supplied as the base64 encoding of the PEM (RFC 7468) encoding of the public key
           name: public_key
           required: true
           schema:
@@ -18,7 +19,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Stable ID of the dataset
+          description: Dataset identifier
         - in: query
           name: fileId
           schema:
@@ -33,15 +34,14 @@ paths:
           description: File path of the file to download. It is an error to supply both filePath and fileId
         - in: query
           name: end
-          description: 'End of requested data in the form of the 0-index of the first octet not included in the
-                                 response. That is, data delivered will have octet indices in the closed-open set
-                                 [start,end). Defaults to end of file if not set'
+          description: End of requested data in the form of the 0-index of the first octet not included in the response. That is, data delivered will have octet indices in the closed-open set [start,end). Defaults to end of file if not set
           required: false
           schema:
             minimum: 0
             type: integer
         - in: query
           name: start
+          description: Start of the requested data. Defaults to start of file if not set
           required: false
           schema:
             default: 0
@@ -63,23 +63,23 @@ paths:
                 format: binary
           description: Successful partial file delivery
         "400":
-          description: Bad request i.e start larger than end
+          description: Bad request ex. start larger than end
         "401":
           description: Authentication failure
         "403":
           description: The user does not have access to the dataset
         "416":
-          description: Unsatisfiable range i.e. end larger than file size
+          description: Unsatisfiable range ex. start larger than the size of the file
         "500":
           description: Internal application error
       security:
         - bearerAuth: []
   /file/{fileId}:
     get:
-      description: Returns the requested file to the user
+      description: Returns the requested file to the user.
       parameters:
         - in: header
-          description: "Public key used to re-encrypt the file header with"
+          description: Public key used to re-encrypt the file (header) with. This should be supplied as the base64 encoding of the PEM (RFC 7468) encoding of the public key
           name: public_key
           required: true
           schema:
@@ -113,13 +113,13 @@ paths:
                 format: binary
           description: Successful partial file delivery
         "400":
-          description: Bad request i.e start larger than end
+          description: Bad request ex. start larger than end
         "401":
           description: Authentication failure
         "403":
           description: The user does not have access to the dataset
         "416":
-          description: Unsatisfiable range i.e. end larger than file size
+          description: Unsatisfiable range ex. start larger than the size of the file
         "500":
           description: Internal application error
       security:
@@ -150,7 +150,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Stable ID of the dataset of interest
+          description: Dataset identifier
       responses:
         "200":
           content:
@@ -175,7 +175,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Stable ID of the dataset of interest
+          description: Dataset identifier
       responses:
         "200":
           content:
@@ -193,14 +193,29 @@ paths:
           description: Internal application error
       security:
         - bearerAuth: []
-  /ready:
+  /health/ready:
     get:
-      description: Returns the status of the application, used by the Kubernets API to decide if traffic should be routed to the app
+      description: Returns the status of the application.
       responses:
         "200":
+          content:
+            application/json:
+              example:
+                {
+                  "c4ghService": "responding",
+                  "database": "responding",
+                  "oidcServer": "responding",
+                  "storageBackend": "responding",
+                }
           description: The service is operational
         "503":
           description: Unhealthy service
+  /health/live:
+    get:
+      description: Returns 200 as long as the main thread is running
+      responses:
+        "200":
+          description: The service is operational
 components:
   schemas:
     DatasetInfo:
@@ -226,7 +241,7 @@ components:
       properties:
         filePath:
           type: string
-          example: "samples/controls/sample1.cram.c4gh"
+          example: samples/controls/sample1.cram.c4gh
         size:
           type: integer
           format: int64

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -141,18 +141,12 @@ paths:
           description: Internal application error
       security:
         - bearerAuth: []
-  /info/datasets/{datasetId}:
+  /info/dataset:
     get:
       description: Returns an array with metadata about the dataset
       parameters:
-        - in: header
-          description: "Public key used to re-encrypt the file header with"
-          name: public_key
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: datasetId
+        - in: query
+          name: dataset
           schema:
             type: string
           required: true
@@ -172,18 +166,12 @@ paths:
           description: Internal application error
       security:
         - bearerAuth: []
-  /info/datasets/{datasetId}/files:
+  /info/dataset/files:
     get:
       description: Returns an array with metadata about all files in a dataset
       parameters:
-        - in: header
-          description: "Public key used to re-encrypt the file header with"
-          name: public_key
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: datasetId
+        - in: query
+          name: dataset
           schema:
             type: string
           required: true

--- a/sda/cmd/download/swagger_v1.yml
+++ b/sda/cmd/download/swagger_v1.yml
@@ -151,12 +151,6 @@ paths:
           required: true
           schema:
             type: string
-        - in: header
-          description: "The JWT used to authenticate the user"
-          name: token
-          required: true
-          schema:
-            type: string
         - in: path
           name: datasetId
           schema:
@@ -185,12 +179,6 @@ paths:
         - in: header
           description: "Public key used to re-encrypt the file header with"
           name: public_key
-          required: true
-          schema:
-            type: string
-        - in: header
-          description: "The JWT used to authenticate the user"
-          name: token
           required: true
           schema:
             type: string


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1378 .


## Description
The `/file/{fileId}:` is optional since the same functionality exists in the `/file` endpoint. Although it provides a more convenient way to get a file out.

### Endpoints

`/file` - endpoint that takes query arguments to return a file by ID or path, the dataset name is a required parameter. 
`/file/{file_stable_id}` - endpoint that returns the file withe the corresponding stable_id

`/info/datasets` - returns a list of datasets the user has access to
`/info/datasets/{dataset_name}` - returns information about the requested dataset
`/info/datasets/{dataset_name}/files` - returns information about the files in the dataset

## How to test
Paste the contents of the yaml file into: https://editor-next.swagger.io/ for a nicer view