### PR TITLE
Add Cron job to run large submission tests

### DIFF
--- a/.github/integration/scripts/large_submission/finalize.sh
+++ b/.github/integration/scripts/large_submission/finalize.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+set -e
+
+for t in curl jq postgresql-client uuid-runtime; do
+    if [ ! "$(command -v $t)" ]; then
+        if [ "$(id -u)" != 0 ]; then
+            echo "$t is missing, unable to install it"
+            exit 1
+        fi
+
+        apt-get -o DPkg::Lock::Timeout=60 update >/dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y "$t" >/dev/null
+    fi
+done
+
+submission_size=100000
+
+## empty all queues ##
+for q in accession archived backup completed inbox ingest mappings verified; do
+    curl -s -k -u guest:guest -X DELETE "http://rabbitmq:15672/api/queues/sda/$q/contents"
+done
+## truncate database
+psql -U postgres -h postgres -d sda -At -c "TRUNCATE TABLE sda.files CASCADE;"
+
+stream_size=$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')
+
+i=1
+while [ $i -le $((submission_size)) ]; do
+    user="test@dummy.org"
+    inbox_path="inbox/test-file-$i.c4gh"
+    fileID=$(psql -U postgres -h postgres -d sda -At -c "SELECT sda.register_file('$inbox_path', '$user');")
+    if [ -z "$fileID" ]; then
+        echo "register_file failed"
+        exit 1
+    fi
+    resp=$(psql -U postgres -h postgres -d sda -At -c "UPDATE sda.files SET archive_file_path = '$fileID', archive_file_size = '$i' WHERE id = '$fileID';")
+    if [ "$resp" != "UPDATE 1" ]; then
+        echo "failed to update file $resp"
+        exit 1
+    fi
+    psql -U postgres -h postgres -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, correlation_id, user_id, message) VALUES('$fileID', 'verified', '$fileID', 'test-user', '{\"uploaded\": \"message\"}');" >/dev/null
+
+    properties=$(
+        jq -c -n \
+            --argjson delivery_mode 2 \
+            --arg correlation_id "$fileID" \
+            --arg content_encoding UTF-8 \
+            --arg content_type application/json \
+            '$ARGS.named'
+    )
+
+    DEC_SHA=$(echo $i | sha256sum | cut -d' ' -f 1)
+    decrypted_checksums=$(
+        jq -c -n \
+            --arg sha256 "$DEC_SHA" \
+            '$ARGS.named|to_entries|map(with_entries(select(.key=="key").key="type"))'
+    )
+
+    accession_id="urn:uuid:$(uuidgen)"
+    accession_payload=$(
+        jq -r -c -n \
+            --arg type accession \
+            --arg user "$user" \
+            --arg filepath "$inbox_path" \
+            --arg accession_id "$accession_id" \
+            --argjson decrypted_checksums "$decrypted_checksums" \
+            '$ARGS.named|@base64'
+    )
+
+    accession_body=$(
+        jq -c -n \
+            --arg vhost sda \
+            --arg name sda \
+            --argjson properties "$properties" \
+            --arg routing_key "accession" \
+            --arg payload_encoding base64 \
+            --arg payload "$accession_payload" \
+            '$ARGS.named'
+    )
+
+    curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -d "$accession_body" >/dev/null
+
+    i=$((i + 1))
+done
+
+RETRY_TIMES=0
+until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/accession | jq '.messages')" -eq 0 ]; do
+    echo "waiting for messages to be processed"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for finalize to compete the work"
+        echo "This is currently expected"
+        exit 1
+    fi
+    sleep 10
+done
+
+RETRY_TIMES=0
+until [ $((stream_size+submission_size)) -eq "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')" ]; do
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "Messages not moved to error"
+        echo "This is currently expected"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "test for finalizing $submission_size files completed successfully"

