### PR TITLE
[API] return stable ID as part of the file info response.

### DIFF
--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -232,7 +232,7 @@ func getFiles(c *gin.Context) {
 		return
 	}
 
-	files, err := Conf.API.DB.GetUserFiles(token.Subject())
+	files, err := Conf.API.DB.GetUserFiles(token.Subject(), false)
 	if err != nil {
 		// something went wrong with querying or parsing rows
 		c.JSON(502, err.Error())
@@ -544,7 +544,7 @@ func listUserFiles(c *gin.Context) {
 	username = strings.TrimPrefix(username, "/")
 	username = strings.TrimSuffix(username, "/files")
 	log.Debugln(username)
-	files, err := Conf.API.DB.GetUserFiles(username)
+	files, err := Conf.API.DB.GetUserFiles(username, true)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 

--- a/sda/internal/database/database.go
+++ b/sda/internal/database/database.go
@@ -46,10 +46,11 @@ type SyncData struct {
 }
 
 type SubmissionFileInfo struct {
-	FileID    string `json:"fileID"`
-	InboxPath string `json:"inboxPath"`
-	Status    string `json:"fileStatus"`
-	CreateAt  string `json:"createAt"`
+	AccessionID string `json:"accessionID,omitempty"`
+	FileID      string `json:"fileID"`
+	InboxPath   string `json:"inboxPath"`
+	Status      string `json:"fileStatus"`
+	CreateAt    string `json:"createAt"`
 }
 
 type DatasetInfo struct {

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -690,14 +690,14 @@ func (dbs *SDAdb) getArchivePath(stableID string) (string, error) {
 }
 
 // GetUserFiles retrieves all the files a user submitted
-func (dbs *SDAdb) GetUserFiles(userID string) ([]*SubmissionFileInfo, error) {
+func (dbs *SDAdb) GetUserFiles(userID string, allData bool) ([]*SubmissionFileInfo, error) {
 	var err error
 
 	files := []*SubmissionFileInfo{}
 
 	// 2, 4, 8, 16, 32 seconds between each retry event.
 	for count := 1; count <= RetryTimes; count++ {
-		files, err = dbs.getUserFiles(userID)
+		files, err = dbs.getUserFiles(userID, allData)
 		if err == nil {
 			break
 		}
@@ -708,7 +708,7 @@ func (dbs *SDAdb) GetUserFiles(userID string) ([]*SubmissionFileInfo, error) {
 }
 
 // getUserFiles is the actual function performing work for GetUserFiles
-func (dbs *SDAdb) getUserFiles(userID string) ([]*SubmissionFileInfo, error) {
+func (dbs *SDAdb) getUserFiles(userID string, allData bool) ([]*SubmissionFileInfo, error) {
 	dbs.checkAndReconnectIfNeeded()
 
 	files := []*SubmissionFileInfo{}
@@ -735,7 +735,10 @@ func (dbs *SDAdb) getUserFiles(userID string) ([]*SubmissionFileInfo, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if allData {
 			fi.AccessionID = accessionID.String
+		}
 
 		// Add instance of struct (file) to array if the status is not disabled
 		if fi.Status != "disabled" {

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -456,6 +456,8 @@ func (suite *DatabaseTests) TestGetUserFiles() {
 		assert.NoError(suite.T(), err, "failed to register file in database")
 		err = db.UpdateFileEventLog(fileID, "uploaded", fileID, testUser, "{}", "{}")
 		assert.NoError(suite.T(), err, "failed to update satus of file in database")
+		err = db.SetAccessionID(fmt.Sprintf("stableID-00%d", i), fileID)
+		assert.NoError(suite.T(), err, "failed to update satus of file in database")
 		err = db.UpdateFileEventLog(fileID, "ready", fileID, testUser, "{}", "{}")
 		assert.NoError(suite.T(), err, "failed to update satus of file in database")
 	}
@@ -469,6 +471,7 @@ func (suite *DatabaseTests) TestGetUserFiles() {
 
 	for _, fileInfo := range filelist {
 		assert.Equal(suite.T(), "ready", fileInfo.Status, "incorrect file status")
+		assert.Contains(suite.T(), fileInfo.AccessionID, "stableID-00", "incorrect file accession ID")
 	}
 }
 

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -461,11 +461,11 @@ func (suite *DatabaseTests) TestGetUserFiles() {
 		err = db.UpdateFileEventLog(fileID, "ready", fileID, testUser, "{}", "{}")
 		assert.NoError(suite.T(), err, "failed to update satus of file in database")
 	}
-	filelist, err := db.GetUserFiles("unknownuser")
+	filelist, err := db.GetUserFiles("unknownuser", true)
 	assert.NoError(suite.T(), err, "failed to get (empty) file list of unknown user")
 	assert.Empty(suite.T(), filelist, "file list of unknown user is not empty")
 
-	filelist, err = db.GetUserFiles(testUser)
+	filelist, err = db.GetUserFiles(testUser, true)
 	assert.NoError(suite.T(), err, "failed to get file list")
 	assert.Equal(suite.T(), testCases, len(filelist), "file list is of incorrect length")
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1417.

## Description
This expands the `SubmissionFileInfo` struct to also contain the file stable IDs but only return them to the queries made to the `/users/:username/files` endpoint

## How to test
