### PR TITLE
Refactor ingest main work loop

### DIFF
--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -411,12 +411,13 @@ func (suite *TestSuite) SetupTest() {
 	assert.NoError(suite.T(), err)
 
 	Conf.Broker = broker.MQConf{
-		Host:     "localhost",
-		Port:     mqPort,
-		User:     "guest",
-		Password: "guest",
-		Exchange: "sda",
-		Vhost:    "/sda",
+		Host:        "localhost",
+		Port:        mqPort,
+		User:        "guest",
+		Password:    "guest",
+		Exchange:    "sda",
+		Vhost:       "/sda",
+		SchemasPath: "../../schemas/isolated",
 	}
 	Conf.API.MQ, err = broker.NewMQ(Conf.Broker)
 	assert.NoError(suite.T(), err)
@@ -851,7 +852,7 @@ func (suite *TestSuite) TestSetAccession() {
 	assert.NoError(suite.T(), err)
 
 	fileInfo := database.FileInfo{
-		Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
+		UploadedChecksum:  fmt.Sprintf("%x", encSha.Sum(nil)),
 		Size:              1000,
 		Path:              filePath,
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
@@ -1005,7 +1006,7 @@ func (suite *TestSuite) TestCreateDataset() {
 	assert.NoError(suite.T(), err)
 
 	fileInfo := database.FileInfo{
-		Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
+		UploadedChecksum:  fmt.Sprintf("%x", encSha.Sum(nil)),
 		Size:              1000,
 		Path:              filePath,
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
@@ -1084,7 +1085,7 @@ func (suite *TestSuite) TestCreateDataset_BadFormat() {
 	assert.NoError(suite.T(), err)
 
 	fileInfo := database.FileInfo{
-		Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
+		UploadedChecksum:  fmt.Sprintf("%x", encSha.Sum(nil)),
 		Size:              1000,
 		Path:              filePath,
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
@@ -1206,7 +1207,7 @@ func (suite *TestSuite) TestCreateDataset_WrongUser() {
 	assert.NoError(suite.T(), err)
 
 	fileInfo := database.FileInfo{
-		Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
+		UploadedChecksum:  fmt.Sprintf("%x", encSha.Sum(nil)),
 		Size:              1000,
 		Path:              filePath,
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
@@ -1968,11 +1969,12 @@ func (suite *TestSuite) TestReVerifyFile() {
 		}
 
 		fileInfo := database.FileInfo{
-			Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
-			Size:              1000,
-			Path:              filePath,
+			ArchiveChecksum:   fmt.Sprintf("%x", encSha.Sum(nil)),
 			DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 			DecryptedSize:     948,
+			Path:              filePath,
+			Size:              1000,
+			UploadedChecksum:  fmt.Sprintf("%x", encSha.Sum(nil)),
 		}
 		if err := Conf.API.DB.SetArchived(fileInfo, fileID); err != nil {
 			suite.FailNow("failed to mark file as Archived")
@@ -1993,7 +1995,6 @@ func (suite *TestSuite) TestReVerifyFile() {
 
 	gin.SetMode(gin.ReleaseMode)
 	assert.NoError(suite.T(), setupJwtAuth())
-	Conf.Broker.SchemasPath = "../../schemas/isolated"
 
 	// Mock request and response holders
 	w := httptest.NewRecorder()
@@ -2070,11 +2071,12 @@ func (suite *TestSuite) TestReVerifyDataset() {
 		}
 
 		fileInfo := database.FileInfo{
-			Checksum:          fmt.Sprintf("%x", encSha.Sum(nil)),
-			Size:              1000,
-			Path:              filePath,
+			ArchiveChecksum:   fmt.Sprintf("%x", encSha.Sum(nil)),
 			DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 			DecryptedSize:     948,
+			Path:              filePath,
+			Size:              1000,
+			UploadedChecksum:  fmt.Sprintf("%x", encSha.Sum(nil)),
 		}
 		if err := Conf.API.DB.SetArchived(fileInfo, fileID); err != nil {
 			suite.FailNow("failed to mark file as Archived")

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -861,7 +861,7 @@ func (suite *TestSuite) TestSetAccession() {
 	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
-	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 
 	gin.SetMode(gin.ReleaseMode)
@@ -1015,7 +1015,7 @@ func (suite *TestSuite) TestCreateDataset() {
 	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
-	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 
 	err = Conf.API.DB.SetAccessionID("API:accession-id-11", fileID)
@@ -1094,7 +1094,7 @@ func (suite *TestSuite) TestCreateDataset_BadFormat() {
 	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
-	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 
 	err = Conf.API.DB.SetAccessionID("API:accession-id-11", fileID)
@@ -1216,7 +1216,7 @@ func (suite *TestSuite) TestCreateDataset_WrongUser() {
 	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
-	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 
 	err = Conf.API.DB.SetAccessionID("API:accession-id-11", fileID)
@@ -1980,7 +1980,7 @@ func (suite *TestSuite) TestReVerifyFile() {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
-		if err := Conf.API.DB.SetVerified(fileInfo, fileID, fileID); err != nil {
+		if err := Conf.API.DB.SetVerified(fileInfo, fileID); err != nil {
 			suite.FailNow("failed to mark file as Verified")
 		}
 
@@ -2082,7 +2082,7 @@ func (suite *TestSuite) TestReVerifyDataset() {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
-		if err := Conf.API.DB.SetVerified(fileInfo, fileID, fileID); err != nil {
+		if err := Conf.API.DB.SetVerified(fileInfo, fileID); err != nil {
 			suite.FailNow("failed to mark file as Verified")
 		}
 

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -857,7 +857,7 @@ func (suite *TestSuite) TestSetAccession() {
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 		DecryptedSize:     948,
 	}
-	err = Conf.API.DB.SetArchived(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
 	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
@@ -1011,7 +1011,7 @@ func (suite *TestSuite) TestCreateDataset() {
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 		DecryptedSize:     948,
 	}
-	err = Conf.API.DB.SetArchived(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
 	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
@@ -1090,7 +1090,7 @@ func (suite *TestSuite) TestCreateDataset_BadFormat() {
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 		DecryptedSize:     948,
 	}
-	err = Conf.API.DB.SetArchived(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
 	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
@@ -1212,7 +1212,7 @@ func (suite *TestSuite) TestCreateDataset_WrongUser() {
 		DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 		DecryptedSize:     948,
 	}
-	err = Conf.API.DB.SetArchived(fileInfo, fileID, fileID)
+	err = Conf.API.DB.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
 	err = Conf.API.DB.SetVerified(fileInfo, fileID, fileID)
@@ -1974,7 +1974,7 @@ func (suite *TestSuite) TestReVerifyFile() {
 			DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 			DecryptedSize:     948,
 		}
-		if err := Conf.API.DB.SetArchived(fileInfo, fileID, fileID); err != nil {
+		if err := Conf.API.DB.SetArchived(fileInfo, fileID); err != nil {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
@@ -2076,7 +2076,7 @@ func (suite *TestSuite) TestReVerifyDataset() {
 			DecryptedChecksum: fmt.Sprintf("%x", decSha.Sum(nil)),
 			DecryptedSize:     948,
 		}
-		if err := Conf.API.DB.SetArchived(fileInfo, fileID, fileID); err != nil {
+		if err := Conf.API.DB.SetArchived(fileInfo, fileID); err != nil {
 			suite.FailNow("failed to mark file as Archived")
 		}
 

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -186,7 +186,6 @@ func main() {
 					log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
 				}
 			default:
-				log.Errorln("better message needed")
 				if err := delivered.Reject(false); err != nil {
 					log.Errorf("failed to reject message for reason: (%s)", err.Error())
 				}
@@ -200,7 +199,7 @@ func main() {
 func (app *Ingest) cancelFile(correlationID string, message schema.IngestionTrigger) string {
 	fileUUID, err := app.DB.GetFileID(correlationID)
 	if err != nil {
-		log.Errorf("failed to get ID for file from message: %s, reason: %s", correlationID, err.Error())
+		log.Errorf("failed to get ID for file from message (correlationID: %s), reason: %s", correlationID, err.Error())
 		if strings.Contains(err.Error(), "sql: no rows in result set") {
 			return "reject"
 		}

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -501,7 +501,7 @@ func (app *Ingest) ingestFile(correlationID string, message schema.IngestionTrig
 		return "ack"
 	}
 
-	if err := app.DB.SetArchived(fileInfo, fileID, correlationID); err != nil {
+	if err := app.DB.SetArchived(fileInfo, fileID); err != nil {
 		log.Errorf("SetArchived failed, reason: (%s)", err.Error())
 
 		return "nack"

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -28,7 +28,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+type Ingest struct {
+	Archive        storage.Backend
+	ArchiveKeyList []*[32]byte
+	Conf           *config.Config
+	DB             *database.SDAdb
+	Inbox          storage.Backend
+	MQ             *broker.AMQPBroker
+}
+
+func (app *Ingest) main() {
+	var err error
 	sigc := make(chan os.Signal, 5)
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	// Create a function to handle panic and exit gracefully
@@ -39,71 +49,71 @@ func main() {
 	}()
 
 	forever := make(chan bool)
-	conf, err := config.NewConfig("ingest")
+
+	app.Conf, err = config.NewConfig("ingest")
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	mq, err := broker.NewMQ(conf.Broker)
+	app.MQ, err = broker.NewMQ(app.Conf.Broker)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	db, err := database.NewSDAdb(conf.Database)
+	app.DB, err = database.NewSDAdb(app.Conf.Database)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	if db.Version < 8 {
+	if app.DB.Version < 8 {
 		log.Error("database schema v8 is required")
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	archiveKeyList, err := config.GetC4GHprivateKeys()
+	app.ArchiveKeyList, err = config.GetC4GHprivateKeys()
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	archive, err := storage.NewBackend(conf.Archive)
+	app.Archive, err = storage.NewBackend(app.Conf.Archive)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	inbox, err := storage.NewBackend(conf.Inbox)
+	app.Inbox, err = storage.NewBackend(app.Conf.Inbox)
 	if err != nil {
 		log.Error(err)
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
 
-	defer mq.Channel.Close()
-	defer mq.Connection.Close()
-	defer db.Close()
+	defer app.MQ.Channel.Close()
+	defer app.MQ.Connection.Close()
+	defer app.DB.Close()
 
 	go func() {
-		connError := mq.ConnectionWatcher()
+		connError := app.MQ.ConnectionWatcher()
 		log.Error(connError)
 		forever <- false
 	}()
 
 	go func() {
-		connError := mq.ChannelWatcher()
+		connError := app.MQ.ChannelWatcher()
 		log.Error(connError)
 		forever <- false
 	}()
 
 	log.Info("starting ingest service")
-	var message schema.IngestionTrigger
 
 	go func() {
 		start := time.Now()
 		for i := 1; i > 0; i++ {
-			h, err := db.ListKeyHashes()
+			h, err := app.DB.ListKeyHashes()
 			if err != nil {
 				log.Errorln(err.Error())
 			}
@@ -119,14 +129,15 @@ func main() {
 			log.Errorln("no crypt4gh key hash registered")
 		}
 
-		messages, err := mq.GetMessages(conf.Broker.Queue)
+		messages, err := app.MQ.GetMessages(app.Conf.Broker.Queue)
 		if err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
-	mainWorkLoop:
+
 		for delivered := range messages {
 			log.Debugf("received a message (corr-id: %s, message: %s)", delivered.CorrelationId, delivered.Body)
-			err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-trigger.json", conf.Broker.SchemasPath), delivered.Body)
+			message := schema.IngestionTrigger{}
+			err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-trigger.json", app.Conf.Broker.SchemasPath), delivered.Body)
 			if err != nil {
 				log.Errorf("validation of incoming message (ingestion-trigger) failed, reason: (%s)", err.Error())
 				// Send the message to an error queue so it can be analyzed.
@@ -137,429 +148,46 @@ func main() {
 				}
 
 				body, _ := json.Marshal(infoErrorMessage)
-				if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "error", body); err != nil {
+				if err := app.MQ.SendMessage(delivered.CorrelationId, app.Conf.Broker.Exchange, "error", body); err != nil {
 					log.Errorf("failed to publish message, reason: (%s)", err.Error())
 				}
 				if err := delivered.Ack(false); err != nil {
 					log.Errorf("Failed acking canceled work, reason: (%s)", err.Error())
 				}
 
-				// Restart on new message
 				continue
 			}
 
 			// we unmarshal the message in the validation step so this is safe to do
 			_ = json.Unmarshal(delivered.Body, &message)
+			log.Infof("Received work (corr-id: %s, filepath: %s, user: %s)", delivered.CorrelationId, message.FilePath, message.User)
 
-			log.Infof(
-				"Received work (corr-id: %s, filepath: %s, user: %s)",
-				delivered.CorrelationId, message.FilePath, message.User,
-			)
-
+			ackNack := ""
 			switch message.Type {
 			case "cancel":
-				fileUUID, err := db.GetFileID(delivered.CorrelationId)
-				if err != nil || fileUUID == "" {
-					log.Errorf("failed to get ID for file from message: %v", delivered.CorrelationId)
-
-					if err = delivered.Nack(false, false); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-
-					continue
+				ackNack = app.cancelFile(delivered.CorrelationId, message)
+			case "ingest":
+				ackNack = app.ingestFile(delivered.CorrelationId, message)
+			default:
+				log.Errorln("unexpected ingest message type")
+				if err := delivered.Reject(false); err != nil {
+					log.Errorf("failed to reject message for reason: (%s)", err.Error())
 				}
+			}
 
-				if err := db.UpdateFileEventLog(fileUUID, "disabled", delivered.CorrelationId, "ingest", "{}", string(delivered.Body)); err != nil {
-					log.Errorf("failed to set ingestion status for file from message: %v", delivered.CorrelationId)
-					if err = delivered.Nack(false, false); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-
-					continue
-				}
-
+			switch ackNack {
+			case "ack":
 				if err := delivered.Ack(false); err != nil {
 					log.Errorf("failed to ack message for reason: (%s)", err.Error())
 				}
-
-				continue
-			case "ingest":
-				var fileID string
-				status, err := db.GetFileStatus(delivered.CorrelationId)
-				if err != nil && err.Error() != "sql: no rows in result set" {
-					log.Errorf("failed to get status for file, reason: (%s)", err.Error())
-					if err := delivered.Nack(false, true); err != nil {
-						log.Errorf("failed to Nack message, reason: (%s)", err.Error())
-					}
-
-					continue
+			case "nack":
+				if err = delivered.Nack(false, false); err != nil {
+					log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
 				}
-
-				switch status {
-				case "disabled":
-					fileID, err := db.GetFileID(delivered.CorrelationId)
-					if err != nil {
-						log.Errorf("failed to get ID for file, reason: %s", err.Error())
-						if err := delivered.Nack(false, true); err != nil {
-							log.Errorf("failed to Nack message, reason: (%s)", err.Error())
-						}
-
-						continue
-					}
-
-					fileInfo, err := db.GetFileInfo(fileID)
-					if err != nil {
-						log.Errorf("failed to get info for file: %s", fileID)
-						if err := delivered.Nack(false, true); err != nil {
-							log.Errorf("failed to Nack message, reason: (%s)", err.Error())
-						}
-
-						continue
-					}
-
-					if err = db.UpdateFileEventLog(fileInfo.Path, "enabled", delivered.CorrelationId, "ingest", "{}", string(delivered.Body)); err != nil {
-						log.Errorf("failed to set ingestion status for file from message: %v", delivered.CorrelationId)
-						if err := delivered.Nack(false, true); err != nil {
-							log.Errorf("failed to Nack message, reason: (%s)", err.Error())
-						}
-
-						continue
-					}
-
-					if fileInfo.Checksum != "" {
-						msg := schema.IngestionVerification{
-							User:        message.User,
-							FilePath:    message.FilePath,
-							FileID:      fileID,
-							ArchivePath: fileInfo.Path,
-							EncryptedChecksums: []schema.Checksums{
-								{Type: "sha256", Value: fileInfo.Checksum},
-							},
-						}
-						archivedMsg, _ := json.Marshal(&msg)
-						err = schema.ValidateJSON(fmt.Sprintf("%s/ingestion-verification.json", conf.Broker.SchemasPath), archivedMsg)
-						if err != nil {
-							log.Errorf("Validation of outgoing message failed, reason: (%s)", err.Error())
-
-							continue
-						}
-						if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingKey, archivedMsg); err != nil {
-							log.Errorf("failed to publish message, reason: (%s)", err.Error())
-
-							continue
-						}
-
-						if err := delivered.Ack(false); err != nil {
-							log.Errorf("failed to Ack message, reason: (%s)", err.Error())
-						}
-
-						continue
-					}
-				case "":
-					// Catch all for inboxes that doesn't update the DB
-					fileID, err = db.RegisterFile(message.FilePath, message.User)
-					if err != nil {
-						log.Errorf("InsertFile failed, reason: (%s)", err.Error())
-						if err := delivered.Nack(false, true); err != nil {
-							log.Errorf("failed to Nack message, reason: (%s)", err.Error())
-						}
-
-						continue
-					}
-				default:
-					fileID, err = db.GetFileID(delivered.CorrelationId)
-					if err != nil {
-						log.Errorf("failed to get ID for file, reason: %s", err.Error())
-						if err := delivered.Nack(false, true); err != nil {
-							log.Errorf("failed to Nack message, reason: (%s)", err.Error())
-						}
-
-						continue
-					}
-				}
-
-				file, err := inbox.NewFileReader(message.FilePath)
-				if err != nil { //nolint:nestif
-					log.Errorf("Failed to open file to ingest reason: (%s)", err.Error())
-					if strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "NoSuchKey:") {
-						jsonMsg, _ := json.Marshal(map[string]string{"error": err.Error()})
-						if err := db.UpdateFileEventLog(fileID, "error", delivered.CorrelationId, "ingest", string(jsonMsg), string(delivered.Body)); err != nil {
-							log.Errorf("failed to set error status for file from message: %v, reason: %s", delivered.CorrelationId, err.Error())
-						}
-						// Send the message to an error queue so it can be analyzed.
-						fileError := broker.InfoError{
-							Error:           "Failed to open file to ingest",
-							Reason:          err.Error(),
-							OriginalMessage: message,
-						}
-						body, _ := json.Marshal(fileError)
-						if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "error", body); err != nil {
-							log.Errorf("failed to publish message, reason: (%s)", err.Error())
-						}
-						if err = delivered.Ack(false); err != nil {
-							log.Errorf("Failed to Ack message, reason: (%s)", err.Error())
-						}
-
-						continue mainWorkLoop
-					}
-
-					if err = delivered.Nack(false, true); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-
-					// Restart on new message
-					continue
-				}
-
-				fileSize, err := inbox.GetFileSize(message.FilePath, false)
-				if err != nil {
-					log.Errorf("Failed to get file size of file to ingest, reason: (%s)", err.Error())
-					// Nack message so the server gets notified that something is wrong and requeue the message.
-					// Since reading the file worked, this should eventually succeed so it is ok to requeue.
-					if err = delivered.Nack(false, true); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-					// Send the message to an error queue so it can be analyzed.
-					fileError := broker.InfoError{
-						Error:           "Failed to get file size of file to ingest",
-						Reason:          err.Error(),
-						OriginalMessage: message,
-					}
-					body, _ := json.Marshal(fileError)
-					if err = mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "error", body); err != nil {
-						log.Errorf("failed to publish message, reason: (%s)", err.Error())
-					}
-
-					// Restart on new message
-					continue
-				}
-
-				if err = db.UpdateFileEventLog(fileID, "submitted", delivered.CorrelationId, message.User, "{}", string(delivered.Body)); err != nil {
-					log.Errorf("failed to set ingestion status for file from message: %v", delivered.CorrelationId)
-				}
-
-				dest, err := archive.NewFileWriter(fileID)
-				if err != nil {
-					log.Errorf("Failed to create archive file, reason: (%s)", err.Error())
-					// Nack message so the server gets notified that something is wrong and requeue the message.
-					// NewFileWriter returns an error when the backend itself fails so this is reasonable to requeue.
-					if err = delivered.Nack(false, true); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-
-					continue
-				}
-
-				// 4MiB readbuffer, this must be large enough that we get the entire header and the first 64KiB datablock
-				var bufSize int
-				if bufSize = 4 * 1024 * 1024; conf.Inbox.S3.Chunksize > 4*1024*1024 {
-					bufSize = conf.Inbox.S3.Chunksize
-				}
-				readBuffer := make([]byte, bufSize)
-				hash := sha256.New()
-				var bytesRead int64
-				var byteBuf bytes.Buffer
-
-				for bytesRead < fileSize {
-					i, _ := io.ReadFull(file, readBuffer)
-					if i == 0 {
-						return
-					}
-					// truncate the readbuffer if the file is smaller than the buffer size
-					if i < len(readBuffer) {
-						readBuffer = readBuffer[:i]
-					}
-
-					bytesRead += int64(i)
-
-					h := bytes.NewReader(readBuffer)
-					if _, err = io.Copy(hash, h); err != nil {
-						log.Errorf("Copy to hash failed while reading file, reason: (%s)", err.Error())
-						if err = delivered.Nack(false, true); err != nil {
-							log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-						}
-
-						continue mainWorkLoop
-					}
-
-					//nolint:nestif
-					if bytesRead <= int64(len(readBuffer)) {
-						var privateKey *[32]byte
-						var header []byte
-
-						// Iterate over the key list to try decryption
-						for _, key := range archiveKeyList {
-							header, err = tryDecrypt(key, readBuffer)
-							if err == nil {
-								privateKey = key
-
-								break
-							}
-							log.Warnf("Decryption failed with key, trying next key. Reason: (%s)", err.Error())
-						}
-
-						// Check if decryption was successful with any key
-						if privateKey == nil {
-							log.Errorf("All keys failed to decrypt the submitted file")
-							if err := db.UpdateFileEventLog(fileID, "error", delivered.CorrelationId, "ingest", `{"error" : "Decryption failed with all available key(s)"}`, string(delivered.Body)); err != nil {
-								log.Errorf("Failed to set ingestion status for file from message: %v", delivered.CorrelationId)
-							}
-
-							if err := delivered.Ack(false); err != nil {
-								log.Errorf("Failed to Ack message, reason: (%s)", err.Error())
-							}
-
-							// Send the message to an error queue so it can be analyzed.
-							fileError := broker.InfoError{
-								Error:           "Trying to decrypt the submitted file failed",
-								Reason:          "Decryption failed with the available key(s)",
-								OriginalMessage: message,
-							}
-							body, _ := json.Marshal(fileError)
-							if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "error", body); err != nil {
-								log.Errorf("failed to publish message, reason: (%s)", err.Error())
-							}
-
-							continue mainWorkLoop
-						}
-
-						// Proceed with the successful key
-						// Set the file's hex encoded public key
-						publicKey := keys.DerivePublicKey(*privateKey)
-						keyhash := hex.EncodeToString(publicKey[:])
-						err = db.SetKeyHash(keyhash, fileID)
-						if err != nil {
-							log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
-							if err = delivered.Nack(false, true); err != nil {
-								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-							}
-
-							continue mainWorkLoop
-						}
-
-						log.Debugln("store header")
-						if err := db.StoreHeader(header, fileID); err != nil {
-							log.Errorf("StoreHeader failed, reason: (%s)", err.Error())
-							if err = delivered.Nack(false, true); err != nil {
-								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-							}
-
-							continue mainWorkLoop
-						}
-
-						if _, err = byteBuf.Write(readBuffer); err != nil {
-							log.Errorf("Failed to write to read buffer for header read, reason: %v)", err.Error())
-							if err = delivered.Nack(false, true); err != nil {
-								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-							}
-
-							continue mainWorkLoop
-						}
-
-						// Strip header from buffer
-						h := make([]byte, len(header))
-						if _, err = byteBuf.Read(h); err != nil {
-							log.Errorf("Failed to strip header from buffer, reason: (%s)", err.Error())
-							if err = delivered.Nack(false, true); err != nil {
-								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-							}
-
-							continue mainWorkLoop
-						}
-					} else {
-						if i < len(readBuffer) {
-							readBuffer = readBuffer[:i]
-						}
-						if _, err = byteBuf.Write(readBuffer); err != nil {
-							log.Errorf("Failed to write to read buffer for full read, reason: (%s)", err.Error())
-							if err = delivered.Nack(false, true); err != nil {
-								log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-							}
-
-							continue mainWorkLoop
-						}
-					}
-
-					// Write data to file
-					if _, err = byteBuf.WriteTo(dest); err != nil {
-						log.Errorf("Failed to write to archive file, reason: (%s)", err.Error())
-
-						continue mainWorkLoop
-					}
-				}
-
-				file.Close()
-				dest.Close()
-
-				// At this point we should do checksum comparison, but that requires updating the AWS library
-
-				fileInfo := database.FileInfo{}
-				fileInfo.Path = fileID
-				fileInfo.Checksum = fmt.Sprintf("%x", hash.Sum(nil))
-				fileInfo.Size, err = archive.GetFileSize(fileID, true)
-				if err != nil {
-					log.Errorf("Couldn't get file size from archive, reason: %v)", err.Error())
-					if err = delivered.Nack(false, true); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-
-					continue
-				}
-
-				log.Debugf("Wrote archived file (corr-id: %s, user: %s, filepath: %s, archivepath: %s, archivedsize: %d)",
-					delivered.CorrelationId, message.User, message.FilePath, fileID, fileInfo.Size)
-
-				status, err = db.GetFileStatus(delivered.CorrelationId)
-				if err != nil {
-					log.Errorf("failed to get file status, reason: (%s)", err.Error())
-					if err = delivered.Nack(false, true); err != nil {
-						log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
-					}
-				}
-				if status == "disabled" {
-					log.Infof("file with correlation ID: %s is disabled, stopping ingestion", delivered.CorrelationId)
-					if err := delivered.Ack(false); err != nil {
-						log.Errorf("Failed acking canceled work, reason: (%s)", err.Error())
-					}
-
-					continue
-				}
-
-				if err := db.SetArchived(fileInfo, fileID, delivered.CorrelationId); err != nil {
-					log.Errorf("SetArchived failed, reason: (%s)", err.Error())
-				}
-
-				log.Debugf("File marked as archived (corr-id: %s, user: %s, filepath: %s, archivepath: %s)",
-					delivered.CorrelationId, message.User, message.FilePath, fileID)
-
-				// Send message to archived
-				msg := schema.IngestionVerification{
-					User:        message.User,
-					FilePath:    message.FilePath,
-					FileID:      fileID,
-					ArchivePath: fileID,
-					EncryptedChecksums: []schema.Checksums{
-						{Type: "sha256", Value: fmt.Sprintf("%x", hash.Sum(nil))},
-					},
-				}
-				archivedMsg, _ := json.Marshal(&msg)
-
-				err = schema.ValidateJSON(fmt.Sprintf("%s/ingestion-verification.json", conf.Broker.SchemasPath), archivedMsg)
-				if err != nil {
-					log.Errorf("Validation of outgoing message failed, reason: (%s)", err.Error())
-
-					continue
-				}
-
-				if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, conf.Broker.RoutingKey, archivedMsg); err != nil {
-					// TODO fix resend mechanism
-					log.Errorf("failed to publish message, reason: (%s)", err.Error())
-
-					// Do not try to ACK message to make sure we have another go
-					continue
-				}
-				if err := delivered.Ack(false); err != nil {
-					log.Errorf("failed to Ack message, reason: (%s)", err.Error())
+			default:
+				log.Errorln("unexpected ingest message type")
+				if err := delivered.Reject(false); err != nil {
+					log.Errorf("failed to reject message for reason: (%s)", err.Error())
 				}
 			}
 		}
@@ -568,9 +196,355 @@ func main() {
 	<-forever
 }
 
+func (app *Ingest) cancelFile(correlationID string, message schema.IngestionTrigger) string {
+	fileUUID, err := app.DB.GetFileID(correlationID)
+	if err != nil {
+		log.Errorf("failed to get ID for file from message: %s, reason: %s", correlationID, err.Error())
+		if strings.Contains(err.Error(), "sql: no rows in result set") {
+			return "reject"
+		}
+
+		return "nack"
+	}
+
+	m, _ := json.Marshal(message)
+	if err := app.DB.UpdateFileEventLog(fileUUID, "disabled", correlationID, "ingest", "{}", string(m)); err != nil {
+		log.Errorf("failed to set event log status for file: %s", correlationID)
+
+		return "nack"
+	}
+
+	return "ack"
+}
+
+func (app *Ingest) ingestFile(correlationID string, message schema.IngestionTrigger) string {
+	var fileID string
+	status, err := app.DB.GetFileStatus(correlationID)
+	if err != nil && err.Error() != "sql: no rows in result set" {
+		log.Errorf("failed to get status for file, reason: (%s)", err.Error())
+
+		return "nack"
+	}
+
+	switch status {
+	case "disabled":
+		fileID, err = app.DB.GetFileID(correlationID)
+		if err != nil {
+			log.Errorf("failed to get ID for file, reason: %s", err.Error())
+
+			return "nack"
+		}
+
+		fileInfo, err := app.DB.GetFileInfo(fileID)
+		if err != nil {
+			log.Errorf("failed to get info for file: %s, reason: %s", fileID, err.Error())
+
+			return "nack"
+		}
+
+		// What if the file in the inbox is different this time?
+		// Check uploaded checksum in the DB against the checksum of the file.
+		// Would be easy if the inbox message had the checksum or that the s3inbox added the checksum to the DB.
+
+		if fileInfo.Checksum != "" {
+			msg := schema.IngestionVerification{
+				User:        message.User,
+				FilePath:    message.FilePath,
+				FileID:      fileID,
+				ArchivePath: fileInfo.Path,
+				EncryptedChecksums: []schema.Checksums{
+					{Type: "sha256", Value: fileInfo.Checksum},
+				},
+			}
+			archivedMsg, _ := json.Marshal(&msg)
+			err = schema.ValidateJSON(fmt.Sprintf("%s/ingestion-verification.json", app.Conf.Broker.SchemasPath), archivedMsg)
+			if err != nil {
+				log.Errorf("Validation of outgoing message failed, reason: (%s)", err.Error())
+
+				return "nack"
+			}
+
+			m, _ := json.Marshal(message)
+			if err = app.DB.UpdateFileEventLog(fileInfo.Path, "enabled", correlationID, "ingest", "{}", string(m)); err != nil {
+				log.Errorf("failed to set ingestion status for file from message: %v", correlationID)
+
+				return "nack"
+			}
+
+			if err := app.MQ.SendMessage(correlationID, app.Conf.Broker.Exchange, app.Conf.Broker.RoutingKey, archivedMsg); err != nil {
+				log.Errorf("failed to publish message, reason: (%s)", err.Error())
+
+				return "reject"
+			}
+
+			return "ack"
+		}
+	case "":
+		// Catch all for inboxes that doesn't update the DB
+		fileID, err = app.DB.RegisterFile(message.FilePath, message.User)
+		if err != nil {
+			log.Errorf("InsertFile failed, reason: (%s)", err.Error())
+
+			return "nack"
+		}
+	case "uploaded":
+		fileID, err = app.DB.GetFileID(correlationID)
+		if err != nil {
+			log.Errorf("failed to get ID for file, reason: %s", err.Error())
+
+			return "nack"
+		}
+	default:
+		return "reject"
+	}
+
+	file, err := app.Inbox.NewFileReader(message.FilePath)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "NoSuchKey:"):
+			log.Errorf("Failed to open file to ingest reason: (%s)", err.Error())
+			jsonMsg, _ := json.Marshal(map[string]string{"error": err.Error()})
+			m, _ := json.Marshal(message)
+			if err := app.DB.UpdateFileEventLog(fileID, "error", correlationID, "ingest", string(jsonMsg), string(m)); err != nil {
+				log.Errorf("failed to set error status for file from message: %v, reason: %s", correlationID, err.Error())
+			}
+			// Send the message to an error queue so it can be analyzed.
+			fileError := broker.InfoError{
+				Error:           "Failed to open file to ingest",
+				Reason:          err.Error(),
+				OriginalMessage: message,
+			}
+			body, _ := json.Marshal(fileError)
+			if err := app.MQ.SendMessage(correlationID, app.Conf.Broker.Exchange, "error", body); err != nil {
+				log.Errorf("failed to publish message, reason: (%s)", err.Error())
+
+				return "reject"
+			}
+
+			return "ack"
+		default:
+			return "nack"
+		}
+	}
+
+	fileSize, err := app.Inbox.GetFileSize(message.FilePath, false)
+	if err != nil {
+		log.Errorf("Failed to get file size of file to ingest, reason: (%s)", err.Error())
+		// Since reading the file worked, this should eventually succeed so it is ok to requeue.
+		return "nack"
+	}
+
+	dest, err := app.Archive.NewFileWriter(fileID)
+	if err != nil {
+		log.Errorf("Failed to create archive file, reason: (%s)", err.Error())
+		// NewFileWriter returns an error when the backend itself fails so this is reasonable to requeue.
+		return "nack"
+	}
+
+	m, _ := json.Marshal(message)
+	if err = app.DB.UpdateFileEventLog(fileID, "submitted", correlationID, "ingest", "{}", string(m)); err != nil {
+		log.Errorf("failed to set ingestion status for file from message: %v", correlationID)
+	}
+
+	// 4MiB readbuffer, this must be large enough that we get the entire header and the first 64KiB datablock
+	var bufSize int
+	if bufSize = 4 * 1024 * 1024; app.Conf.Inbox.S3.Chunksize > 4*1024*1024 {
+		bufSize = app.Conf.Inbox.S3.Chunksize
+	}
+	readBuffer := make([]byte, bufSize)
+	hash := sha256.New()
+	var bytesRead int64
+	var byteBuf bytes.Buffer
+
+	for bytesRead < fileSize {
+		i, _ := io.ReadFull(file, readBuffer)
+		if i == 0 {
+			log.Debugln("this should not happen")
+
+			return "reject"
+		}
+		// truncate the readbuffer if the file is smaller than the buffer size
+		if i < len(readBuffer) {
+			readBuffer = readBuffer[:i]
+		}
+
+		bytesRead += int64(i)
+
+		h := bytes.NewReader(readBuffer)
+		if _, err = io.Copy(hash, h); err != nil {
+			log.Errorf("Copy to hash failed while reading file, reason: (%s)", err.Error())
+
+			return "nack"
+		}
+
+		switch {
+		case bytesRead <= int64(len(readBuffer)):
+			var privateKey *[32]byte
+			var header []byte
+
+			// Iterate over the key list to try decryption
+			for _, key := range app.ArchiveKeyList {
+				header, err = tryDecrypt(key, readBuffer)
+				if err == nil {
+					privateKey = key
+
+					break
+				}
+				log.Warnf("Decryption failed with key, trying next key. Reason: (%s)", err.Error())
+			}
+
+			// Check if decryption was successful with any key
+			if privateKey == nil {
+				log.Errorf("All keys failed to decrypt the submitted file")
+				m, _ := json.Marshal(message)
+				if err := app.DB.UpdateFileEventLog(fileID, "error", correlationID, "ingest", `{"error" : "Decryption failed with all available key(s)"}`, string(m)); err != nil {
+					log.Errorf("Failed to set ingestion status for file from message: %v", correlationID)
+				}
+
+				// Send the message to an error queue so it can be analyzed.
+				fileError := broker.InfoError{
+					Error:           "Trying to decrypt the submitted file failed",
+					Reason:          "Decryption failed with the available key(s)",
+					OriginalMessage: message,
+				}
+				body, _ := json.Marshal(fileError)
+				if err := app.MQ.SendMessage(correlationID, app.Conf.Broker.Exchange, "error", body); err != nil {
+					log.Errorf("failed to publish message, reason: (%s)", err.Error())
+				}
+
+				return "ack"
+			}
+
+			// Proceed with the successful key
+			// Set the file's hex encoded public key
+			publicKey := keys.DerivePublicKey(*privateKey)
+			keyhash := hex.EncodeToString(publicKey[:])
+			err = app.DB.SetKeyHash(keyhash, fileID)
+			if err != nil {
+				log.Errorf("Key hash %s could not be set for fileID %s: (%s)", keyhash, fileID, err.Error())
+
+				return "nack"
+			}
+
+			log.Debugln("store header")
+			if err := app.DB.StoreHeader(header, fileID); err != nil {
+				log.Errorf("StoreHeader failed, reason: (%s)", err.Error())
+
+				return "nack"
+			}
+
+			if _, err = byteBuf.Write(readBuffer); err != nil {
+				log.Errorf("Failed to write to read buffer for header read, reason: %v)", err.Error())
+
+				return "nack"
+			}
+
+			// Strip header from buffer
+			h := make([]byte, len(header))
+			if _, err = byteBuf.Read(h); err != nil {
+				log.Errorf("Failed to strip header from buffer, reason: (%s)", err.Error())
+
+				return "nack"
+			}
+		default:
+			if i < len(readBuffer) {
+				readBuffer = readBuffer[:i]
+			}
+			if _, err = byteBuf.Write(readBuffer); err != nil {
+				log.Errorf("Failed to write to read buffer for full read, reason: (%s)", err.Error())
+
+				return "nack"
+			}
+		}
+
+		// Write data to file
+		if _, err = byteBuf.WriteTo(dest); err != nil {
+			log.Errorf("Failed to write to archive file, reason: (%s)", err.Error())
+
+			_ = file.Close()
+			_ = dest.Close()
+			if err := app.Archive.RemoveFile(fileID); err != nil {
+				log.Errorf("error when removing uncompleted file: %s", fileID)
+			}
+
+			return "nack"
+		}
+	}
+
+	file.Close()
+	dest.Close()
+
+	// At this point we should do checksum comparison, but that requires updating the AWS library
+
+	fileInfo := database.FileInfo{}
+	fileInfo.Path = fileID
+	fileInfo.UploadedChecksum = fmt.Sprintf("%x", hash.Sum(nil))
+	fileInfo.Size, err = app.Archive.GetFileSize(fileID, true)
+	if err != nil {
+		log.Errorf("Couldn't get file size from archive, reason: %v)", err.Error())
+
+		return "nack"
+	}
+
+	log.Debugf("Wrote archived file (corr-id: %s, user: %s, filepath: %s, archivepath: %s, archivedsize: %d)", correlationID, message.User, message.FilePath, fileID, fileInfo.Size)
+
+	status, err = app.DB.GetFileStatus(correlationID)
+	if err != nil {
+		log.Errorf("failed to get file status, reason: (%s)", err.Error())
+
+		return "nack"
+	}
+
+	if status == "disabled" {
+		log.Infof("file with correlation ID: %s is disabled, stopping ingestion", correlationID)
+
+		return "ack"
+	}
+
+	if err := app.DB.SetArchived(fileInfo, fileID, correlationID); err != nil {
+		log.Errorf("SetArchived failed, reason: (%s)", err.Error())
+
+		return "nack"
+	}
+
+	if err := app.DB.UpdateFileEventLog(fileID, "archived", correlationID, "ingest", "{}", string(m)); err != nil {
+		log.Errorf("failed to set event log status for file: %s", correlationID)
+
+		return "nack"
+	}
+	log.Debugf("File marked as archived (corr-id: %s, user: %s, filepath: %s, archivepath: %s)", correlationID, message.User, message.FilePath, fileID)
+
+	// Send message to archived
+	msg := schema.IngestionVerification{
+		User:        message.User,
+		FilePath:    message.FilePath,
+		FileID:      fileID,
+		ArchivePath: fileID,
+		EncryptedChecksums: []schema.Checksums{
+			{Type: "sha256", Value: fmt.Sprintf("%x", hash.Sum(nil))},
+		},
+	}
+	archivedMsg, _ := json.Marshal(&msg)
+
+	err = schema.ValidateJSON(fmt.Sprintf("%s/ingestion-verification.json", app.Conf.Broker.SchemasPath), archivedMsg)
+	if err != nil {
+		log.Errorf("Validation of outgoing message failed, reason: (%s)", err.Error())
+
+		return "nack"
+	}
+
+	if err := app.MQ.SendMessage(correlationID, app.Conf.Broker.Exchange, app.Conf.Broker.RoutingKey, archivedMsg); err != nil {
+		// TODO fix resend mechanism
+		log.Errorf("failed to publish message, reason: (%s)", err.Error())
+
+		return "reject"
+	}
+
+	return "ack"
+}
+
 // tryDecrypt tries to decrypt the start of buf.
 func tryDecrypt(key *[32]byte, buf []byte) ([]byte, error) {
-
 	log.Debugln("Try decrypting the first data block")
 	a := bytes.NewReader(buf)
 	b, err := streaming.NewCrypt4GHReader(a, *key, nil)

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -37,7 +37,8 @@ type Ingest struct {
 	MQ             *broker.AMQPBroker
 }
 
-func (app *Ingest) main() {
+func main() {
+	app := Ingest{}
 	var err error
 	sigc := make(chan os.Signal, 5)
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -253,7 +253,7 @@ func (app *Ingest) ingestFile(correlationID string, message schema.IngestionTrig
 				FileID:      fileID,
 				ArchivePath: fileInfo.Path,
 				EncryptedChecksums: []schema.Checksums{
-					{Type: "sha256", Value: fileInfo.Checksum},
+					{Type: "sha256", Value: fileInfo.ArchiveChecksum},
 				},
 			}
 			archivedMsg, _ := json.Marshal(&msg)

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -186,6 +186,7 @@ func main() {
 					log.Errorf("Failed to Nack message, reason: (%s)", err.Error())
 				}
 			default:
+				// will catch `reject`s, failures that should not be requeued.
 				if err := delivered.Reject(false); err != nil {
 					log.Errorf("failed to reject message for reason: (%s)", err.Error())
 				}
@@ -401,7 +402,7 @@ func (app *Ingest) ingestFile(correlationID string, message schema.IngestionTrig
 	for bytesRead < fileSize {
 		i, _ := io.ReadFull(file, readBuffer)
 		if i == 0 {
-			log.Debugln("this should not happen")
+			log.Errorln("readBuffer returned 0 bytes, this should not happen")
 
 			return "reject"
 		}

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -572,7 +572,7 @@ func (suite *TestSuite) TestIngestFile_reingestVerifiedFile() {
 	// fake file verification
 	sha256hash := sha256.New()
 	var fi database.FileInfo
-	fi.Checksum = hex.EncodeToString(sha256hash.Sum(nil))
+	fi.ArchiveChecksum = hex.EncodeToString(sha256hash.Sum(nil))
 	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
 	fi.DecryptedSize = 10 * 1024 * 1024
 	fi.Size = (10 * 1024 * 1024) + 456
@@ -604,7 +604,7 @@ func (suite *TestSuite) TestIngestFile_reingestVerifiedCancelledFile() {
 	// fake file verification
 	sha256hash := sha256.New()
 	var fi database.FileInfo
-	fi.Checksum = hex.EncodeToString(sha256hash.Sum(nil))
+	fi.ArchiveChecksum = hex.EncodeToString(sha256hash.Sum(nil))
 	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
 	fi.DecryptedSize = 10 * 1024 * 1024
 	fi.Size = (10 * 1024 * 1024) + 456

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -709,3 +709,17 @@ func (suite *TestSuite) TestIngestFile_reingestVerifiedCancelledFileNewChecksum(
 
 	assert.NotEqual(suite.T(), dbChecksum, firstDbChecksum)
 }
+func (suite *TestSuite) TestIngestFile_missingFile() {
+	// prepare the DB entries
+	UserName := "test-ingest"
+	corrID := uuid.New().String()
+	basepath := filepath.Dir(suite.filePath)
+
+	message := schema.IngestionTrigger{
+		Type:     "ingest",
+		FilePath: fmt.Sprintf("%s/missing.file.c4gh", basepath),
+		User:     UserName,
+	}
+
+	assert.Equal(suite.T(), "ack", suite.ingest.ingestFile(corrID, message))
+}

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -550,3 +550,162 @@ func (suite *TestSuite) TestIngestFile_reingestCancelledFileNewChecksum() {
 
 	assert.Equal(suite.T(), dbChecksum, hex.EncodeToString(sha256hash.Sum(nil)))
 }
+func (suite *TestSuite) TestIngestFile_reingestVerifiedFile() {
+	// prepare the DB entries
+	UserName := "test-ingest"
+	fileID, err := suite.ingest.DB.RegisterFile(suite.filePath, UserName)
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	corrID := uuid.New().String()
+
+	if err = suite.ingest.DB.UpdateFileEventLog(fileID, "uploaded", corrID, UserName, "{}", "{}"); err != nil {
+		suite.Fail("failed to update file event log")
+	}
+
+	message := schema.IngestionTrigger{
+		Type:     "ingest",
+		FilePath: suite.filePath,
+		User:     UserName,
+	}
+
+	assert.Equal(suite.T(), "ack", suite.ingest.ingestFile(corrID, message))
+
+	// fake file verification
+	sha256hash := sha256.New()
+	var fi database.FileInfo
+	fi.Checksum = hex.EncodeToString(sha256hash.Sum(nil))
+	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
+	fi.DecryptedSize = 10 * 1024 * 1024
+	fi.Size = (10 * 1024 * 1024) + 456
+	if err := suite.ingest.DB.SetVerified(fi, fileID, corrID); err != nil {
+		suite.Fail("failed to mark file as verified")
+	}
+
+	assert.Equal(suite.T(), "reject", suite.ingest.ingestFile(corrID, message))
+}
+func (suite *TestSuite) TestIngestFile_reingestVerifiedCancelledFile() {
+	// prepare the DB entries
+	UserName := "test-ingest"
+	fileID, err := suite.ingest.DB.RegisterFile(suite.filePath, UserName)
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	corrID := uuid.New().String()
+
+	if err = suite.ingest.DB.UpdateFileEventLog(fileID, "uploaded", corrID, UserName, "{}", "{}"); err != nil {
+		suite.Fail("failed to update file event log")
+	}
+
+	message := schema.IngestionTrigger{
+		Type:     "ingest",
+		FilePath: suite.filePath,
+		User:     UserName,
+	}
+
+	assert.Equal(suite.T(), "ack", suite.ingest.ingestFile(corrID, message))
+
+	// fake file verification
+	sha256hash := sha256.New()
+	var fi database.FileInfo
+	fi.Checksum = hex.EncodeToString(sha256hash.Sum(nil))
+	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
+	fi.DecryptedSize = 10 * 1024 * 1024
+	fi.Size = (10 * 1024 * 1024) + 456
+	if err := suite.ingest.DB.SetVerified(fi, fileID, corrID); err != nil {
+		suite.Fail("failed to mark file as verified")
+	}
+
+	if err = suite.ingest.DB.UpdateFileEventLog(fileID, "disabled", corrID, "ingest", "{}", "{}"); err != nil {
+		suite.Fail("failed to update file event log")
+	}
+
+	assert.Equal(suite.T(), "ack", suite.ingest.ingestFile(corrID, message))
+}
+func (suite *TestSuite) TestIngestFile_reingestVerifiedCancelledFileNewChecksum() {
+	// prepare the DB entries
+	UserName := "test-ingest"
+	fileID, err := suite.ingest.DB.RegisterFile(suite.filePath, UserName)
+	assert.NoError(suite.T(), err, "failed to register file in database")
+	corrID := uuid.New().String()
+
+	if err = suite.ingest.DB.UpdateFileEventLog(fileID, "uploaded", corrID, UserName, "{}", "{}"); err != nil {
+		suite.Fail("failed to update file event log")
+	}
+
+	message := schema.IngestionTrigger{
+		Type:     "ingest",
+		FilePath: suite.filePath,
+		User:     UserName,
+	}
+
+	assert.Equal(suite.T(), "ack", suite.ingest.ingestFile(corrID, message))
+
+	var firstDbChecksum string
+	const q1 = "SELECT checksum from sda.checksums WHERE source = 'UPLOADED' and file_id = $1;"
+	if err := suite.ingest.DB.DB.QueryRow(q1, fileID).Scan(&firstDbChecksum); err != nil {
+		suite.FailNow("failed to get checksum from database")
+	}
+
+	// fake file verification
+	verifiedSha256 := sha256.New()
+	var fi database.FileInfo
+	fi.ArchiveChecksum = hex.EncodeToString(verifiedSha256.Sum(nil))
+	fi.DecryptedChecksum = hex.EncodeToString(verifiedSha256.Sum(nil))
+	fi.DecryptedSize = 10 * 1024 * 1024
+	fi.Size = (10 * 1024 * 1024) + 456
+	if err := suite.ingest.DB.SetVerified(fi, fileID, corrID); err != nil {
+		suite.Fail("failed to mark file as verified")
+	}
+
+	if err = suite.ingest.DB.UpdateFileEventLog(fileID, "disabled", corrID, "ingest", "{}", "{}"); err != nil {
+		suite.Fail("failed to update file event log")
+	}
+
+	// over write the encrypted file to generate new checksum
+	f, err := os.CreateTemp(suite.ingest.Conf.Inbox.Posix.Location, "")
+	if err != nil {
+		suite.FailNow("failed to create test file")
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, io.LimitReader(rand.Reader, 10*1024*1024))
+	if err != nil {
+		suite.FailNow("failed to write data to test file")
+	}
+
+	_, privateKey, err := keys.GenerateKeyPair()
+	if err != nil {
+		suite.FailNow("failed to create private c4gh key")
+	}
+
+	outFile, err := os.Create(path.Join(suite.ingest.Conf.Inbox.Posix.Location, suite.filePath))
+	if err != nil {
+		suite.FailNowf("failed to create encrypted test file: %s", err.Error())
+	}
+	defer outFile.Close()
+
+	sha256hash := sha256.New()
+	mr := io.MultiWriter(outFile, sha256hash)
+
+	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(mr, privateKey, suite.pubKeyList, nil)
+	if err != nil {
+		suite.FailNowf("failed to create c4gh writer: %s", err.Error())
+	}
+
+	_, err = io.Copy(crypt4GHWriter, io.LimitReader(rand.Reader, 10*1024*1024))
+	if err != nil {
+		suite.FailNow("failed to write data to encrypted test file")
+	}
+	crypt4GHWriter.Close()
+
+	// reingestion should work
+	assert.Equal(suite.T(), "ack", suite.ingest.ingestFile(corrID, message))
+
+	// DB should have the new checksum
+	var dbChecksum string
+	const q = "SELECT checksum from sda.checksums WHERE source = 'UPLOADED' and file_id = $1;"
+	if err := suite.ingest.DB.DB.QueryRow(q, fileID).Scan(&dbChecksum); err != nil {
+		suite.FailNow("failed to get checksum from database")
+	}
+
+	assert.Equal(suite.T(), dbChecksum, hex.EncodeToString(sha256hash.Sum(nil)))
+
+	assert.NotEqual(suite.T(), dbChecksum, firstDbChecksum)
+}

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -576,7 +576,7 @@ func (suite *TestSuite) TestIngestFile_reingestVerifiedFile() {
 	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
 	fi.DecryptedSize = 10 * 1024 * 1024
 	fi.Size = (10 * 1024 * 1024) + 456
-	if err := suite.ingest.DB.SetVerified(fi, fileID, corrID); err != nil {
+	if err := suite.ingest.DB.SetVerified(fi, fileID); err != nil {
 		suite.Fail("failed to mark file as verified")
 	}
 
@@ -608,7 +608,7 @@ func (suite *TestSuite) TestIngestFile_reingestVerifiedCancelledFile() {
 	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
 	fi.DecryptedSize = 10 * 1024 * 1024
 	fi.Size = (10 * 1024 * 1024) + 456
-	if err := suite.ingest.DB.SetVerified(fi, fileID, corrID); err != nil {
+	if err := suite.ingest.DB.SetVerified(fi, fileID); err != nil {
 		suite.Fail("failed to mark file as verified")
 	}
 
@@ -650,7 +650,7 @@ func (suite *TestSuite) TestIngestFile_reingestVerifiedCancelledFileNewChecksum(
 	fi.DecryptedChecksum = hex.EncodeToString(verifiedSha256.Sum(nil))
 	fi.DecryptedSize = 10 * 1024 * 1024
 	fi.Size = (10 * 1024 * 1024) + 456
-	if err := suite.ingest.DB.SetVerified(fi, fileID, corrID); err != nil {
+	if err := suite.ingest.DB.SetVerified(fi, fileID); err != nil {
 		suite.Fail("failed to mark file as verified")
 	}
 

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -1,66 +1,300 @@
 package main
 
 import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
+	"time"
 
+	log "github.com/sirupsen/logrus"
+
+	"github.com/google/uuid"
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/crypt4gh/streaming"
+	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
 	"github.com/neicnordic/sensitive-data-archive/internal/helper"
+	"github.com/neicnordic/sensitive-data-archive/internal/schema"
+	"github.com/neicnordic/sensitive-data-archive/internal/storage"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
-type TestSuite struct {
-	suite.Suite
+var DBport, MQport int
+var BrokerAPI string
+
+func TestMain(m *testing.M) {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		m.Run()
+	}
+	_, b, _, _ := runtime.Caller(0)
+	rootDir := path.Join(path.Dir(b), "../../../")
+
+	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		log.Fatalf("Could not construct pool: %s", err)
+	}
+
+	// uses pool to try to connect to Docker
+	err = pool.Client.Ping()
+	if err != nil {
+		log.Fatalf("Could not connect to Docker: %s", err)
+	}
+
+	// pulls an image, creates a container based on it and runs it
+	postgres, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "postgres",
+		Tag:        "15.2-alpine3.17",
+		Env: []string{
+			"POSTGRES_PASSWORD=rootpasswd",
+			"POSTGRES_DB=sda",
+		},
+		Mounts: []string{
+			fmt.Sprintf("%s/postgresql/initdb.d:/docker-entrypoint-initdb.d", rootDir),
+		},
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{
+			Name: "no",
+		}
+	})
+	if err != nil {
+		log.Fatalf("Could not start resource: %s", err)
+	}
+
+	dbHostAndPort := postgres.GetHostPort("5432/tcp")
+	DBport, _ = strconv.Atoi(postgres.GetPort("5432/tcp"))
+	databaseURL := fmt.Sprintf("postgres://postgres:rootpasswd@%s/sda?sslmode=disable", dbHostAndPort)
+
+	pool.MaxWait = 120 * time.Second
+	if err = pool.Retry(func() error {
+		db, err := sql.Open("postgres", databaseURL)
+		if err != nil {
+			log.Println(err)
+
+			return err
+		}
+
+		query := "SELECT MAX(version) FROM sda.dbschema_version;"
+		var dbVersion int
+
+		return db.QueryRow(query).Scan(&dbVersion)
+	}); err != nil {
+		log.Fatalf("Could not connect to postgres: %s", err)
+	}
+
+	// pulls an image, creates a container based on it and runs it
+	rabbitmq, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "ghcr.io/neicnordic/sensitive-data-archive",
+		Tag:        "v0.3.89-rabbitmq",
+	}, func(config *docker.HostConfig) {
+		// set AutoRemove to true so that stopped container goes away by itself
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{
+			Name: "no",
+		}
+	})
+	if err != nil {
+		if err := pool.Purge(postgres); err != nil {
+			log.Fatalf("Could not purge resource: %s", err)
+		}
+		log.Fatalf("Could not start resource: %s", err)
+	}
+
+	MQport, _ = strconv.Atoi(rabbitmq.GetPort("5672/tcp"))
+	BrokerAPI = rabbitmq.GetHostPort("15672/tcp")
+
+	client := http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, "http://"+BrokerAPI+"/api/queues/sda/", http.NoBody)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.SetBasicAuth("guest", "guest")
+
+	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
+	if err := pool.Retry(func() error {
+		res, err := client.Do(req)
+		if err != nil || res.StatusCode != 200 {
+			return err
+		}
+		res.Body.Close()
+
+		return nil
+	}); err != nil {
+		if err := pool.Purge(postgres); err != nil {
+			log.Fatalf("Could not purge resource: %s", err)
+		}
+		if err := pool.Purge(rabbitmq); err != nil {
+			log.Fatalf("Could not purge resource: %s", err)
+		}
+		log.Fatalf("Could not connect to rabbitmq: %s", err)
+	}
+
+	log.Println("starting tests")
+	code := m.Run()
+
+	log.Println("tests completed")
+	if err := pool.Purge(postgres); err != nil {
+		log.Fatalf("Could not purge resource: %s", err)
+	}
+	if err := pool.Purge(rabbitmq); err != nil {
+		log.Fatalf("Could not purge resource: %s", err)
+	}
+
+	os.Exit(code)
 }
 
-var pubKeyList = [][32]byte{}
-
-func TestConfigTestSuite(t *testing.T) {
+func TestIngestTestSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }
 
-func (suite *TestSuite) SetupTest() {
-	viper.Set("log.level", "debug")
-	archive := suite.T().TempDir()
-	defer os.RemoveAll(archive)
-	viper.Set("archive.location", archive)
+type TestSuite struct {
+	suite.Suite
+	filePath   string
+	pubKeyList [][32]byte
+	ingest     Ingest
+}
 
+func (suite *TestSuite) SetupSuite() {
+	viper.Set("log.level", "debug")
 	tempDir := suite.T().TempDir()
 	keyFile1 := fmt.Sprintf("%s/c4gh1.key", tempDir)
 	keyFile2 := fmt.Sprintf("%s/c4gh2.key", tempDir)
 
 	publicKey, err := helper.CreatePrivateKeyFile(keyFile1, "test")
-	assert.NoError(suite.T(), err)
+	if err != nil {
+		suite.FailNow("Failed to create c4gh key")
+	}
 	// Add only the first public key to the list
-	pubKeyList = append(pubKeyList, publicKey)
+	suite.pubKeyList = append(suite.pubKeyList, publicKey)
 
 	_, err = helper.CreatePrivateKeyFile(keyFile2, "test")
-	assert.NoError(suite.T(), err)
+	if err != nil {
+		suite.FailNow("Failed to create c4gh key")
+	}
 
 	viper.Set("c4gh.privateKeys", []config.C4GHprivateKeyConf{
 		{FilePath: keyFile1, Passphrase: "test"},
 		{FilePath: keyFile2, Passphrase: "test"},
 	})
+	viper.Set("archive.type", "posix")
+	viper.Set("archive.location", "/tmp/")
+	viper.Set("broker.host", "localhost")
+	viper.Set("broker.port", MQport)
+	viper.Set("broker.user", "guest")
+	viper.Set("broker.password", "guest")
+	viper.Set("broker.queue", "ingest")
+	viper.Set("broker.routingkey", "verify")
+	viper.Set("broker.vhost", "sda")
+	viper.Set("db.host", "localhost")
+	viper.Set("db.port", DBport)
+	viper.Set("db.user", "postgres")
+	viper.Set("db.password", "rootpasswd")
+	viper.Set("db.database", "sda")
+	viper.Set("db.sslMode", "disable")
+	viper.Set("inbox.type", "posix")
+	viper.Set("inbox.location", "/tmp/")
+	viper.Set("schema.path", "../../schemas/isolated/")
 
-	viper.Set("broker.host", "test")
-	viper.Set("broker.port", 123)
-	viper.Set("broker.user", "test")
-	viper.Set("broker.password", "test")
-	viper.Set("broker.queue", "test")
-	viper.Set("broker.routingkey", "test")
-	viper.Set("db.host", "test")
-	viper.Set("db.port", 123)
-	viper.Set("db.user", "test")
-	viper.Set("db.password", "test")
-	viper.Set("db.database", "test")
+	suite.ingest.Conf, err = config.NewConfig("ingest")
+	if err != nil {
+		suite.FailNowf("failed to init config: %s", err.Error())
+	}
+	suite.ingest.DB, err = database.NewSDAdb(suite.ingest.Conf.Database)
+	if err != nil {
+		suite.FailNowf("failed to setup database connection: %s", err.Error())
+	}
+	suite.ingest.MQ, err = broker.NewMQ(suite.ingest.Conf.Broker)
+	if err != nil {
+		suite.FailNowf("failed to setup rabbitMQ connection: %s", err.Error())
+	}
+	suite.ingest.ArchiveKeyList, err = config.GetC4GHprivateKeys()
+	if err != nil {
+		suite.FailNow("no private keys configured")
+	}
+
+	if err := suite.ingest.DB.AddKeyHash(hex.EncodeToString(publicKey[:]), "the test key"); err != nil {
+		suite.FailNow("failed to register the public key")
+	}
 }
 
+func (suite *TestSuite) TearDownSuite() {
+	_ = os.RemoveAll(suite.ingest.Conf.Archive.Posix.Location)
+	_ = os.RemoveAll(suite.ingest.Conf.Inbox.Posix.Location)
+}
+
+func (suite *TestSuite) SetupTest() {
+	var err error
+	suite.ingest.Conf.Archive.Posix.Location, err = os.MkdirTemp("", "archive")
+	if err != nil {
+		suite.FailNow("failed to create temp folder")
+	}
+
+	suite.ingest.Conf.Inbox.Posix.Location, err = os.MkdirTemp("", "inbox")
+	if err != nil {
+		suite.FailNow("failed to create temp folder")
+	}
+
+	f, err := os.CreateTemp(suite.ingest.Conf.Inbox.Posix.Location, "")
+	if err != nil {
+		suite.FailNow("failed to create test file")
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, io.LimitReader(rand.Reader, 10*1024*1024))
+	if err != nil {
+		suite.FailNow("failed to write data to test file")
+	}
+
+	outFileName := f.Name() + ".c4gh"
+	outFile, err := os.Create(outFileName)
+	if err != nil {
+		suite.FailNow("failed to create encrypted test file")
+	}
+	defer outFile.Close()
+
+	_, privateKey, err := keys.GenerateKeyPair()
+	if err != nil {
+		suite.FailNow("failed to create private c4gh key")
+	}
+
+	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(outFile, privateKey, suite.pubKeyList, nil)
+	if err != nil {
+		suite.FailNow("failed to create c4gh writer")
+	}
+
+	_, err = io.Copy(crypt4GHWriter, io.LimitReader(rand.Reader, 10*1024*1024))
+	if err != nil {
+		suite.FailNow("failed to write data to encrypted test file")
+	}
+	crypt4GHWriter.Close()
+
+	suite.filePath = filepath.Base(outFileName)
+
+	suite.ingest.Archive, err = storage.NewBackend(suite.ingest.Conf.Archive)
+	if err != nil {
+		suite.FailNow("failed to setup archive backend")
+	}
+	suite.ingest.Inbox, err = storage.NewBackend(suite.ingest.Conf.Inbox)
+	if err != nil {
+		suite.FailNow("failed to setup inbox backend")
+	}
+}
 func (suite *TestSuite) TestTryDecrypt_wrongFile() {
 	tempDir := suite.T().TempDir()
 	err := os.WriteFile(fmt.Sprintf("%s/dummy.file", tempDir), []byte("hello\ngo\n"), 0600)
@@ -80,7 +314,6 @@ func (suite *TestSuite) TestTryDecrypt_wrongFile() {
 	assert.Nil(suite.T(), header)
 	assert.EqualError(suite.T(), err, "not a Crypt4GH file")
 }
-
 func (suite *TestSuite) TestTryDecrypt() {
 	_, signingKey, err := keys.GenerateKeyPair()
 	assert.NoError(suite.T(), err)
@@ -96,7 +329,7 @@ func (suite *TestSuite) TestTryDecrypt() {
 	encryptedFile, err := os.CreateTemp(tempDir, "encryptedFile-")
 	assert.NoError(suite.T(), err)
 
-	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(encryptedFile, signingKey, pubKeyList, nil)
+	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(encryptedFile, signingKey, suite.pubKeyList, nil)
 	assert.NoError(suite.T(), err)
 
 	_, err = io.Copy(crypt4GHWriter, unencryptedFile)

--- a/sda/cmd/sync/sync_test.go
+++ b/sda/cmd/sync/sync_test.go
@@ -168,7 +168,7 @@ func (suite *SyncTest) TestBuildSyncDatasetJSON() {
 	fileInfo := database.FileInfo{Checksum: fmt.Sprintf("%x", sha256.New().Sum(nil)), Size: 1234, Path: "dummy.user/test/file1.c4gh", DecryptedChecksum: checksum, DecryptedSize: 999}
 	corrID := uuid.New().String()
 
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 	err = db.SetVerified(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "failed to mark file as Verified")

--- a/sda/cmd/sync/sync_test.go
+++ b/sda/cmd/sync/sync_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
 	"github.com/ory/dockertest/v3"
@@ -166,11 +165,10 @@ func (suite *SyncTest) TestBuildSyncDatasetJSON() {
 
 	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
 	fileInfo := database.FileInfo{ArchiveChecksum: fmt.Sprintf("%x", sha256.New().Sum(nil)), Size: 1234, Path: "dummy.user/test/file1.c4gh", DecryptedChecksum: checksum, DecryptedSize: 999}
-	corrID := uuid.New().String()
 
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Verified")
 
 	accessions := []string{"ed6af454-d910-49e3-8cda-488a6f246e67"}

--- a/sda/cmd/sync/sync_test.go
+++ b/sda/cmd/sync/sync_test.go
@@ -165,7 +165,7 @@ func (suite *SyncTest) TestBuildSyncDatasetJSON() {
 	assert.NoError(suite.T(), err)
 
 	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
-	fileInfo := database.FileInfo{Checksum: fmt.Sprintf("%x", sha256.New().Sum(nil)), Size: 1234, Path: "dummy.user/test/file1.c4gh", DecryptedChecksum: checksum, DecryptedSize: 999}
+	fileInfo := database.FileInfo{ArchiveChecksum: fmt.Sprintf("%x", sha256.New().Sum(nil)), Size: 1234, Path: "dummy.user/test/file1.c4gh", DecryptedChecksum: checksum, DecryptedSize: 999}
 	corrID := uuid.New().String()
 
 	err = db.SetArchived(fileInfo, fileID)

--- a/sda/cmd/verify/verify.go
+++ b/sda/cmd/verify/verify.go
@@ -257,7 +257,7 @@ func main() {
 
 			// At this point we should do checksum comparison
 
-			file.Checksum = fmt.Sprintf("%x", archiveFileHash.Sum(nil))
+			file.ArchiveChecksum = fmt.Sprintf("%x", archiveFileHash.Sum(nil))
 			file.DecryptedChecksum = fmt.Sprintf("%x", sha256hash.Sum(nil))
 
 			switch {
@@ -289,8 +289,8 @@ func main() {
 					continue
 				}
 
-				if file.Checksum != message.EncryptedChecksums[0].Value {
-					log.Errorf("encrypted checksum don't match for file: %s, expected %s, got %s", message.FilePath, message.EncryptedChecksums[0].Value, file.Checksum)
+				if file.ArchiveChecksum != message.EncryptedChecksums[0].Value {
+					log.Errorf("encrypted checksum don't match for file: %s, expected %s, got %s", message.FilePath, message.EncryptedChecksums[0].Value, file.ArchiveChecksum)
 					if err := db.UpdateFileEventLog(message.FileID, "error", delivered.CorrelationId, "verify", `{"error":"encrypted checksum don't match"}`, string(delivered.Body)); err != nil {
 						log.Errorf("set status ready failed, reason: (%v)", err)
 						if err := delivered.Nack(false, true); err != nil {

--- a/sda/internal/database/database.go
+++ b/sda/internal/database/database.go
@@ -32,11 +32,12 @@ type SDAdb struct {
 
 // FileInfo is used by ingest for file metadata (path, size, checksum)
 type FileInfo struct {
-	Checksum          string
+	ArchiveChecksum   string
 	Size              int64
 	Path              string
 	DecryptedChecksum string
 	DecryptedSize     int64
+	UploadedChecksum  string
 }
 
 type SyncData struct {

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -572,9 +572,12 @@ func (dbs *SDAdb) getFileInfo(id string) (FileInfo, error) {
 		return FileInfo{}, err
 	}
 
-	if err := db.QueryRow(checkSum, id).Scan(&info.Checksum, &info.DecryptedChecksum); err != nil {
+	var checksum, decryptedChecksum sql.NullString
+	if err := db.QueryRow(checkSum, id).Scan(&checksum, &decryptedChecksum); err != nil {
 		return FileInfo{}, err
 	}
+	info.Checksum = checksum.String
+	info.DecryptedChecksum = decryptedChecksum.String
 
 	return info, nil
 }

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -157,9 +157,11 @@ func (suite *DatabaseTests) TestSetVerified() {
 	fileID, err := db.RegisterFile("/testuser/TestSetVerified.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
-	corrID := uuid.New().String()
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/testuser/TestSetVerified.c4gh", fmt.Sprintf("%x", sha256.New()), 948, fmt.Sprintf("%x", sha256.New())}
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
+	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
+
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 }
 
@@ -172,10 +174,10 @@ func (suite *DatabaseTests) TestGetArchived() {
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestGetArchived.c4gh", fmt.Sprintf("%x", sha256.New()), 987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 
 	filePath, fileSize, err := db.GetArchived(fileID)
@@ -192,10 +194,10 @@ func (suite *DatabaseTests) TestSetAccessionID() {
 	fileID, err := db.RegisterFile("/testuser/TestSetAccessionID.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestSetAccessionID.c4gh", fmt.Sprintf("%x", sha256.New()), 987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 	stableID := "TEST:000-1234-4567"
 	err = db.SetAccessionID(stableID, fileID)
@@ -210,10 +212,10 @@ func (suite *DatabaseTests) TestCheckAccessionIDExists() {
 	fileID, err := db.RegisterFile("/testuser/TestCheckAccessionIDExists.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestCheckAccessionIDExists.c4gh", fmt.Sprintf("%x", sha256.New()), 987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 	stableID := "TEST:111-1234-4567"
 	err = db.SetAccessionID(stableID, fileID)
@@ -245,10 +247,10 @@ func (suite *DatabaseTests) TestGetFileInfo() {
 	assert.NoError(suite.T(), err)
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/tmp/TestGetFileInfo.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 
 	info, err := db.GetFileInfo(fileID)
@@ -381,11 +383,11 @@ func (suite *DatabaseTests) TestGetSyncData() {
 
 	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, "/tmp/TestGetGetSyncData.c4gh", checksum, 999, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
-	err = db.SetVerified(fileInfo, fileID, corrID)
+	err = db.SetVerified(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Verified")
 
 	stableID := "TEST:000-1111-2222"
@@ -609,7 +611,7 @@ func (suite *DatabaseTests) TestListActiveUsers() {
 				suite.FailNow("failed to mark file as Archived")
 			}
 
-			err = db.SetVerified(fileInfo, fileID, corrID)
+			err = db.SetVerified(fileInfo, fileID)
 			if err != nil {
 				suite.FailNow("failed to mark file as Verified")
 			}
@@ -673,7 +675,7 @@ func (suite *DatabaseTests) TestGetDatasetStatus() {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
-		err = db.SetVerified(fileInfo, fileID, corrID)
+		err = db.SetVerified(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Verified")
 		}
@@ -858,7 +860,7 @@ func (suite *DatabaseTests) TestListDatasets() {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
-		err = db.SetVerified(fileInfo, fileID, corrID)
+		err = db.SetVerified(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Verified")
 		}
@@ -942,7 +944,7 @@ func (suite *DatabaseTests) TestListUserDatasets() {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
-		err = db.SetVerified(fileInfo, fileID, corrID)
+		err = db.SetVerified(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Verified")
 		}
@@ -1071,11 +1073,10 @@ func (suite *DatabaseTests) TestGetReVerificationData() {
 	}
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
 	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
 	}
-	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
+	if err = db.SetVerified(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to mark file as verified")
 	}
 	accession := "acession-001"
@@ -1110,11 +1111,11 @@ func (suite *DatabaseTests) TestGetReVerificationData_wrongAccessionID() {
 	}
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
 	}
-	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
+	if err = db.SetVerified(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to mark file as verified")
 	}
 	accession := "acession-001"
@@ -1149,11 +1150,11 @@ func (suite *DatabaseTests) TestGetDecryptedChecksum() {
 	}
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetDecryptedChecksum.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
-	corrID := uuid.New().String()
+
 	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
 	}
-	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
+	if err = db.SetVerified(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to mark file as verified")
 	}
 
@@ -1198,7 +1199,7 @@ func (suite *DatabaseTests) TestGetDsatasetFiles() {
 			suite.FailNow("failed to mark file as Archived")
 		}
 
-		err = db.SetVerified(fileInfo, fileID, corrID)
+		err = db.SetVerified(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Verified")
 		}

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -105,16 +105,15 @@ func (suite *DatabaseTests) TestSetArchived() {
 	fileID, err := db.RegisterFile("/testuser/TestSetArchived.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestSetArchived.c4gh", fmt.Sprintf("%x", sha256.New()), -1}
-	corrID := uuid.New().String()
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestSetArchived.c4gh", fmt.Sprintf("%x", sha256.New()), -1, fmt.Sprintf("%x", sha256.New())}
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
-	err = db.SetArchived(fileInfo, "00000000-0000-0000-0000-000000000000", corrID)
+	err = db.SetArchived(fileInfo, "00000000-0000-0000-0000-000000000000")
 	assert.ErrorContains(suite.T(), err, "violates foreign key constraint")
 
-	err = db.SetArchived(fileInfo, fileID, "00000000-0000-0000-0000-000000000000")
-	assert.ErrorContains(suite.T(), err, "duplicate key value violates unique constraint")
+	err = db.SetArchived(fileInfo, fileID)
+	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 }
 
 func (suite *DatabaseTests) TestGetFileStatus() {
@@ -159,7 +158,7 @@ func (suite *DatabaseTests) TestSetVerified() {
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
 	corrID := uuid.New().String()
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/testuser/TestSetVerified.c4gh", fmt.Sprintf("%x", sha256.New()), 948}
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/testuser/TestSetVerified.c4gh", fmt.Sprintf("%x", sha256.New()), 948, fmt.Sprintf("%x", sha256.New())}
 	err = db.SetVerified(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
 }
@@ -174,7 +173,7 @@ func (suite *DatabaseTests) TestGetArchived() {
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestGetArchived.c4gh", fmt.Sprintf("%x", sha256.New()), 987}
 	corrID := uuid.New().String()
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
 	err = db.SetVerified(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
@@ -194,7 +193,7 @@ func (suite *DatabaseTests) TestSetAccessionID() {
 	assert.NoError(suite.T(), err, "failed to register file in database")
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestSetAccessionID.c4gh", fmt.Sprintf("%x", sha256.New()), 987}
 	corrID := uuid.New().String()
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
 	err = db.SetVerified(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
@@ -212,7 +211,7 @@ func (suite *DatabaseTests) TestCheckAccessionIDExists() {
 	assert.NoError(suite.T(), err, "failed to register file in database")
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestCheckAccessionIDExists.c4gh", fmt.Sprintf("%x", sha256.New()), 987}
 	corrID := uuid.New().String()
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
 	err = db.SetVerified(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
@@ -247,7 +246,7 @@ func (suite *DatabaseTests) TestGetFileInfo() {
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/tmp/TestGetFileInfo.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
 	corrID := uuid.New().String()
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
 	err = db.SetVerified(fileInfo, fileID, corrID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as verified", err)
@@ -383,7 +382,7 @@ func (suite *DatabaseTests) TestGetSyncData() {
 	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
 	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, "/tmp/TestGetGetSyncData.c4gh", checksum, 999}
 	corrID := uuid.New().String()
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
 	err = db.SetVerified(fileInfo, fileID, corrID)
@@ -442,8 +441,8 @@ func (suite *DatabaseTests) TestGetArchivePath() {
 
 	checksum := fmt.Sprintf("%x", sha256.New())
 	corrID := uuid.New().String()
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1234, corrID, checksum, 999}
-	err = db.SetArchived(fileInfo, fileID, corrID)
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1234, corrID, checksum, 999, fmt.Sprintf("%x", sha256.New())}
+	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
 
 	err = db.SetAccessionID("acession-0001", fileID)
@@ -517,8 +516,8 @@ func (suite *DatabaseTests) TestGetCorrID_sameFilePath() {
 	}
 
 	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, fileID, checksum, 999}
-	if err := db.SetArchived(fileInfo, fileID, fileID); err != nil {
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, fileID, checksum, 999, fmt.Sprintf("%x", sha256.New())}
+	if err := db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to mark file as archived")
 	}
 	if err := db.UpdateFileEventLog(fileID, "archived", fileID, user, "{}", "{}"); err != nil {
@@ -604,8 +603,8 @@ func (suite *DatabaseTests) TestListActiveUsers() {
 			assert.Equal(suite.T(), fileID, corrID)
 
 			checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
-			fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, filePath, checksum, 999}
-			err = db.SetArchived(fileInfo, fileID, corrID)
+			fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, filePath, checksum, 999, fmt.Sprintf("%x", sha256.New())}
+			err = db.SetArchived(fileInfo, fileID)
 			if err != nil {
 				suite.FailNow("failed to mark file as Archived")
 			}
@@ -668,7 +667,7 @@ func (suite *DatabaseTests) TestGetDatasetStatus() {
 			checksum,
 			999,
 		}
-		err = db.SetArchived(fileInfo, fileID, corrID)
+		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Archived")
 		}
@@ -852,7 +851,7 @@ func (suite *DatabaseTests) TestListDatasets() {
 			checksum,
 			999,
 		}
-		err = db.SetArchived(fileInfo, fileID, corrID)
+		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Archived")
 		}
@@ -935,7 +934,7 @@ func (suite *DatabaseTests) TestListUserDatasets() {
 			checksum,
 			999,
 		}
-		err = db.SetArchived(fileInfo, fileID, corrID)
+		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Archived")
 		}
@@ -1070,7 +1069,7 @@ func (suite *DatabaseTests) TestGetReVerificationData() {
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
 	corrID := uuid.New().String()
-	if err = db.SetArchived(fileInfo, fileID, corrID); err != nil {
+	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
 	}
 	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
@@ -1109,7 +1108,7 @@ func (suite *DatabaseTests) TestGetReVerificationData_wrongAccessionID() {
 
 	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
 	corrID := uuid.New().String()
-	if err = db.SetArchived(fileInfo, fileID, corrID); err != nil {
+	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
 	}
 	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
@@ -1146,9 +1145,9 @@ func (suite *DatabaseTests) TestGetDecryptedChecksum() {
 		suite.FailNow("failed to generate checksum")
 	}
 
-	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetDecryptedChecksum.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetDecryptedChecksum.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
-	if err = db.SetArchived(fileInfo, fileID, corrID); err != nil {
+	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
 	}
 	if err = db.SetVerified(fileInfo, fileID, corrID); err != nil {
@@ -1190,7 +1189,7 @@ func (suite *DatabaseTests) TestGetDsatasetFiles() {
 			checksum,
 			999,
 		}
-		err = db.SetArchived(fileInfo, fileID, corrID)
+		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
 			suite.FailNow("failed to mark file as Archived")
 		}

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -171,7 +171,7 @@ func (suite *DatabaseTests) TestGetArchived() {
 	fileID, err := db.RegisterFile("/testuser/TestGetArchived.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestGetArchived.c4gh", fmt.Sprintf("%x", sha256.New()), 987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestGetArchived.c4gh", fmt.Sprintf("%x", sha256.New()), 987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
@@ -191,7 +191,7 @@ func (suite *DatabaseTests) TestSetAccessionID() {
 	// register a file in the database
 	fileID, err := db.RegisterFile("/testuser/TestSetAccessionID.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestSetAccessionID.c4gh", fmt.Sprintf("%x", sha256.New()), 987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestSetAccessionID.c4gh", fmt.Sprintf("%x", sha256.New()), 987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
@@ -209,7 +209,7 @@ func (suite *DatabaseTests) TestCheckAccessionIDExists() {
 	// register a file in the database
 	fileID, err := db.RegisterFile("/testuser/TestCheckAccessionIDExists.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestCheckAccessionIDExists.c4gh", fmt.Sprintf("%x", sha256.New()), 987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, "/tmp/TestCheckAccessionIDExists.c4gh", fmt.Sprintf("%x", sha256.New()), 987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
@@ -244,7 +244,7 @@ func (suite *DatabaseTests) TestGetFileInfo() {
 	_, err = decSha.Write([]byte("DecryptedChecksum"))
 	assert.NoError(suite.T(), err)
 
-	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/tmp/TestGetFileInfo.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/tmp/TestGetFileInfo.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "got (%v) when marking file as Archived")
@@ -255,7 +255,7 @@ func (suite *DatabaseTests) TestGetFileInfo() {
 	assert.NoError(suite.T(), err, "got (%v) when getting file archive information", err)
 	assert.Equal(suite.T(), int64(2000), info.Size)
 	assert.Equal(suite.T(), "/tmp/TestGetFileInfo.c4gh", info.Path)
-	assert.Equal(suite.T(), "11c94bc7fb13afeb2b3fb16c1dbe9206dc09560f1b31420f2d46210ca4ded0a8", info.Checksum)
+	assert.Equal(suite.T(), "11c94bc7fb13afeb2b3fb16c1dbe9206dc09560f1b31420f2d46210ca4ded0a8", info.ArchiveChecksum)
 	assert.Equal(suite.T(), "a671218c2418aa51adf97e33c5c91a720289ba3c9fd0d36f6f4bf9610730749f", info.DecryptedChecksum)
 }
 
@@ -380,7 +380,7 @@ func (suite *DatabaseTests) TestGetSyncData() {
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
 	checksum := fmt.Sprintf("%x", sha256.New().Sum(nil))
-	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, "/tmp/TestGetGetSyncData.c4gh", checksum, 999}
+	fileInfo := FileInfo{fmt.Sprintf("%x", sha256.New().Sum(nil)), 1234, "/tmp/TestGetGetSyncData.c4gh", checksum, 999, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	err = db.SetArchived(fileInfo, fileID)
 	assert.NoError(suite.T(), err, "failed to mark file as Archived")
@@ -666,6 +666,7 @@ func (suite *DatabaseTests) TestGetDatasetStatus() {
 			filePath,
 			checksum,
 			999,
+			fmt.Sprintf("%x", sha256.New()),
 		}
 		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
@@ -850,6 +851,7 @@ func (suite *DatabaseTests) TestListDatasets() {
 			filePath,
 			checksum,
 			999,
+			fmt.Sprintf("%x", sha256.New()),
 		}
 		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
@@ -933,6 +935,7 @@ func (suite *DatabaseTests) TestListUserDatasets() {
 			filePath,
 			checksum,
 			999,
+			fmt.Sprintf("%x", sha256.New()),
 		}
 		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {
@@ -1067,7 +1070,7 @@ func (suite *DatabaseTests) TestGetReVerificationData() {
 		suite.FailNow("failed to generate checksum")
 	}
 
-	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
@@ -1106,7 +1109,7 @@ func (suite *DatabaseTests) TestGetReVerificationData_wrongAccessionID() {
 		suite.FailNow("failed to generate checksum")
 	}
 
-	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987}
+	fileInfo := FileInfo{fmt.Sprintf("%x", encSha.Sum(nil)), 2000, "/archive/TestGetReVerificationData.c4gh", fmt.Sprintf("%x", decSha.Sum(nil)), 1987, fmt.Sprintf("%x", sha256.New())}
 	corrID := uuid.New().String()
 	if err = db.SetArchived(fileInfo, fileID); err != nil {
 		suite.FailNow("failed to archive file")
@@ -1188,6 +1191,7 @@ func (suite *DatabaseTests) TestGetDsatasetFiles() {
 			filePath,
 			checksum,
 			999,
+			fmt.Sprintf("%x", sha256.New()),
 		}
 		err = db.SetArchived(fileInfo, fileID)
 		if err != nil {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1561 


This PR also closes #1519 and #1037.

## Description
The code for the main pipeline components are all cluttered i n the main function. That makes it all but impossible to run any tests other than full integration tests using the final container.

This PR breaks apart the main work loop in `ingest` into parts that can be tested and adds test for the following conditions:
* TestCancelFile
* TestCancelFile_wrongCorrelationID
* TestIngestFile
* TestIngestFile_missingFile
* TestIngestFile_reingestCancelledFile
* TestIngestFile_reingestCancelledFileNewChecksum
* TestIngestFile_reingestVerifiedCancelledFile
* TestIngestFile_reingestVerifiedCancelledFileNewChecksum
* TestIngestFile_reingestVerifiedFile
* TestIngestFile_secondTime
* TestIngestFile_unknownInboxType


## How to test
While in the `sda` folder run `go test -v cmd/ingest/*.go` to only test the ingest part. In order to test all of the GO code just run `go test`.