### PR TITLE
[syncapi] Fix error handling when parsing dataset fails

### DIFF
--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -364,7 +364,7 @@ func (app *Ingest) ingestFile(correlationID string, message schema.IngestionTrig
 
 			return "ack"
 		default:
-			log.Errorf("unexpected eror when opening file for reading: %s", err.Error())
+			log.Errorf("unexpected error when opening file for reading: %s", err.Error())
 
 			return "nack"
 		}

--- a/sda/cmd/sync/sync_test.go
+++ b/sda/cmd/sync/sync_test.go
@@ -199,6 +199,8 @@ func (s *SyncTest) TestSendPOST() {
 		username, _, ok := r.BasicAuth()
 		if ok && username == "foo" {
 			w.WriteHeader(http.StatusUnauthorized)
+
+			return
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/sda/cmd/syncapi/syncapi.go
+++ b/sda/cmd/syncapi/syncapi.go
@@ -137,13 +137,16 @@ func dataset(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	if err := schema.ValidateJSON(fmt.Sprintf("%s/../bigpicture/file-sync.json", Conf.Broker.SchemasPath), b); err != nil {
-		respondWithError(w, http.StatusBadRequest, fmt.Sprintf("eror on JSON validation: %s", err.Error()))
+		respondWithError(w, http.StatusBadRequest, fmt.Sprintf("error on JSON validation: %s", err.Error()))
 
 		return
 	}
 
 	if err := parseDatasetMessage(b); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		log.Errorf("error on parsing dataset message: %v", err)
+		respondWithError(w, http.StatusInternalServerError, "error while processing message")
+
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Description
When posting a dataset to the sync api, the error message was not logged anywhere for us to see. In addition, the function was missing a return statement.