### PR TITLE
fix blank page on failed ega login

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ Bootstrap the dependencies with the command: `make k3d-deploy-dependencies`.
 
 Start by building and importing the required containers using the `make k3d-import-images`.
 
-The Postgres and RabbitMQ Needs to be deployed first using the following commands: `make k3d-deplploy-postgres` and `make k3d-deploy-rabbitmq`.
+The Postgres and RabbitMQ Needs to be deployed first using the following commands: `make k3d-deploy-postgres` and `make k3d-deploy-rabbitmq`.
 
-Once the DB and MQ are installed the SDA stack can be installed, here the desired storage backend needs to specified as well (`posix` or `s3`), `make k3d-deplpoy-sda-posix` or `make k3d-deplpoy-sda-s3`.
+Once the DB and MQ are installed the SDA stack can be installed, here the desired storage backend needs to specified as well (`posix` or `s3`), `make k3d-deploy-sda-posix` or `make k3d-deploy-sda-s3`.
 
 #### Testing with ingress
 

--- a/sda/cmd/auth/cega.go
+++ b/sda/cmd/auth/cega.go
@@ -11,11 +11,6 @@ import (
 	bcrypt "golang.org/x/crypto/bcrypt"
 )
 
-// EGALoginError is used to store message errors
-type EGALoginError struct {
-	Reason string
-}
-
 // CegaUserResponse captures the response list
 type CegaUserResponse struct {
 	PasswordHash string `json:"passwordHash"`

--- a/sda/cmd/auth/cega.go
+++ b/sda/cmd/auth/cega.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
-	log "github.com/sirupsen/logrus"
 	bcrypt "golang.org/x/crypto/bcrypt"
 )
 
@@ -44,7 +43,7 @@ func authenticateWithCEGA(conf config.CegaConfig, username string) (*http.Respon
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", strings.TrimSuffix(conf.AuthURL, "/"), username), payload)
 
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	req.Header.Add("Authorization", "Basic "+getb64Credentials(conf.ID, conf.Secret))

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -118,13 +118,16 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 
 	res, err := authenticateWithCEGA(auth.Config.Cega, username)
 
+	var statusCode int
 	if err != nil {
 		log.Error(err)
+		statusCode = 404
+	} else {
+		statusCode = res.StatusCode
+		defer res.Body.Close()
 	}
 
-	defer res.Body.Close()
-
-	switch res.StatusCode {
+	switch statusCode {
 	case 200:
 		if err != nil {
 			log.Error(err)

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -208,27 +208,15 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 func (auth AuthHandler) getEGALogin(ctx iris.Context) {
 
 	s := sessions.Get(ctx)
-	message := s.GetFlashString("message")
-	if message == "" {
-		ctx.ViewData("infoUrl", auth.Config.InfoURL)
-		ctx.ViewData("infoText", auth.Config.InfoText)
-		err := ctx.View("loginform.html")
-		if err != nil {
-			log.Error("Failed to return to login form: ", err)
-
-			return
-		}
-
-		return
-	}
 	ctx.ViewData("infoUrl", auth.Config.InfoURL)
 	ctx.ViewData("infoText", auth.Config.InfoText)
-	ctx.ViewData("Reason", message)
+	message := s.GetFlashString("message")
+	if message != "" {
+		ctx.ViewData("Reason", message)
+	}
 	err := ctx.View("loginform.html")
 	if err != nil {
 		log.Error("Failed to view invalid credentials form: ", err)
-
-		return
 	}
 }
 

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -160,6 +160,7 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 
 			s3conf := getS3ConfigMap(token, auth.Config.S3Inbox, username)
 			s.SetFlash("ega", s3conf)
+
 			ctx.ViewData("infoUrl", auth.Config.InfoURL)
 			ctx.ViewData("infoText", auth.Config.InfoText)
 			ctx.ViewData("User", username)
@@ -210,7 +211,8 @@ func (auth AuthHandler) getEGALogin(ctx iris.Context) {
 	}
 	ctx.ViewData("infoUrl", auth.Config.InfoURL)
 	ctx.ViewData("infoText", auth.Config.InfoText)
-	err := ctx.View("loginform.html", EGALoginError{Reason: message})
+	ctx.ViewData("Reason", message)
+	err := ctx.View("loginform.html")
 	if err != nil {
 		log.Error("Failed to view invalid credentials form: ", err)
 

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -188,6 +188,10 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 		s.SetFlash("message", "EGA authentication server could not be contacted")
 		ctx.Redirect("/ega/login", iris.StatusSeeOther)
 
+	case 401:
+		log.WithFields(log.Fields{"authType": "cega", "user": username}).Error("Failed to authenticate service (auth_cega_id/secret)")
+		s.SetFlash("message", "Problems connecting to EGA authentication server")
+		ctx.Redirect("/ega/login", iris.StatusSeeOther)
 	default:
 		log.WithFields(log.Fields{"authType": "cega", "user": username}).Error("Failed to authenticate user")
 		s.SetFlash("message", "Provided credentials are not valid")

--- a/sda/cmd/auth/main.go
+++ b/sda/cmd/auth/main.go
@@ -118,25 +118,19 @@ func (auth AuthHandler) postEGA(ctx iris.Context) {
 
 	res, err := authenticateWithCEGA(auth.Config.Cega, username)
 
-	var statusCode int
 	if err != nil {
-		log.Error(err)
-		statusCode = 404
-	} else {
-		statusCode = res.StatusCode
-		defer res.Body.Close()
-	}
-
-	switch statusCode {
-	case 200:
-		if err != nil {
-			log.Error(err)
-
-			return
+		log.Errorf("No response from cega, error: %v", err)
+		res = &http.Response{
+			Body:       io.NopCloser(nil),
+			StatusCode: http.StatusInternalServerError,
 		}
+	}
+	defer res.Body.Close()
 
+	switch res.StatusCode {
+	case 200:
 		var ur CegaUserResponse
-		err = json.NewDecoder(res.Body).Decode(&ur)
+		err := json.NewDecoder(res.Body).Decode(&ur)
 
 		if err != nil {
 			log.Error("Failed to parse response: ", err)


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1416 .


## Description
This PR
- fixes the bug that caused the blank page when logging in with bad credentials from the user. _Provided credentials are not valid_ is shown
- fixes the bug that caused the blank page when auth service is badly configured (`auth_cega_id` or `auth_cega_secret` is wrong). _Problems connecting to EGA authenticaton server_ is shown
- fixes the bug that lead to _This page isn't worknig_ when `cega-nss` is down. _EGA authentication server could not be contacted_ is shown.
- fixes some unrelated typos in the README

## How to test
- [ ] `make sda-s3-up`
- [ ] navigate to `localhost:8888`, choose the EGA login, and try to log in with a bad username/password
- [ ] verify that the page is not blank, but contains an error message and a new login form
- [ ] Stop `cega-nss` and verify that the page does not break when trying to log in
- [ ] Change `AUTH_CEGA_SECRET` in `.github/integration/sda-s3-integration.yml` and verify that the page does not turn blank or break when trying to log in.
- [ ] Please test anything else you might come up with

**Additional notes**
No tests are added, manual testing of the webpage will still be the standard.