### PR TITLE
Ingest waits for delays from s3

### DIFF
--- a/sda/cmd/finalize/finalize.go
+++ b/sda/cmd/finalize/finalize.go
@@ -244,7 +244,7 @@ func backupFile(delivered amqp.Delivery) error {
 	}
 
 	// Get size on disk, will also give some time for the file to appear if it has not already
-	diskFileSize, err := archive.GetFileSize(filePath)
+	diskFileSize, err := archive.GetFileSize(filePath, false)
 	if err != nil {
 		return fmt.Errorf("failed to get size info for archived file, reason: %v", err)
 	}

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -311,7 +311,7 @@ func main() {
 					continue
 				}
 
-				fileSize, err := inbox.GetFileSize(message.FilePath)
+				fileSize, err := inbox.GetFileSize(message.FilePath, false)
 				if err != nil {
 					log.Errorf("Failed to get file size of file to ingest, reason: (%s)", err.Error())
 					// Nack message so the server gets notified that something is wrong and requeue the message.
@@ -496,7 +496,7 @@ func main() {
 				fileInfo := database.FileInfo{}
 				fileInfo.Path = fileID
 				fileInfo.Checksum = fmt.Sprintf("%x", hash.Sum(nil))
-				fileInfo.Size, err = archive.GetFileSize(fileID)
+				fileInfo.Size, err = archive.GetFileSize(fileID, true)
 				if err != nil {
 					log.Errorf("Couldn't get file size from archive, reason: %v)", err.Error())
 					if err = delivered.Nack(false, true); err != nil {

--- a/sda/cmd/sync/sync.go
+++ b/sda/cmd/sync/sync.go
@@ -172,7 +172,7 @@ func syncFiles(stableID string) error {
 		return fmt.Errorf("failed to get archive path for file with stable ID: %s", stableID)
 	}
 
-	fileSize, err := archive.GetFileSize(archivePath)
+	fileSize, err := archive.GetFileSize(archivePath, false)
 	if err != nil {
 		return err
 	}

--- a/sda/cmd/verify/verify.go
+++ b/sda/cmd/verify/verify.go
@@ -157,7 +157,7 @@ func main() {
 			}
 
 			var file database.FileInfo
-			file.Size, err = archive.GetFileSize(message.ArchivePath)
+			file.Size, err = archive.GetFileSize(message.ArchivePath, false)
 			if err != nil { //nolint:nestif
 				log.Errorf("Failed to get archived file size, reson: (%s)", err.Error())
 				if strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "NoSuchKey:") || strings.Contains(err.Error(), "NotFound:") {

--- a/sda/internal/storage/storage_test.go
+++ b/sda/internal/storage/storage_test.go
@@ -256,7 +256,7 @@ func (suite *StorageTestSuite) TestPosixBackend() {
 	assert.Equal(suite.T(), writeData, readBackBuffer[:readBack], "did not read back data as expected")
 	assert.Nil(suite.T(), err, "unexpected error when reading back data")
 
-	size, err := backend.GetFileSize("testFile")
+	size, err := backend.GetFileSize("testFile", false)
 	assert.Nil(suite.T(), err, "posix NewFileReader failed when it should work")
 	assert.NotNil(suite.T(), size, "Got a nil size for posix")
 
@@ -270,7 +270,7 @@ func (suite *StorageTestSuite) TestPosixBackend() {
 	assert.NotZero(suite.T(), buf.Len(), "Expected warning missing")
 
 	buf.Reset()
-	_, err = backend.GetFileSize("posixDoesNotExist")
+	_, err = backend.GetFileSize("posixDoesNotExist", false)
 	assert.Error(suite.T(), err, "posix GetFileSize worked when it should not")
 	assert.NotZero(suite.T(), buf.Len(), "Expected warning missing")
 
@@ -296,7 +296,7 @@ func (suite *StorageTestSuite) TestPosixBackend() {
 	assert.NotNil(suite.T(), err, "NewFileWriter worked when it should not")
 	assert.Nil(suite.T(), failWriter, "Got a Writer when expected not to")
 
-	_, err = dummyBackend.GetFileSize("/")
+	_, err = dummyBackend.GetFileSize("/", false)
 	assert.NotNil(suite.T(), err, "GetFileSize worked when it should not")
 
 	err = dummyBackend.RemoveFile("/")
@@ -323,8 +323,14 @@ func (suite *StorageTestSuite) TestS3Backend() {
 	assert.NoError(suite.T(), err, "s3 NewFileReader failed when it should work")
 	assert.NotNil(suite.T(), reader, "Reader that should be usable is not, bailing out")
 
-	size, err := s3back.GetFileSize("s3Creatable")
+	size, err := s3back.GetFileSize("s3Creatable", false)
 	assert.Nil(suite.T(), err, "s3 GetFileSize failed when it should work")
+	assert.NotNil(suite.T(), size, "Got a nil size for s3")
+	assert.Equal(suite.T(), int64(len(writeData)), size, "Got an incorrect file size")
+
+	// make sure expectDelay=true works
+	size, err = s3back.GetFileSize("s3Creatable", true)
+	assert.Nil(suite.T(), err, "s3 GetFileSize with expected delay failed when it should work")
 	assert.NotNil(suite.T(), size, "Got a nil size for s3")
 	assert.Equal(suite.T(), int64(len(writeData)), size, "Got an incorrect file size")
 
@@ -339,7 +345,7 @@ func (suite *StorageTestSuite) TestS3Backend() {
 	err = s3back.RemoveFile("s3Creatable")
 	assert.Nil(suite.T(), err, "s3 RemoveFile failed when it should work")
 
-	_, err = s3back.GetFileSize("s3DoesNotExist")
+	_, err = s3back.GetFileSize("s3DoesNotExist", false)
 	assert.NotNil(suite.T(), err, "s3 GetFileSize worked when it should not")
 	assert.Error(suite.T(), err)
 
@@ -377,7 +383,7 @@ func (suite *StorageTestSuite) TestSftpBackend() {
 	assert.Nil(suite.T(), err, "sftp NewFileReader failed when it should work")
 	assert.NotNil(suite.T(), reader, "Reader that should be usable is not, bailing out")
 
-	size, err := sftpBack.GetFileSize(sftpCreatable)
+	size, err := sftpBack.GetFileSize(sftpCreatable, false)
 	assert.Nil(suite.T(), err, "sftp GetFileSize failed when it should work")
 	assert.NotNil(suite.T(), size, "Got a nil size for sftp")
 	assert.Equal(suite.T(), int64(len(writeData)), size, "Got an incorrect file size")
@@ -398,7 +404,7 @@ func (suite *StorageTestSuite) TestSftpBackend() {
 		assert.Nil(suite.T(), err, "unexpected error when reading back data")
 	}
 
-	_, err = sftpBack.GetFileSize(sftpDoesNotExist)
+	_, err = sftpBack.GetFileSize(sftpDoesNotExist, false)
 	assert.EqualError(suite.T(), err, "failed to get file size with sftp, file does not exist")
 	reader, err = sftpBack.NewFileReader(sftpDoesNotExist)
 	assert.EqualError(suite.T(), err, "failed to open file with sftp, file does not exist")
@@ -442,7 +448,7 @@ func (suite *StorageTestSuite) TestSftpBackend() {
 	assert.NotNil(suite.T(), err, "NewFileWriter worked when it should not")
 	assert.Nil(suite.T(), failWriter, "Got a Writer when expected not to")
 
-	_, err = dummyBackend.GetFileSize("/")
+	_, err = dummyBackend.GetFileSize("/", false)
 	assert.NotNil(suite.T(), err, "GetFileSize worked when it should not")
 
 	err = dummyBackend.RemoveFile("/")

--- a/sda/internal/storage/storage_test.go
+++ b/sda/internal/storage/storage_test.go
@@ -329,6 +329,19 @@ func (suite *StorageTestSuite) TestS3Backend() {
 	assert.Equal(suite.T(), int64(len(writeData)), size, "Got an incorrect file size")
 
 	// make sure expectDelay=true works
+	// delete file and make sure the file size can not be retrieved anymore
+	err = s3back.RemoveFile("s3Creatable")
+	assert.Nil(suite.T(), err, "s3 RemoveFile failed when it should work")
+	_, err = s3back.GetFileSize("s3Creatable", true)
+	assert.NotNil(suite.T(), err, "s3 GetFileSize worked when it should not")
+	assert.Error(suite.T(), err)
+	// rewrite file, do not wait before retrieving file size
+	writer, err = s3back.NewFileWriter("s3Creatable")
+	assert.Nil(suite.T(), err, "s3 NewFileWriter failed when it shouldn't")
+	written, err = writer.Write(writeData)
+	assert.Equal(suite.T(), len(writeData), written, "Did not write all writeData")
+	assert.Nil(suite.T(), err, "Failure when writing to s3 writer")
+	writer.Close()
 	size, err = s3back.GetFileSize("s3Creatable", true)
 	assert.Nil(suite.T(), err, "s3 GetFileSize with expected delay failed when it should work")
 	assert.NotNil(suite.T(), size, "Got a nil size for s3")


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1430 .

## Description
Ingest needs the `GetFileSize` to accept some delay from s3, so that it does not immediately fail when receiving `NoSuchKey` or `NotFound`. At other points, however, this extra waiting time is not wanted, for example when calling the function from [`verify`](https://github.com/neicnordic/sensitive-data-archive/blob/main/sda/cmd/verify/verify.go#L160), since that would give 2 minutes extra waiting time before the call fails (if the file is not present in the storage). Notably, [this test](https://github.com/neicnordic/sensitive-data-archive/blob/main/.github/integration/tests/sda/22_error_test.sh#L120) would require a lot of retries. 

My assumption is that it should be optional whether a delay from s3 should be expected or not.
This PR therefore adds an extra parameter to allow for this.
**If you have other ideas, please feel very welcome to post them here.**

## How to test
Make sure all tests pass. You could also mock [this call](https://github.com/neicnordic/sensitive-data-archive/blob/main/sda/internal/storage/storage.go#L293) so that it does not find the queried file at once.