### PR TITLE
Release tags based on branch

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -34,6 +34,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
         DEFAULT_BUMP: patch
+        TAG_CONTEXT: branch
 
   push_to_registry:
     needs: tag_release


### PR DESCRIPTION
by default anothrNick/github-tag-action fetches all the tags(refss) in repo and then creates a new tag based on them, with this change the new tag will be created based on the tags related to the current branch, so tags wont collide when we start versioning v1.


## Related issue(s) and PR(s)
This PR related [#1522 ].


## Description
the way that this action treats custom tag:
git_refs=
case "$tag_context" in
    *repo*)
        git_refs=$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)')
        ;;
    *branch*)
        git_refs=$(git tag --list --merged HEAD --sort=-committerdate)
        ;;
    * ) echo "Unrecognised context"
        exit 1;;
esac

## How to test
pr #1479 is for test with dry-run activated. by playing with this pr you can see the new tag in workflow: [Print version tag / tag version] step: print.
