### PR TITLE
add release_v1 prefix to dependabot commit-message

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -56,7 +56,7 @@ updates:
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
-      interval: "weekly"
+      interval: weekly
 
   - package-ecosystem: gomod
     directory: "/sda-download"
@@ -109,7 +109,7 @@ updates:
     target-branch: release_v1
     directory: "/postgresql"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -120,7 +120,7 @@ updates:
     target-branch: release_v1
     directory: "/rabbitmq"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -131,7 +131,7 @@ updates:
     target-branch: release_v1
     directory: "/sda"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -142,7 +142,7 @@ updates:
     target-branch: release_v1
     directory: "/sda-doa"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -153,7 +153,7 @@ updates:
     target-branch: release_v1
     directory: "/sda-download"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -164,7 +164,7 @@ updates:
     target-branch: release_v1
     directory: "/sda-sftp-inbox"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
@@ -183,7 +183,7 @@ updates:
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "[release_v1]"
 
@@ -198,7 +198,7 @@ updates:
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "[release_v1]"
 ### GO
@@ -213,7 +213,7 @@ updates:
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "[release_v1]"
 
@@ -228,6 +228,6 @@ updates:
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: "[release_v1]"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -113,6 +113,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: docker
     target-branch: release_v1
@@ -122,6 +124,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: docker
     target-branch: release_v1
@@ -131,6 +135,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: docker
     target-branch: release_v1
@@ -140,6 +146,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: docker
     target-branch: release_v1
@@ -149,6 +157,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: docker
     target-branch: release_v1
@@ -158,6 +168,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "neicnordic/sensitive-data-development-collaboration"
+    commit-message:
+      prefix: "[release_v1]"
 
 ### JAVA
   - package-ecosystem: maven
@@ -172,6 +184,8 @@ updates:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: maven
     target-branch: release_v1
@@ -185,6 +199,8 @@ updates:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[release_v1]"
 ### GO
   - package-ecosystem: gomod
     target-branch: release_v1
@@ -198,6 +214,8 @@ updates:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[release_v1]"
 
   - package-ecosystem: gomod
     target-branch: release_v1
@@ -211,3 +229,5 @@ updates:
       - "neicnordic/sensitive-data-development-collaboration"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[release_v1]"


### PR DESCRIPTION
add release_v1 prefix to commit messages of dependabot prs toward release_v1, for better differentiation

## Related issue(s) and PR(s)
This PR closes [#1396].

## Description
It will look like this:
![Screenshot 2025-02-17 at 11 53 37](https://github.com/user-attachments/assets/1cd5db2c-b90b-462b-89a5-b8064fa35464)


## How to test
