### PR TITLE
configure Dependabot for elixir-no Maven registry

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  maven-github-elixir-no:
+    type: maven-repository
+    url: 'https://maven.pkg.github.com/ELIXIR-NO'
+    username: '${{secrets.DOA_MAVEN_GITHUB_USERNAME}}'
+    password: '${{secrets.DOA_MAVEN_GITHUB_TOKEN}}'
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -85,6 +91,7 @@ updates:
 
   - package-ecosystem: maven
     directory: "/sda-doa"
+    registries: "*"
     groups:
       all-modules:
         patterns:
@@ -175,6 +182,7 @@ updates:
   - package-ecosystem: maven
     target-branch: release_v1
     directory: "/sda-doa"
+    registries: "*"
     groups:
       all-modules:
         patterns:


### PR DESCRIPTION
## Related issue(s) and PR(s)
Related to his issue [#901].


## Description
Configured dependabot to access the ELIXIR-NO Maven registry. This is added because sda-doa now use 2 dependencies from this repo(clearinghouse and crypt4gh).

