### PR TITLE
[s3inbox] store uploaded file size in db

### DIFF
--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -646,6 +646,11 @@ func (p *Proxy) storeObjectSizeInDB(path, fileID string) error {
 		return err
 	}
 
+	if err := p.database.DB.Ping(); err != nil {
+		p.database.Close()
+		_ = p.database.Connect()
+	}
+
 	const setObjectSize = "UPDATE sda.files set submission_file_size = $1 where id = $2;"
 	_, err = p.database.DB.Exec(setObjectSize, *o.ContentLength, fileID)
 

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -227,6 +227,13 @@ func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request, token jw
 			log.Debugf("resuming work on file with fileId: %v", p.fileIds[r.URL.Path])
 		}
 
+		if err := p.storeObjectSizeInDB(rawFilepath, p.fileIds[r.URL.Path]); err != nil {
+			log.Errorf("storeObjectSizeInDB failed because: %s", err.Error())
+			p.internalServerError(w, r, "storeObjectSizeInDB failed")
+
+			return
+		}
+
 		log.Debugf("marking file %v as 'uploaded' in database", p.fileIds[r.URL.Path])
 		err = p.database.UpdateFileEventLog(p.fileIds[r.URL.Path], "uploaded", p.fileIds[r.URL.Path], "inbox", "{}", string(jsonMessage))
 		if err != nil {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1482 .

~~This will be kept as a draft until #1543 is merged~~
## Description
This PA adds a function that stores the size of the uploaded file in the database (`submission_file_size`) upon completed upload. The size of the file is read from the S3 backend.

3 test cases could be generated, 1 positive and 2 negative. The 4th test case (fastCheck) didn't go as planned but will be kept in order to catch any regression.

## How to test
