### PR TITLE
[s3inbox] Send remove message on overwrite

### DIFF
--- a/.github/integration/tests/sda/10_upload_test.sh
+++ b/.github/integration/tests/sda/10_upload_test.sh
@@ -33,13 +33,9 @@ done
 ## reupload a file under a different name
 s3cmd -c s3cfg put NA12878.bam.c4gh s3://test_dummy.org/NB12878.bam.c4gh
 
-## reupload a file with the same name
-s3cmd -c s3cfg put NA12878.bam.c4gh s3://test_dummy.org/
-
-
 echo "waiting for upload to complete"
 RETRY_TIMES=0
-until [ "$(curl -s -k -u guest:guest $URI/api/queues/sda/inbox | jq -r '."messages_ready"')" -eq 6 ]; do
+until [ "$(curl -s -k -u guest:guest $URI/api/queues/sda/inbox | jq -r '."messages_ready"')" -eq 5 ]; do
     echo "waiting for upload to complete"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
@@ -48,6 +44,23 @@ until [ "$(curl -s -k -u guest:guest $URI/api/queues/sda/inbox | jq -r '."messag
     fi
     sleep 2
 done
+
+## reupload a file with the same name
+s3cmd -c s3cfg put NA12878.bam.c4gh s3://test_dummy.org/
+
+## expect 2 new messages, one for deletion of the overwritten file, one for the new upload
+echo "waiting for re-upload to complete"
+RETRY_TIMES=0
+until [ "$(curl -s -k -u guest:guest $URI/api/queues/sda/inbox | jq -r '."messages_ready"')" -eq 7 ]; do
+    echo "waiting for re-upload to complete"
+    RETRY_TIMES=$((RETRY_TIMES + 1))
+    if [ "$RETRY_TIMES" -eq 30 ]; then
+        echo "::error::Time out while waiting for re-upload to complete"
+        exit 1
+    fi
+    sleep 2
+done
+
 
 num_rows=$(psql -U postgres -h postgres -d sda -At -c "SELECT COUNT(*) from sda.files;")
 if [ "$num_rows" -ne 5 ]; then

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -9,13 +9,21 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
 	"github.com/neicnordic/sensitive-data-archive/internal/helper"
+	"github.com/neicnordic/sensitive-data-archive/internal/storage"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
 type HealthcheckTestSuite struct {
-	ProxyTests
+	suite.Suite
+	S3Fakeconf storage.S3Conf // fakeserver
+	S3conf     storage.S3Conf // actual s3 container
+	DBConf     database.DBConf
+	fakeServer *FakeServer
+	MQConf     broker.MQConf
+	messenger  *broker.AMQPBroker
+	database   *database.SDAdb
 }
 
 func TestHealthTestSuite(t *testing.T) {
@@ -23,13 +31,49 @@ func TestHealthTestSuite(t *testing.T) {
 }
 
 func (suite *HealthcheckTestSuite) SetupTest() {
-	// Reuse the setup from Proxy
-	suite.ProxyTests.SetupTest()
+	suite.fakeServer = startFakeServer("9024")
+
+	// Create an s3config for the fake server
+	suite.S3Fakeconf = storage.S3Conf{
+		URL:       "http://127.0.0.1",
+		Port:      9024,
+		AccessKey: "someAccess",
+		SecretKey: "someSecret",
+		Bucket:    "buckbuck",
+		Region:    "us-east-1",
+	}
+
+	// Create a configuration for the fake MQ
+	suite.MQConf = broker.MQConf{
+		Host:     "127.0.0.1",
+		Port:     MQport,
+		User:     "guest",
+		Password: "guest",
+		Vhost:    "/",
+		Exchange: "",
+	}
+
+	suite.messenger = &broker.AMQPBroker{}
+
+	// Create a database configuration for the fake database
+	suite.DBConf = database.DBConf{
+		Host:       "127.0.0.1",
+		Port:       DBport,
+		User:       "postgres",
+		Password:   "rootpasswd",
+		Database:   "sda",
+		CACert:     "",
+		SslMode:    "disable",
+		ClientCert: "",
+		ClientKey:  "",
+	}
+
+	suite.database = &database.SDAdb{}
 }
 
 func (suite *HealthcheckTestSuite) TearDownTest() {
-	// Reuse the teardown from Proxy
-	suite.ProxyTests.TearDownTest()
+	suite.fakeServer.Close()
+	suite.database.Close()
 }
 
 func (suite *HealthcheckTestSuite) TestHttpsGetCheck() {

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -33,7 +33,7 @@ func (suite *HealthcheckTestSuite) TearDownTest() {
 }
 
 func (suite *HealthcheckTestSuite) TestHttpsGetCheck() {
-	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
+	p := NewProxy(suite.S3Fakeconf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
 
 	url, _ := p.getS3ReadyPath()
 	assert.NoError(suite.T(), p.httpsGetCheck(url))
@@ -41,7 +41,7 @@ func (suite *HealthcheckTestSuite) TestHttpsGetCheck() {
 }
 
 func (suite *HealthcheckTestSuite) TestS3URL() {
-	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
+	p := NewProxy(suite.S3Fakeconf, &helper.AlwaysAllow{}, suite.messenger, suite.database, new(tls.Config))
 
 	_, err := p.getS3ReadyPath()
 	assert.NoError(suite.T(), err)
@@ -57,7 +57,7 @@ func (suite *HealthcheckTestSuite) TestHealthchecks() {
 	database, _ := database.NewSDAdb(suite.DBConf)
 	messenger, err := broker.NewMQ(suite.MQConf)
 	assert.NoError(suite.T(), err)
-	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
+	p := NewProxy(suite.S3Fakeconf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
 	w := httptest.NewRecorder()
 	p.CheckHealth(w, httptest.NewRequest(http.MethodGet, "https://dummy/health", nil))
@@ -72,7 +72,7 @@ func (suite *HealthcheckTestSuite) TestClosedDBHealthchecks() {
 	database, _ := database.NewSDAdb(suite.DBConf)
 	messenger, err := broker.NewMQ(suite.MQConf)
 	assert.NoError(suite.T(), err)
-	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
+	p := NewProxy(suite.S3Fakeconf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
 	// Check that 200 is reported
 	w := httptest.NewRecorder()
@@ -95,7 +95,7 @@ func (suite *HealthcheckTestSuite) TestNoS3Healthchecks() {
 	database, _ := database.NewSDAdb(suite.DBConf)
 	messenger, err := broker.NewMQ(suite.MQConf)
 	assert.NoError(suite.T(), err)
-	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
+	p := NewProxy(suite.S3Fakeconf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
 	// S3 unavailable, check that 503 is reported
 	w := httptest.NewRecorder()
@@ -111,7 +111,7 @@ func (suite *HealthcheckTestSuite) TestNoMQHealthchecks() {
 	database, _ := database.NewSDAdb(suite.DBConf)
 	messenger, err := broker.NewMQ(suite.MQConf)
 	assert.NoError(suite.T(), err)
-	p := NewProxy(suite.S3conf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
+	p := NewProxy(suite.S3Fakeconf, &helper.AlwaysAllow{}, messenger, database, new(tls.Config))
 
 	// Messenger unavailable, check that 503 is reported
 	p.messenger.Conf.Port = 123456

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -552,7 +552,6 @@ func (p *Proxy) checkFileExists(fullPath string) (bool, error) {
 func (p *Proxy) sendMessageOnOverwrite(r *http.Request, rawFilepath string, token jwt.Token) error {
 	exist, err := p.checkFileExists(r.URL.Path)
 	if err != nil {
-
 		return err
 	}
 	if exist {
@@ -568,13 +567,11 @@ func (p *Proxy) sendMessageOnOverwrite(r *http.Request, rawFilepath string, toke
 
 		jsonMessage, err := json.Marshal(msg)
 		if err != nil {
-
 			return err
 		}
 
 		err = p.checkAndSendMessage(jsonMessage, r)
 		if err != nil {
-
 			return err
 		}
 	}

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -550,15 +550,12 @@ func (p *Proxy) checkFileExists(fullPath string) (bool, error) {
 }
 
 func (p *Proxy) sendMessageOnOverwrite(r *http.Request, rawFilepath string, token jwt.Token) error {
-
 	exist, err := p.checkFileExists(r.URL.Path)
 	if err != nil {
 
 		return err
 	}
 	if exist {
-		log.Error("create rewrite message")
-
 		username := token.Subject()
 		msg := schema.InboxRemove{
 			User:      username,
@@ -580,7 +577,6 @@ func (p *Proxy) sendMessageOnOverwrite(r *http.Request, rawFilepath string, toke
 
 			return err
 		}
-
 	}
 
 	return nil

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -508,9 +507,7 @@ func (suite *ProxyTests) TestDatabaseConnection() {
 	// PUT a file into the system
 	filename := "/dummy/db-test-file"
 
-	myString := "Hello, world!"
-	stringReader := strings.NewReader(myString)
-
+	stringReader := strings.NewReader("a brand new string")
 	r, _ := http.NewRequest("PUT", filename, stringReader)
 	w := httptest.NewRecorder()
 	suite.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/db-test-file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1480 .

## Description
When uploading a file to s3inbox, a check is done to see if the file is already there. If it is, a delete message is sent before the upload message, so that the FEGA portal will know that the new version of the file exists.

~**Note**: The `remove` message is formatted according to [this spec](https://neic-sda.readthedocs.io/en/latest/connection/#message-format). However, our messages will have two extra fields, `"encrypted_checksums":null` and `"filesize":0`, since it shares the go struct with upload messages. Hopefully, that won't be any problem. Please let me know if you think it will.~


## How to test
Run the integration tests, and check that after the tests in `.github/integration/tests/sda/10_upload_test.sh` are run, there are 6 messages for `upload` and one for `remove` in  rabbitmq messages in the `inbox` queue.

You can also manually upload a file twice, and check the queue and the logs to make sure the `remove` message is only sent the second time:
```s3cmd -c /tmp/shared/s3cfg put dummyfile.c4gh s3://test_dummy.org/```