--- a/.github/integration/scripts/large_submission/finalize.sh
+++ b/.github/integration/scripts/large_submission/finalize.sh
@@ -13,7 +13,7 @@ for t in curl jq postgresql-client uuid-runtime; do
     fi
 done
 
-submission_size=100000
+submission_size=60000
 
 ## empty all queues ##
 for q in accession archived backup completed inbox ingest mappings verified; do

--- a/.github/integration/scripts/large_submission/finalize.sh
+++ b/.github/integration/scripts/large_submission/finalize.sh
@@ -90,7 +90,7 @@ until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/accession
     echo "waiting for messages to be processed"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
-        echo "::error::Time out while waiting for finalize to compete the work"
+        echo "::error::Time out while waiting for finalize to complete the work"
         echo "This is currently expected"
         exit 1
     fi

--- a/.github/integration/scripts/large_submission/ingest.sh
+++ b/.github/integration/scripts/large_submission/ingest.sh
@@ -13,7 +13,7 @@ for t in curl jq postgresql-client uuid-runtime; do
     fi
 done
 
-submission_size=100000
+submission_size=60000
 
 ## empty all queues ##
 for q in accession archived backup completed inbox ingest mappings verified; do

--- a/.github/integration/scripts/large_submission/ingest.sh
+++ b/.github/integration/scripts/large_submission/ingest.sh
@@ -87,7 +87,7 @@ until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/ingest | 
     echo "waiting for messages to be processed"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
-        echo "::error::Time out while waiting for ingest to compete the work"
+        echo "::error::Time out while waiting for ingest to complete the work"
         exit 1
     fi
     sleep 10

--- a/.github/integration/scripts/large_submission/ingest.sh
+++ b/.github/integration/scripts/large_submission/ingest.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+set -e
+
+for t in curl jq postgresql-client uuid-runtime; do
+    if [ ! "$(command -v $t)" ]; then
+        if [ "$(id -u)" != 0 ]; then
+            echo "$t is missing, unable to install it"
+            exit 1
+        fi
+
+        apt-get -o DPkg::Lock::Timeout=60 update >/dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y "$t" >/dev/null
+    fi
+done
+
+submission_size=100000
+
+## empty all queues ##
+for q in accession archived backup completed inbox ingest mappings verified; do
+    curl -s -k -u guest:guest -X DELETE "http://rabbitmq:15672/api/queues/sda/$q/contents"
+done
+## truncate database
+psql -U postgres -h postgres -d sda -At -c "TRUNCATE TABLE sda.files CASCADE;"
+payload=$(
+	jq -c -n \
+		--arg description "this is the key description" \
+		--arg pubkey "$( base64 -w0 /shared/c4gh.pub.pem)" \
+		'$ARGS.named'
+)
+token="$(cat /shared/token)"
+resp="$(curl -s -k -L -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "Content-Type: application/json" -X POST -d "$payload" "http://api:8080/c4gh-keys/add")"
+if [ "$resp" != "200" ]; then
+	echo "Error when adding a public key hash, expected 200 got: $resp"
+	exit 1
+fi
+
+stream_size=$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')
+
+i=1
+while [ $i -le $((submission_size)) ]; do
+    user="test@dummy.org"
+    inbox_path="inbox/test-file-$i.c4gh"
+    fileID=$(psql -U postgres -h postgres -d sda -At -c "SELECT sda.register_file('$inbox_path', '$user');")
+    if [ -z "$fileID" ]; then
+        echo "register_file failed"
+        exit 1
+    fi
+
+    properties=$(
+        jq -c -n \
+            --argjson delivery_mode 2 \
+            --arg correlation_id "$fileID" \
+            --arg content_encoding UTF-8 \
+            --arg content_type application/json \
+            '$ARGS.named'
+    )
+
+    ingest_payload=$(
+        jq -r -c -n \
+            --arg type ingest \
+            --arg user "$user" \
+            --arg filepath "$inbox_path" \
+            '$ARGS.named|@base64'
+    )
+
+    ingest_body=$(
+        jq -c -n \
+            --arg vhost sda \
+            --arg name sda \
+            --argjson properties "$properties" \
+            --arg routing_key "ingest" \
+            --arg payload_encoding base64 \
+            --arg payload "$ingest_payload" \
+            '$ARGS.named'
+    )
+
+    curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -d "$ingest_body" >/dev/null
+
+    i=$((i + 1))
+done
+
+sleep 10
+RETRY_TIMES=0
+until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/ingest | jq '.messages')" -eq 0 ]; do
+    echo "waiting for messages to be processed"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for ingest to compete the work"
+        exit 1
+    fi
+    sleep 10
+done
+
+RETRY_TIMES=0
+until [ $((stream_size+submission_size)) -eq "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')" ]; do
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "Messages not moved to error"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "test for ingesting $submission_size files completed successfully"

