### PR TITLE
[internal/database] add test step to append files to a dataset.

### DIFF
--- a/.github/integration/sda/rbac.json
+++ b/.github/integration/sda/rbac.json
@@ -12,8 +12,8 @@
       },
       {
          "role": "admin",
-         "path": "/dataset/verify/:dataset",
-         "action": "PUT"
+         "path": "/dataset/*",
+         "action": "(POST)|(PUT)"
       },
        {
          "role": "submission",

--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -27,9 +27,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7.0.0
+        uses: golangci/golangci-lint-action@v6.5.2
         with:
           args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck -e G401,G501,G107,G115 --timeout 5m
+          version: v1.64.8
           working-directory: sda-download
 
   lint_sda:
@@ -48,9 +49,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7.0.0
+        uses: golangci/golangci-lint-action@v6.5.2
         with:
           args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,rowserrcheck -e G401,G501,G107,G115 --timeout 5m
+          version: v1.64.8
           working-directory: sda
 
   lint_sda_admin:
@@ -69,7 +71,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7.0.0
+        uses: golangci/golangci-lint-action@v6.5.2
         with:
           args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,rowserrcheck -e G401,G501,G107,G115 --timeout 5m
+          version: v1.64.8
           working-directory: sda-admin

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -286,6 +286,15 @@ func (suite *DatabaseTests) TestMapFilesToDataset() {
 		err := db.MapFilesToDataset(di, acs)
 		assert.NoError(suite.T(), err, "failed to map file to dataset")
 	}
+
+	// Append files to an existing dataset
+	assert.NoError(suite.T(), db.MapFilesToDataset("dataset1", accessions[9:11]), "failed to append files to a dataset")
+	var dsMembers int
+	const q1 = "SELECT count(file_id) from sda.file_dataset WHERE dataset_id = (SELECT id from sda.datasets WHERE stable_id = $1);"
+	if err := db.DB.QueryRow(q1, "dataset1").Scan(&dsMembers); err != nil {
+		suite.FailNow("failed to get dataset members from database")
+	}
+	assert.Equal(suite.T(), 5, dsMembers)
 }
 
 func (suite *DatabaseTests) TestGetInboxPath() {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1503.


## Description
This adds a missing step for appending files to a dataset in the `MapFilesToDataset` DB call.

## How to test
