### PR TITLE
Bugfix in the sda-svc helm chart

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 0.30.5
+version: 0.30.6
 appVersion: v0.3.196
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/templates/api-deploy.yaml
+++ b/charts/sda-svc/templates/api-deploy.yaml
@@ -189,6 +189,8 @@ spec:
         - name: LOG_LEVEL
           value: {{ .Values.global.log.level | quote }}
     {{- end }}
+        - name: SCHEMA_TYPE
+          value: {{ default "federated" .Values.global.schemaType }}
     {{- if .Values.global.api.jwtPubKeyName }}
         - name: SERVER_JWTPUBKEYPATH
           value: {{ include "jwtPath" . }}

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -94,7 +94,7 @@ spec:
           value: "{{ .Values.global.archive.volumePath }}"
       {{- end }}
         - name: OIDC_CONFIGURATION_URL
-          value: "{{ .Values.global.oidc.provider }}/.well-known/openid-configuration"
+          value: "{{ .Values.global.oidc.provider | trimSuffix "/" }}/.well-known/openid-configuration"
       {{- if .Values.global.download.trusted.iss }}
         - name: OIDC_TRUSTED_ISS
           value: {{ include "trustedIssPath" . }}/{{ default "iss.json" .Values.global.download.trusted.configFile }}


### PR DESCRIPTION
Closes #1069

## Description
This PR fixes some issues with the sda-svc chart
- SCHEMA_TYPE is added to the list of ENVs for the API service so that it will work properly in any deployment scenario.
- OIDC_CONFIGURATION_URL in the download service strips the `/` as the last character in the OIDC URL. This is to prevent a string concatenation error.

## How to test
make k3d-create-cluster
make k3d-import-images
make k3d-deploy-dependencies
make k3d-deploy-postgres
make 3d-deploy-rabbitmq
make k3d-deploy-sda-s3