### PR TITLE
Update Go to version 1.24

### DIFF
--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -8,7 +8,7 @@ on:
       - '**/go.*'
 
 env:
-  go-version: '1.23'
+  go-version: '1.24'
 
 jobs:
   lint_download:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore: [main]
 
 env:
-  go-version: '1.23'
+  go-version: '1.24'
 
 jobs:
 

--- a/sda-admin/go.mod
+++ b/sda-admin/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sensitive-data-archive/sda-admin
 
-go 1.23.1
+go 1.24.0
 
 require (
 	github.com/neicnordic/crypt4gh v1.12.0

--- a/sda-download/.github/workflows/test.yml
+++ b/sda-download/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - "schemas/**"
 
 env:
-  go-version: '1.23'
+  go-version: '1.24'
 
 jobs:
   build:

--- a/sda-download/Dockerfile
+++ b/sda-download/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ENV GOPATH=$PWD
 ENV CGO_ENABLED=0

--- a/sda-download/go.mod
+++ b/sda-download/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sda-download
 
-go 1.23.1
+go 1.24.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/sda/Dockerfile
+++ b/sda/Dockerfile
@@ -1,4 +1,4 @@
-FROM "golang:${GOLANG_VERSION:-1.23}-bullseye" AS Build
+FROM "golang:${GOLANG_VERSION:-1.24}-bullseye" AS Build
 ENV GO111MODULE=on
 ENV GOPATH=$PWD
 ENV CGO_ENABLED=0

--- a/sda/go.mod
+++ b/sda/go.mod
@@ -1,6 +1,6 @@
 module github.com/neicnordic/sensitive-data-archive
 
-go 1.23.1
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.1


### PR DESCRIPTION
## Description
This PR updates all GO instances to use version `1.24`

## How to test
Taken care of by GitHub