### PR TITLE
Remove junit dependency to avoid conflicts

### DIFF
--- a/sda-doa/pom.xml
+++ b/sda-doa/pom.xml
@@ -108,12 +108,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.11.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>no.elixir</groupId>
             <artifactId>crypt4gh</artifactId>
             <version>3.0.5</version>


### PR DESCRIPTION
## Description
This pr removes junit-jupiter-api dependency, allowing spring boot to manage junit dependencies (api, engine, ...) to avoid conflicts and version mismatches.


