### PR TITLE
update compose volume mounts for sda-doa src and pom.xml

### DIFF
--- a/.github/integration/sda-doa-posix-outbox.yml
+++ b/.github/integration/sda-doa-posix-outbox.yml
@@ -128,7 +128,8 @@ services:
     image: maven:3.9.9-eclipse-temurin-21
     profiles: [test]
     volumes:
-      - ../../sda-doa:/sda-doa
+      - ../../sda-doa/src:/sda-doa/src
+      - ../../sda-doa/pom.xml:/sda-doa/pom.xml
       - ../../sda-doa/settings.xml:/root/.m2/settings.xml
       - test_file:/sda-doa/outbox
       - ./tests:/tests

--- a/.github/integration/sda-doa-s3-outbox.yml
+++ b/.github/integration/sda-doa-s3-outbox.yml
@@ -157,7 +157,8 @@ services:
     image: maven:3.9.9-eclipse-temurin-21
     profiles: [test]
     volumes:
-      - ../../sda-doa:/sda-doa
+      - ../../sda-doa/src:/sda-doa/src
+      - ../../sda-doa/pom.xml:/sda-doa/pom.xml
       - ../../sda-doa/settings.xml:/root/.m2/settings.xml
       - ./tests:/tests
       - encryption_files:/test


### PR DESCRIPTION

## Description
mounting the entire sda-doa folder leads to files and folders created inside the container being mounted back into the sda-doa folder in the codebase. This PR fixes that.



## How to test