--- a/.github/integration/scripts/large_submission/ingest.sh
+++ b/.github/integration/scripts/large_submission/ingest.sh
@@ -36,8 +36,6 @@ fi
 
 stream_size=$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')
 
-token="$(cat /shared/token)"
-
 i=1
 while [ $i -le $((submission_size)) ]; do
     user="test@dummy.org"
@@ -49,7 +47,7 @@ while [ $i -le $((submission_size)) ]; do
     fi
 
     # the API assumed that a file has a correlation ID so this needs to be done for now.
-    psql -U postgres -h postgres -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, correlation_id, user_id, message) VALUES('$fileID', 'submitted', '$fileID', '$user', '{}');" >/dev/null
+    psql -U postgres -h postgres -d sda -At -c "INSERT INTO sda.file_event_log(file_id, event, correlation_id, user_id, message) VALUES('$fileID', 'uploaded', '$fileID', '$user', '{}');" >/dev/null
 
     ingest_payload=$(
         jq -r -c -n \

--- a/.github/integration/scripts/large_submission/mapper.sh
+++ b/.github/integration/scripts/large_submission/mapper.sh
@@ -59,13 +59,13 @@ mapping_payload=$(
 echo "$mapping_payload" >/shared/payload
 
 token="$(cat /shared/token)"
-curl -s -d @/tmp/dataset \
+curl -d @/shared/payload \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $token" \
-    -X POST http://localhost:8090/dataset/create >/dev/null
+    -X POST http://api:8080/dataset/create >/dev/null
 
 RETRY_TIMES=0
-until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/mappings | jq '.messages')" -eq 0 ]; do
+until [ "$(psql -U postgres -h postgres -d sda -At -c "SELECT COUNT(file_id) FROM sda.file_dataset;")" -eq "$submission_size" ]; do
     echo "waiting for dataset be registered"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then

--- a/.github/integration/scripts/large_submission/mapper.sh
+++ b/.github/integration/scripts/large_submission/mapper.sh
@@ -13,7 +13,7 @@ for t in curl jq postgresql-client uuid-runtime; do
     fi
 done
 
-submission_size=100000
+submission_size=60000
 
 ## empty all queues ##
 for q in accession archived backup completed inbox ingest mappings verified; do

--- a/.github/integration/scripts/large_submission/mapper.sh
+++ b/.github/integration/scripts/large_submission/mapper.sh
@@ -22,7 +22,6 @@ done
 ## truncate database
 psql -U postgres -h postgres -d sda -At -c "TRUNCATE TABLE sda.files CASCADE;"
 
-# stream_size=$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')
 rm /shared/accessions.txt /shared/payload /shared/message.json || true
 touch "/shared/accessions.txt"
 
@@ -86,7 +85,7 @@ until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/mappings 
     echo "waiting for dataset be registered"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
-        echo "::error::Time out while waiting for mapper to compete the work"
+        echo "::error::Time out while waiting for mapper to complete the work"
         exit 1
     fi
     sleep 10

--- a/.github/integration/scripts/large_submission/mapper.sh
+++ b/.github/integration/scripts/large_submission/mapper.sh
@@ -59,10 +59,18 @@ mapping_payload=$(
 echo "$mapping_payload" >/shared/payload
 
 token="$(cat /shared/token)"
-curl -d @/shared/payload \
+
+set +e
+resp=$(curl -s -d @/shared/payload \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $token" \
-    -X POST http://api:8080/dataset/create >/dev/null
+    -X POST http://api:8080/dataset/create >/dev/null)
+
+if [ "$resp" -eq 1 ]; then
+    echo "create dataset failed"
+    exit 1
+fi
+set -e
 
 RETRY_TIMES=0
 until [ "$(psql -U postgres -h postgres -d sda -At -c "SELECT COUNT(file_id) FROM sda.file_dataset;")" -eq "$submission_size" ]; do

--- a/.github/integration/scripts/large_submission/mapper.sh
+++ b/.github/integration/scripts/large_submission/mapper.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+set -e
+
+for t in curl jq postgresql-client uuid-runtime; do
+    if [ ! "$(command -v $t)" ]; then
+        if [ "$(id -u)" != 0 ]; then
+            echo "$t is missing, unable to install it"
+            exit 1
+        fi
+
+        apt-get -o DPkg::Lock::Timeout=60 update >/dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y "$t" >/dev/null
+    fi
+done
+
+submission_size=100000
+
+## empty all queues ##
+for q in accession archived backup completed inbox ingest mappings verified; do
+    curl -s -k -u guest:guest -X DELETE "http://rabbitmq:15672/api/queues/sda/$q/contents"
+done
+## truncate database
+psql -U postgres -h postgres -d sda -At -c "TRUNCATE TABLE sda.files CASCADE;"
+
+# stream_size=$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')
+rm /shared/accessions.txt /shared/payload /shared/message.json || true
+touch "/shared/accessions.txt"
+
+i=1
+while [ $i -le $((submission_size)) ]; do
+    user="test@dummy.org"
+    inbox_path="inbox/test-file-$i.c4gh"
+    fileID=$(psql -U postgres -h postgres -d sda -At -c "SELECT sda.register_file('$inbox_path', '$user');")
+    if [ -z "$fileID" ]; then
+        echo "register_file failed"
+        exit 1
+    fi
+
+    accession="urn:uuid:$(uuidgen)"
+    resp=$(psql -U postgres -h postgres -d sda -At -c "UPDATE sda.files SET stable_id = '$accession' WHERE id = '$fileID';")
+    if [ "$resp" != "UPDATE 1" ]; then
+        echo "mark file ready failed $resp"
+        exit 1
+    fi
+    echo "\"$accession\"" >>"/shared/accessions.txt"
+
+    i=$((i + 1))
+done
+
+## map files to dataset
+properties=$(
+    jq -cn \
+        --argjson delivery_mode 2 \
+        --arg content_encoding UTF-8 \
+        --arg content_type application/json \
+        '$ARGS.named'
+)
+
+mapping_payload=$(
+    jq -Rrcn \
+        --arg type mapping \
+        --arg dataset_id EGAD74900000101 \
+        --slurpfile accession_ids /shared/accessions.txt \
+        '$ARGS.named|@base64'
+)
+echo "$mapping_payload" >/shared/payload
+
+mapping_body=$(
+    jq -Rcn \
+        --arg vhost test \
+        --arg name sda \
+        --argjson properties "$properties" \
+        --arg routing_key "mappings" \
+        --arg payload_encoding base64 \
+        --rawfile payload "/shared/payload" \
+        '$ARGS.named'
+)
+echo "$mapping_body" >/shared/message.json
+
+curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d "@/shared/message.json" >/dev/null
+
+RETRY_TIMES=0
+until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/mappings | jq '.messages')" -eq 0 ]; do
+    echo "waiting for dataset be registered"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for mapper to compete the work"
+        exit 1
+    fi
+    sleep 10
+done
+
+echo "test for mapping a large dataset completed successfully"

--- a/.github/integration/scripts/large_submission/sda-s3.yml
+++ b/.github/integration/scripts/large_submission/sda-s3.yml
@@ -258,7 +258,7 @@ services:
     ports:
       - "8443:8443"
     volumes:
-      - ../sda/users.py:/cega/users.py
+      - ../../sda/users.py:/cega/users.py
       - shared:/shared
 
   auth-cega:

--- a/.github/integration/scripts/large_submission/sda-s3.yml
+++ b/.github/integration/scripts/large_submission/sda-s3.yml
@@ -384,7 +384,6 @@ services:
       - tests
     volumes:
       - shared:/shared
-      - ../../tests:/tests
       - ./:/submission_tests
 
 volumes:

--- a/.github/integration/scripts/large_submission/sda-s3.yml
+++ b/.github/integration/scripts/large_submission/sda-s3.yml
@@ -173,6 +173,7 @@ services:
       - BROKER_ROUTINGKEY=completed
       - DB_PASSWORD=finalize
       - DB_USER=finalize
+      - SCHEMA_TYPE=isolated
     restart: always
     volumes:
       - ../../sda/config.yaml:/config.yaml
@@ -219,6 +220,7 @@ services:
       - BROKER_USER=api
       - DB_PASSWORD=api
       - DB_USER=api
+      - SCHEMA_TYPE=isolated
     extra_hosts:
       - "localhost:host-gateway"
     image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}

--- a/.github/integration/scripts/large_submission/sda-s3.yml
+++ b/.github/integration/scripts/large_submission/sda-s3.yml
@@ -1,0 +1,394 @@
+services:
+  credentials:
+    container_name: credentials
+    command:
+      - "/bin/sh"
+      - "/scripts/make_sda_credentials.sh"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - PGPASSWORD=rootpasswd
+    image: python:3.11-slim
+    volumes:
+      - ../../scripts:/scripts
+      - shared:/shared
+
+  postgres:
+    container_name: postgres
+    environment:
+      - POSTGRES_PASSWORD=rootpasswd
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 2s
+      retries: 6
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}-postgres
+    ports:
+      - "15432:5432"
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  rabbitmq:
+    container_name: rabbitmq
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}-rabbitmq
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    restart: always
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
+  minio:
+    image: minio/minio:RELEASE.2023-05-18T00-05-36Z
+    command: server /data  --console-address ":9001"
+    container_name: s3
+    environment:
+      - MINIO_ROOT_USER=access
+      - MINIO_ROOT_PASSWORD=secretKey
+      - MINIO_SERVER_URL=http://127.0.0.1:9000
+    healthcheck:
+      test: ["CMD", "curl", "-fkq", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 2s
+      retries: 6
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    volumes:
+      - minio_data:/data
+
+  s3inbox:
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    command: [sda-s3inbox]
+    container_name: s3inbox
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      mock-aai:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=inbox
+      - BROKER_USER=inbox
+      - BROKER_ROUTINGKEY=inbox
+      - DB_PASSWORD=inbox
+      - DB_USER=inbox
+    extra_hosts:
+      - "localhost:host-gateway"
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+    ports:
+      - "18000:8000"
+      - "18001:8001"
+
+  ingest:
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    command: [sda-ingest]
+    container_name: ingest
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=ingest
+      - BROKER_USER=ingest
+      - BROKER_QUEUE=ingest
+      - BROKER_ROUTINGKEY=archived
+      - DB_PASSWORD=ingest
+      - DB_USER=ingest
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  verify:
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    command: [sda-verify]
+    container_name: verify
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=verify
+      - BROKER_USER=verify
+      - BROKER_QUEUE=archived
+      - BROKER_ROUTINGKEY=verified
+      - DB_PASSWORD=verify
+      - DB_USER=verify
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  finalize:
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    command: [sda-finalize]
+    container_name: finalize
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=finalize
+      - BROKER_USER=finalize
+      - BROKER_QUEUE=accession
+      - BROKER_ROUTINGKEY=completed
+      - DB_PASSWORD=finalize
+      - DB_USER=finalize
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  mapper:
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    command: [sda-mapper]
+    container_name: mapper
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=mapper
+      - BROKER_USER=mapper
+      - BROKER_QUEUE=mappings
+      - DB_PASSWORD=mapper
+      - DB_USER=mapper
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  api:
+    command: [sda-api]
+    container_name: api
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      mock-aai:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - BROKER_PASSWORD=api
+      - BROKER_USER=api
+      - DB_PASSWORD=api
+      - DB_USER=api
+    extra_hosts:
+      - "localhost:host-gateway"
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    ports:
+      - "8090:8080"
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - ../../sda/rbac.json:/rbac.json
+      - shared:/shared
+
+  reencrypt:
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    command: [sda-reencrypt]
+    container_name: reencrypt
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+    ports:
+      - "50051:50051"
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  cega-nss:
+    container_name: cega-nss
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+    command:
+      ["python", "/cega/users.py", "0.0.0.0", "8443", "/shared/users.json"]
+    environment:
+      - CEGA_USERS_PASSWORD=test
+      - CEGA_USERS_USER=test
+    image: "egarchive/lega-base:release.v0.2.0"
+    ports:
+      - "8443:8443"
+    volumes:
+      - ../sda/users.py:/cega/users.py
+      - shared:/shared
+
+  auth-cega:
+    command: [sda-auth]
+    container_name: auth-cega
+    depends_on:
+      cega-nss:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    environment:
+      - AUTH_RESIGNJWT=true
+      - AUTH_CEGA_ID=test
+      - AUTH_CEGA_SECRET=test
+      - OIDC_REDIRECTURL=http://localhost:8888/oidc/login
+      - OIDC_ID=XC56EL11zz
+      - OIDC_SECRET=wHPVQaYXmdDHa
+      - DB_PASSWORD=auth
+      - DB_USER=auth
+    extra_hosts:
+      - "localhost:host-gateway"
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    ports:
+      - "8888:8080"
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  auth-aai:
+    command: [sda-auth]
+    container_name: auth-aai
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      mock-aai:
+        condition: service_started
+    environment:
+      - AUTH_RESIGNJWT=false
+      - DB_PASSWORD=auth
+      - DB_USER=auth
+    extra_hosts:
+      - "localhost:host-gateway"
+    image: ghcr.io/neicnordic/sensitive-data-archive:${TAG}
+    ports:
+      - "8801:8080"
+    restart: always
+    volumes:
+      - ../../sda/config.yaml:/config.yaml
+      - shared:/shared
+
+  mock-aai:
+    container_name: ls-aai-mock
+    depends_on:
+      aai-db:
+        condition: service_healthy
+    environment:
+      - DOCKERHOST=localhost
+    extra_hosts:
+      - "localhost:host-gateway"
+    healthcheck:
+      test:
+        [ "CMD", "/bin/true" ]
+      interval: 10s
+      timeout: 2s
+      retries: 6
+    image: registry.gitlab.ics.muni.cz:443/perun/deployment/proxyidp/proxyidp-public-docker-images/ls_aai_mock:2.5.2-broker2.1.10-tomcat9.0-jdk11
+    ports:
+      - "8800:8080"
+    volumes:
+      - ../../sda/aai-mock:/etc/lsaai-mock
+  aai-db:
+    container_name: ls-aai-db
+    environment:
+      MYSQL_ROOT_PASSWORD: "aaiPass"
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_DATABASE: "aai"
+      MYSQL_USER: "aai"
+      MYSQL_PASSWORD: "aaiPass"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 2s
+      retries: 6
+    image: mysql/mysql-server:latest
+    volumes:
+      - ../../sda/aai-mock/aai-mock.sql:/docker-entrypoint-initdb.d/1.sql
+  integration_test:
+    container_name: tester
+    command:
+      - "/bin/sh"
+      - "/submission_tests/${TEST}.sh"
+    depends_on:
+      auth-cega:
+        condition: service_started
+      auth-aai:
+        condition: service_started
+      cega-nss:
+        condition: service_started
+      credentials:
+        condition: service_completed_successfully
+      finalize:
+        condition: service_started
+      ingest:
+        condition: service_started
+      mapper:
+        condition: service_started
+      s3inbox:
+        condition: service_started
+      verify:
+        condition: service_started
+      api:
+        condition: service_started
+      reencrypt:
+        condition: service_started
+    extra_hosts:
+      - "localhost:host-gateway"
+    environment:
+      - PGPASSWORD=rootpasswd
+      - STORAGETYPE=s3
+    image: python:3.11-slim-bullseye
+    profiles:
+      - tests
+    volumes:
+      - shared:/shared
+      - ../../tests:/tests
+      - ./:/submission_tests
+
+volumes:
+  minio_data:
+  postgres_data:
+  rabbitmq_data:
+  shared:

--- a/.github/integration/scripts/large_submission/verify.sh
+++ b/.github/integration/scripts/large_submission/verify.sh
@@ -13,7 +13,7 @@ for t in curl jq postgresql-client uuid-runtime; do
     fi
 done
 
-submission_size=100000
+submission_size=60000
 
 ## empty all queues ##
 for q in accession archived backup completed inbox ingest mappings verified; do

--- a/.github/integration/scripts/large_submission/verify.sh
+++ b/.github/integration/scripts/large_submission/verify.sh
@@ -89,7 +89,7 @@ until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/archived 
     echo "waiting for messages to be processed"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
-        echo "::error::Time out while waiting for verify to compete the work"
+        echo "::error::Time out while waiting for verify to complete the work"
         exit 1
     fi
     sleep 10

--- a/.github/integration/scripts/large_submission/verify.sh
+++ b/.github/integration/scripts/large_submission/verify.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -e
+
+for t in curl jq postgresql-client uuid-runtime; do
+    if [ ! "$(command -v $t)" ]; then
+        if [ "$(id -u)" != 0 ]; then
+            echo "$t is missing, unable to install it"
+            exit 1
+        fi
+
+        apt-get -o DPkg::Lock::Timeout=60 update >/dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y "$t" >/dev/null
+    fi
+done
+
+submission_size=100000
+
+## empty all queues ##
+for q in accession archived backup completed inbox ingest mappings verified; do
+    curl -s -k -u guest:guest -X DELETE "http://rabbitmq:15672/api/queues/sda/$q/contents"
+done
+## truncate database
+psql -U postgres -h postgres -d sda -At -c "TRUNCATE TABLE sda.files CASCADE;"
+
+stream_size=$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')
+i=1
+while [ $i -le $((submission_size)) ]; do
+    user="test@dummy.org"
+    inbox_path="inbox/test_dummy.org/test-file-$i.c4gh"
+    fileID=$(psql -U postgres -h postgres -d sda -At -c "SELECT sda.register_file('$inbox_path', '$user');")
+    if [ -z "$fileID" ]; then
+        echo "register_file failed"
+        exit 1
+    fi
+    psql -U postgres -h postgres -d sda -At -c "UPDATE sda.files SET header = '565f129f4727ecb986814e0278dd2d0b21521159ac19a1292403826302d62462' WHERE id = '$fileID';" >/dev/null
+    psql -U postgres -h postgres -d sda -At -c "SELECT sda.set_archived('$fileID', '$fileID', '$inbox_path', '$i','$(echo "0$i" | sha256sum)', 'SHA256');" >/dev/null
+
+    ENC_SHA=$(echo $i | sha256sum | cut -d' ' -f 1)
+    ENC_MD5=$(echo $i | md5sum | cut -d' ' -f 1)
+
+    properties=$(
+        jq -c -n \
+            --argjson delivery_mode 2 \
+            --arg correlation_id "$fileID" \
+            --arg content_encoding UTF-8 \
+            --arg content_type application/json \
+            '$ARGS.named'
+    )
+
+    encrypted_checksums=$(
+        jq -c -n \
+            --arg sha256 "$ENC_SHA" \
+            --arg md5 "$ENC_MD5" \
+            '$ARGS.named|to_entries|map(with_entries(select(.key=="key").key="type"))'
+    )
+
+    verify_payload=$(
+        jq -r -c -n \
+            --arg archive_path "$fileID" \
+            --arg file_id "$fileID" \
+            --arg user test@dummy.org \
+            --arg filepath "$inbox_path" \
+            --argjson encrypted_checksums "$encrypted_checksums" \
+            --argjson re_verify false \
+            '$ARGS.named|@base64'
+    )
+
+    verify_body=$(
+        jq -c -n \
+            --arg vhost sda \
+            --arg name sda \
+            --argjson properties "$properties" \
+            --arg routing_key "archived" \
+            --arg payload_encoding base64 \
+            --arg payload "$verify_payload" \
+            '$ARGS.named'
+    )
+
+    curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -d "$verify_body" >/dev/null
+
+    i=$((i + 1))
+done
+
+sleep 10
+RETRY_TIMES=0
+until [ "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/archived | jq '.messages')" -eq 0 ]; do
+    echo "waiting for messages to be processed"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for verify to compete the work"
+        exit 1
+    fi
+    sleep 10
+done
+
+RETRY_TIMES=0
+until [ $((stream_size+submission_size)) -eq "$(curl -s -u guest:guest http://rabbitmq:15672/api/queues/sda/error_stream | jq '.messages_ready')" ]; do
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "Messages not moved to error"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "test for verifying $submission_size files completed successfully"

--- a/.github/workflows/large_cronjob.yaml
+++ b/.github/workflows/large_cronjob.yaml
@@ -1,6 +1,10 @@
 name: Big test
 
 on:
+  push:
+    paths:
+      - ".github/integration/scripts/large_submission/*"
+      - ".github/workflows/large_cronjob.yaml"
   schedule:
     - cron: "21 21 * * 6"
   workflow_dispatch:

--- a/.github/workflows/large_cronjob.yaml
+++ b/.github/workflows/large_cronjob.yaml
@@ -1,0 +1,25 @@
+name: Big test
+
+on:
+  schedule:
+    - cron: "21 21 * * 6"
+  workflow_dispatch:
+
+jobs:
+  big_test:
+    name: Test large submission
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test: ["finalize", "ingest", "mapper", "verify"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set test env
+        run: |
+          echo "TEST=${{ matrix.test }}" >> $GITHUB_ENV
+          echo "TAG=$(curl -s https://api.github.com/repos/neicnordic/sensitive-data-archive/tags | jq -r '.[0].name')" >> $GITHUB_ENV
+      - name: Run the tests
+        run: docker compose -f .github/integration/scripts/large_submission/sda-s3.yml run integration_test


### PR DESCRIPTION
The test for finalize is expected to fail for now.

## Related issue(s) and PR(s)
This PR closes #1504 .

## Description
These tests create DB entries for 100k files, sends the messages to the MQ.

The test suite is run as a cronjob on Saturdays, all 4 tests are run in parallel in order to cope with the max runtime of 6h for a job.

### Expected results

- finalize - failed test due to timeout
- ingest - passed test, 100k messages sent to the error queue
- mapper- passed test, no errors
- verify - passed test, 100k messages sent to the error queue

## How to test
Once merged there is an option to manually trigger the tests.