### PR TITLE
Download re-encrypted file from the inbox through API

### DIFF
--- a/.github/integration/scripts/make_sda_credentials.sh
+++ b/.github/integration/scripts/make_sda_credentials.sh
@@ -111,6 +111,11 @@ if [ ! -f "/shared/c4gh1.sec.pem" ]; then
     /shared/crypt4gh generate -n /shared/c4gh1 -p c4ghpass
 fi
 
+if [ ! -f "/shared/client.sec.pem" ]; then # client key for re-encryption
+    echo "creating client crypth4gh key"
+    /shared/crypt4gh generate -n /shared/client -p c4ghpass
+fi
+
 if [ ! -f "/shared/sync.sec.pem" ]; then
     echo "creating sync crypth4gh key"
     /shared/crypt4gh generate -n /shared/sync -p syncPass

--- a/.github/integration/sda/config.yaml
+++ b/.github/integration/sda/config.yaml
@@ -13,6 +13,10 @@ archive:
   bucket: "archive"
   region: "us-east-1"
 
+grpc:
+  host: "reencrypt"
+  port: 50051
+
 auth:
   cega:
     authUrl: "http://cega-nss:8443/username/"

--- a/.github/integration/sda/rbac.json
+++ b/.github/integration/sda/rbac.json
@@ -47,7 +47,7 @@
        },
        {
           "role": "submission",
-          "path": "/users/:username/file/*",
+          "path": "/users/:username/file/:fileid",
           "action": "GET"
        },
        {

--- a/.github/integration/sda/rbac.json
+++ b/.github/integration/sda/rbac.json
@@ -46,6 +46,11 @@
           "action": "GET"
        },
        {
+          "role": "submission",
+          "path": "/users/:username/file/*",
+          "action": "GET"
+       },
+       {
           "role": "*",
           "path": "/datasets",
           "action": "GET"

--- a/.github/integration/tests/sda/60_api_admin_test.sh
+++ b/.github/integration/tests/sda/60_api_admin_test.sh
@@ -66,50 +66,6 @@ if [ -z "$output" ] ; then
     echo "Uploaded file not in inbox"
     exit 1
 fi
-
-# download the file, re-encrypted with the client key
-clientPubKey="$(base64 -w0 /shared/client.pub.pem)"
-outFile="download_reenc_NA12878.bam.c4gh"
-resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
-if [ "$resp" != "200" ]; then
-    echo "Error when downloading the file, expected 200 got: $resp"
-    exit 1
-fi
-
-# decrypt the downloaded file
-export C4GH_PASSPHRASE=c4ghpass
-if [ ! -f "$outFile" ]; then
-    echo "downloaded file $outFile not found"
-    exit 1
-fi
-if [ ! -f "/shared/client.sec.pem" ]; then
-    echo "client key not found"
-    exit 1
-fi
-if ! /shared/crypt4gh decrypt -f "$outFile" -s "/shared/client.sec.pem"; then
-    echo "decrypting file $outFile failed"
-    exit 1
-fi
-
-# check the file content
-decryptedFile="${outFile%.*}"
-if [ ! -f "$decryptedFile" ]; then
-    echo "decrypted file ${decryptedFile} not found"
-    exit 1
-fi
-if ! cmp -s "$decryptedFile" "NA12878.bam" ; then
-   echo "downloaded file is different from the original one"
-   exit 1
-fi
-
-# download file as a non admin user should fail
-token_nonAdmin=$(grep 'access_token' /shared/s3cfg | sed -E 's/access_token="?([^"]+)"?/\1/')
-resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token_nonAdmin" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
-if [ "$resp" != "401" ]; then
-    echo "Error when downloading the file, expected 401 got: $resp"
-    exit 1
-fi
-
 # delete it
 resp="$(curl -s -k -L -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token" -X DELETE "http://api:8080/file/test@dummy.org/$fileid")"
 if [ "$resp" != "200" ]; then
@@ -126,13 +82,6 @@ fi
 output=$(s3cmd -c s3cfg ls s3://test_dummy.org/NC12878.bam.c4gh 2>/dev/null)
 if [ -n "$output" ] ; then
     echo "Deleted file is still in inbox"
-    exit 1
-fi
-
-# Try to download the file that has been deleted
-resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
-if [ "$resp" != "404" ]; then
-    echo "Trying to download a non existing file, expected 404 got: $resp"
     exit 1
 fi
 
@@ -206,4 +155,66 @@ resp="$(curl -s -k -L -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer
 if [ "$resp" != "404" ]; then
 	echo "Error when deleting the file, expected 404 got: $resp"
 	exit 1
+fi
+
+# Test downloading the file from the inbox
+# Reupload a file under a different name, test to download it
+s3cmd -c s3cfg put "NA12878.bam.c4gh" s3://test_dummy.org/NC12878.bam.c4gh
+fileid="$(curl -k -L -H "Authorization: Bearer $token" "http://api:8080/users/test@dummy.org/files" | jq -r '.[] | select(.inboxPath == "test_dummy.org/NC12878.bam.c4gh") | .fileID')"
+
+output=$(s3cmd -c s3cfg ls s3://test_dummy.org/NC12878.bam.c4gh 2>/dev/null)
+if [ -z "$output" ] ; then
+    echo "Uploaded file NC12878.bam.c4gh not found in inbox"
+    exit 1
+fi
+
+# download the file, re-encrypted with the client key
+clientPubKey="$(base64 -w0 /shared/client.pub.pem)"
+resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -JO)"
+if [ "$resp" != "200" ]; then
+    echo "Error when downloading the file, expected 200 got: $resp"
+    exit 1
+fi
+
+# decrypt the downloaded file
+export C4GH_PASSPHRASE=c4ghpass
+if [ ! -f "NC12878.bam.c4gh" ]; then
+    echo "downloaded file NC12878.bam.c4gh not found"
+    exit 1
+fi
+if [ ! -f "/shared/client.sec.pem" ]; then
+    echo "client key not found"
+    exit 1
+fi
+
+# copy the file to avoid overwriting the original
+if ! /shared/crypt4gh decrypt -f "NC12878.bam.c4gh" -s "/shared/client.sec.pem" ; then
+    echo "decrypting file NC12878.bam.c4gh failed"
+    exit 1
+fi
+
+# check the file content
+if [ ! -f "NC12878.bam" ]; then
+    echo "decrypted file NC12878.bam not found"
+    exit 1
+fi
+if ! cmp -s "NC12878.bam" "NA12878.bam" ; then
+   echo "downloaded file is different from the original one"
+   exit 1
+fi
+
+# download file as a non admin user should fail
+token_nonAdmin=$(grep 'access_token' /shared/s3cfg | sed -E 's/access_token="?([^"]+)"?/\1/')
+resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token_nonAdmin" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -JO)"
+if [ "$resp" != "401" ]; then
+    echo "Error when downloading the file, expected 401 got: $resp"
+    exit 1
+fi
+
+# download a non existing file should fail
+badfileid="badfileid"
+resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$badfileid" -JO)"
+if [ "$resp" != "404" ]; then
+    echo "Trying to download a non existing file, expected 404 got: $resp"
+    exit 1
 fi

--- a/.github/integration/tests/sda/60_api_admin_test.sh
+++ b/.github/integration/tests/sda/60_api_admin_test.sh
@@ -70,7 +70,7 @@ fi
 # download the file, re-encrypted with the client key
 clientPubKey="$(base64 -w0 /shared/client.pub.pem)"
 outFile="download_reenc_NA12878.bam.c4gh"
-resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "Client-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
+resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
 if [ "$resp" != "200" ]; then
     echo "Error when downloading the file, expected 200 got: $resp"
     exit 1
@@ -122,7 +122,7 @@ if [ -n "$output" ] ; then
 fi
 
 # Try to download the file that has been deleted
-resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "Client-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
+resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
 if [ "$resp" != "404" ]; then
     echo "Trying to download a non existing file, expected 404 got: $resp"
     exit 1

--- a/.github/integration/tests/sda/60_api_admin_test.sh
+++ b/.github/integration/tests/sda/60_api_admin_test.sh
@@ -102,6 +102,14 @@ if ! cmp -s "$decryptedFile" "NA12878.bam" ; then
    exit 1
 fi
 
+# download file as a non admin user should fail
+token_nonAdmin=$(grep 'access_token' /shared/s3cfg | sed -E 's/access_token="?([^"]+)"?/\1/')
+resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token_nonAdmin" -H "C4GH-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
+if [ "$resp" != "401" ]; then
+    echo "Error when downloading the file, expected 401 got: $resp"
+    exit 1
+fi
+
 # delete it
 resp="$(curl -s -k -L -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $token" -X DELETE "http://api:8080/file/test@dummy.org/$fileid")"
 if [ "$resp" != "200" ]; then

--- a/.github/integration/tests/sda/60_api_admin_test.sh
+++ b/.github/integration/tests/sda/60_api_admin_test.sh
@@ -123,8 +123,8 @@ fi
 
 # Try to download the file that has been deleted
 resp="$(curl -s -k -L -w "%{http_code}\n" -H "Authorization: Bearer $token" -H "Client-Public-Key: $clientPubKey" "http://api:8080/users/test@dummy.org/file/$fileid" -o $outFile)"
-if [ "$resp" != "500" ]; then
-    echo "Trying to download a non existing file, expected 500 got: $resp"
+if [ "$resp" != "404" ]; then
+    echo "Trying to download a non existing file, expected 404 got: $resp"
     exit 1
 fi
 

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -168,6 +168,8 @@ Parameter | Description | Default
 `global.tls.enabled` | Use TLS for all connections. |`true`
 `global.tls.issuer` | Issuer for TLS certificate creation. |`""`
 `global.tls.clusterIssuer` | ClusterIssuer for TLS certificate creation. |`""`
+`global.reencrypt.host` | gRPC host for reencryption |`""`
+`global.reencrypt.port` | port number of the gRPC host for reencryption |`"50051"`
 
 ### Credentials
 

--- a/charts/sda-svc/templates/api-secrets.yaml
+++ b/charts/sda-svc/templates/api-secrets.yaml
@@ -50,6 +50,11 @@ stringData:
       port: {{ .Values.global.db.port }}
       sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
       user: {{ required "DB user is required" (include "dbUserAPI" .) }}
+    grpc:
+      host: {{ required "A valid grpc host is required" .Values.global.reencrypt.host }}
+      {{- if .Values.global.reencrypt.port}}
+      port: {{ .Values.global.reencrypt.port }}
+      {{- end }}
     inbox:
       type: {{ required "Inbox storage type is not set" .Values.global.inbox.storageType }}
     {{- if eq "s3" .Values.global.inbox.storageType }}

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -27,7 +27,6 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
-	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/neicnordic/sensitive-data-archive/internal/jsonadapter"
 	"github.com/neicnordic/sensitive-data-archive/internal/reencrypt"
 	"github.com/neicnordic/sensitive-data-archive/internal/schema"
@@ -396,14 +395,11 @@ func reencryptHeader(oldHeader []byte, c4ghPubKey string) ([]byte, error) {
 func downloadFile(c *gin.Context) {
 	// Get the public key from the request header.
 	c4ghPubKey := c.GetHeader("Client-Public-Key")
-	if c4ghPubKey == "" {
-		c.String(http.StatusBadRequest, "client public key is not provided in the header")
 
-		return
-	}
-
-	if !helper.IsValidC4GHPubKey(c4ghPubKey) {
-		c.String(http.StatusBadRequest, "client public key is not valid")
+	pubKey, err := base64.StdEncoding.DecodeString(c4ghPubKey)
+	if err != nil || len(pubKey) == 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, "bad public key")
+		log.Errorf("bad public key, error: %v", err)
 
 		return
 	}

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -425,7 +425,7 @@ func downloadFile(c *gin.Context) {
 	// Get inbox file handle
 	file, err := inbox.NewFileReader(filePath)
 	if err != nil {
-		log.Errorf("inbox file %s not found or failed to read, %s", filePath, err)
+		log.Errorf("inbox file %s not found or failed to read, %s", filePath, err.Error())
 		c.AbortWithStatusJSON(http.StatusInternalServerError, "failed to read inbox file")
 
 		return

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	"github.com/neicnordic/sensitive-data-archive/internal/config"
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
+	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/neicnordic/sensitive-data-archive/internal/jsonadapter"
 	"github.com/neicnordic/sensitive-data-archive/internal/reencrypt"
 	"github.com/neicnordic/sensitive-data-archive/internal/schema"
@@ -436,6 +437,12 @@ func downloadFile(c *gin.Context) {
 	c4ghPubKey := c.GetHeader("Client-Public-Key")
 	if c4ghPubKey == "" {
 		c.String(http.StatusBadRequest, "client public key is not provided in the header")
+
+		return
+	}
+
+	if !helper.IsValidC4GHPubKey(c4ghPubKey) {
+		c.String(http.StatusBadRequest, "client public key is not valid")
 
 		return
 	}

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -454,12 +454,6 @@ func downloadFile(c *gin.Context) {
 	submissionUser = strings.TrimPrefix(submissionUser, "/")
 	fileID = strings.TrimPrefix(fileID, "/")
 
-	if fileID == "" {
-		c.AbortWithStatusJSON(http.StatusBadRequest, "file ID is required")
-
-		return
-	}
-
 	// Retrieve the actual file path for the user's file.
 	filePath, err := Conf.API.DB.GetInboxFilePathFromID(submissionUser, fileID)
 	if err != nil {

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -450,7 +450,7 @@ func downloadFile(c *gin.Context) {
 
 	// Set the headers for the response.
 	c.Header("Content-Type", "application/octet-stream")
-	c.Header("Content-Disposition", fmt.Sprintf("filename: %v", path.Base(filePath)))
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", path.Base(filePath)))
 
 	reader := io.MultiReader(bytes.NewReader(newHeader), file)
 	_, err = io.Copy(c.Writer, reader)

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -121,10 +121,10 @@ func setup(conf *config.Config) *http.Server {
 	r.POST("/dataset/release/*dataset", rbac(e), releaseDataset)  // Releases a dataset to be accessible
 	r.PUT("/dataset/verify/*dataset", rbac(e), reVerifyDataset)   // Re-verify all files in the dataset
 	r.GET("/datasets/list", rbac(e), listAllDatasets)             // Lists all datasets with their status
-	r.GET("/datasets/list/:username", rbac(e), listUserDatasets)  // Lists datasets with their status for a specififc user
+	r.GET("/datasets/list/:username", rbac(e), listUserDatasets)  // Lists datasets with their status for a specific user
 	r.GET("/users", rbac(e), listActiveUsers)                     // Lists all users
 	r.GET("/users/:username/files", rbac(e), listUserFiles)       // Lists all unmapped files for a user
-	r.GET("/users/:username/file/:fileid", rbac(e), downloadFile) // Download a file for a user
+	r.GET("/users/:username/file/:fileid", rbac(e), downloadFile) // Download a file from a users inbox
 
 	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 
@@ -372,7 +372,7 @@ func reencryptHeader(oldHeader []byte, c4ghPubKey string) ([]byte, error) {
 
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%d", Conf.API.Grpc.Host, Conf.API.Grpc.Port), opts...)
 	if err != nil {
-		log.Errorf("Failed to connect to the reencrypt service, reason: %s", err)
+		log.Errorf("failed to connect to the reencrypt service, reason: %s", err)
 
 		return nil, err
 	}
@@ -541,7 +541,7 @@ func createDataset(c *gin.Context) {
 	}
 
 	if len(dataset.AccessionIDs) == 0 {
-		c.AbortWithStatusJSON(http.StatusBadRequest, "at least one accessionID is reqired")
+		c.AbortWithStatusJSON(http.StatusBadRequest, "at least one accessionID is required")
 
 		return
 	}

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -46,9 +46,10 @@ type dataset struct {
 }
 
 var (
-	Conf *config.Config
-	err  error
-	auth *userauth.ValidateFromToken
+	Conf                *config.Config
+	err                 error
+	auth                *userauth.ValidateFromToken
+	reencryptHeaderFunc = reencryptHeader // for testing purposes
 )
 
 func main() {
@@ -504,7 +505,7 @@ func downloadFile(c *gin.Context) {
 	c.Header("Content-Disposition", fmt.Sprintf("filename: %v", fileID))
 	c.Header("ETag", fmt.Sprintf("decryptedChecksum: %s", decryptedChecksum))
 
-	newHeader, err := reencryptHeader(header, reEncKey)
+	newHeader, err := reencryptHeaderFunc(header, reEncKey)
 	if err != nil {
 		log.Errorf("failed to reencrypt header, reason: %v", err)
 		c.String(http.StatusInternalServerError, "failed to reencrypt header")

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -235,7 +235,7 @@ Admin endpoints are only available to a set of whitelisted users specified in th
     Example:
 
     ```bash
-    curl -H "Authorization: Bearer $token" -H "Client-Public-Key: $base64_encoded_public_key" -X GET  https://HOSTNAME/users/submitter@example.org/file/123abc
+    curl -H "Authorization: Bearer $token" -H "C4GH-Public-Key: $base64_encoded_public_key" -X GET  https://HOSTNAME/users/submitter@example.org/file/c2acecc6-f208-441c-877a-2670e4cbb040
     ```
 
 - `/c4gh-keys/add`

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -220,6 +220,24 @@ Admin endpoints are only available to a set of whitelisted users specified in th
     - `401` Token user is not in the list of admins.
     - `500` Internal error due to DB failure.
 
+- `/users/:username/file/:fileid`
+  - accepts `GET` requests.
+  - download a file from the inbox, re-encrypted with the client’s public key provided in the request header.
+  - the public key provided in the header should be `base64` encoded.
+
+  - Error codes
+    - `200` Query execute ok.
+    - `400` Client public key not provided or not valid.
+    - `401` Token user is not in the list of admins.
+    - `404` File not found
+    - `500` Internal error due to Inbox, Reencrypt, DB, MQ or streaming failures.
+
+    Example:
+
+    ```bash
+    curl -H "Authorization: Bearer $token" -H "Client-Public-Key: $base64_encoded_public_key" -X GET  https://HOSTNAME/users/submitter@example.org/file/123abc
+    ```
+
 - `/c4gh-keys/add`
   - accepts `POST` requests with the hex hash of the key and its description
   - registers the key hash in the database.

--- a/sda/cmd/api/api.md
+++ b/sda/cmd/api/api.md
@@ -222,7 +222,7 @@ Admin endpoints are only available to a set of whitelisted users specified in th
 
 - `/users/:username/file/:fileid`
   - accepts `GET` requests.
-  - download a file from the inbox, re-encrypted with the client’s public key provided in the request header.
+  - downloads a file from the inbox, re-encrypted with the client’s public key provided in the request header.
   - the public key provided in the header should be `base64` encoded.
 
   - Error codes

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -2300,7 +2300,7 @@ func (s *TestSuite) TestDownloadFile() {
 	req, err := http.NewRequest("GET", downloadURL, nil)
 	assert.NoError(s.T(), err)
 	req.Header.Set("Authorization", "Bearer "+s.Token)
-	req.Header.Set("Client-Public-Key", s.ClientKey.PubKeyBase64)
+	req.Header.Set("C4GH-Public-Key", s.ClientKey.PubKeyBase64)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -2359,34 +2359,6 @@ func (s *TestSuite) TestDownloadFile_fileNotExist() {
 	defer resp.Body.Close()
 
 	assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
-}
-
-func (s *TestSuite) TestSendStream() {
-	// Create a mock ResponseWriter
-	recorder := httptest.NewRecorder()
-
-	data := []byte("This is some test data.")
-	reader := bytes.NewReader(data)
-
-	err := sendStream(recorder, reader)
-
-	s.NoError(err, "sendStream should not return an error on success")
-	s.Equal(http.StatusOK, recorder.Code, "Response status code should be OK")
-	s.Equal(data, recorder.Body.Bytes(), "Response body should match the streamed data")
-}
-
-func (s *TestSuite) TestSendStream_copyError() {
-	// Create a mock ResponseWriter
-	recorder := httptest.NewRecorder()
-
-	// Create a mock Reader that will return an error on Read
-	errReader := &errorReader{}
-
-	err := sendStream(recorder, errReader)
-
-	s.Error(err, "sendStream should return an error if io.Copy fails")
-	s.Equal(http.StatusInternalServerError, recorder.Code, "Response status code should be Internal Server Error")
-	s.Equal("file streaming failed\n", recorder.Body.String(), "Response body should contain the error message")
 }
 
 func (s *TestSuite) TestReencryptHeader() {

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -2339,7 +2339,8 @@ func (s *TestSuite) TestDownloadFile_fileNotExist() {
 	req, err := http.NewRequest("GET", downloadURL, nil)
 	assert.NoError(s.T(), err)
 	req.Header.Set("Authorization", "Bearer "+s.Token)
-	req.Header.Set("Client-Public-Key", "base64-key-string")
+	req.Header.Set("Client-Public-Key", s.ClientKey.PubKeyBase64)
+	log.Debugf("public key: %s", s.ClientKey.PubKeyBase64)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -400,7 +400,7 @@ func (s *TestSuite) SetupSuite() {
 	{"role":"submission","path":"/file/accession","action":"POST"},
 	{"role":"submission","path":"/users","action":"GET"},
 	{"role":"submission","path":"/users/:username/files","action":"GET"},
-	{"role":"submission","path":"/users/:username/file/*","action":"GET"},
+	{"role":"submission","path":"/users/:username/file/:fileid","action":"GET"},
 	{"role":"*","path":"/files","action":"GET"}],
 	"roles":[{"role":"admin","rolebinding":"submission"},
 	{"role":"dummy","rolebinding":"admin"}]}`)
@@ -2203,7 +2203,7 @@ func (s *TestSuite) TestReVerifyDataset_wrongDatasetName() {
 	assert.Equal(s.T(), http.StatusNotFound, okResponse.StatusCode)
 }
 
-func (s *TestSuite) TestDownloadFileSuccess() {
+func (s *TestSuite) TestDownloadFile() {
 	origReencryptHeaderFunc := reencryptHeaderFunc
 	reencryptHeaderFunc = func(oldHeader []byte, reEncKey string) ([]byte, error) {
 		return oldHeader, nil
@@ -2305,7 +2305,7 @@ func (s *TestSuite) TestDownloadFileSuccess() {
 	assert.Equal(s.T(), expectedContent, actualContent)
 }
 
-func (s *TestSuite) TestDownloadFile_FileNotExist() {
+func (s *TestSuite) TestDownloadFile_fileNotExist() {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 	m, err := model.NewModelFromString(jsonadapter.Model)

--- a/sda/cmd/api/swagger_v1.yml
+++ b/sda/cmd/api/swagger_v1.yml
@@ -331,7 +331,12 @@ paths:
           required: true
       responses:
         "200":
-          description: Successful operation.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: Successful operation
         "400":
           description: User public key not provided or not valid.
         "401":

--- a/sda/cmd/api/swagger_v1.yml
+++ b/sda/cmd/api/swagger_v1.yml
@@ -315,6 +315,31 @@ paths:
           description: Authentication failure
         "500":
           description: Internal application error
+  /users/{userName}/file/{fileID}:
+    get:
+      description: Download a file from the inbox re-encrypted with the user public key.
+      parameters:
+        - in: path
+          name: userName
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: fileID
+          schema:
+            type: string
+          required: true
+      responses:
+        "200":
+          description: Successful operation.
+        "400":
+          description: User public key not provided or not valid.
+        "401":
+          description: Authentication failure.
+        "404":
+          description: File not found.
+        "500":
+          description: Internal application error.
 components:
   schemas:
     C4ghKeyAdd:

--- a/sda/config_local.yaml
+++ b/sda/config_local.yaml
@@ -3,6 +3,11 @@ log:
   level: "debug"
 api:
   rbacFile: ../.github/integration/sda/rbac.json 
+  port: 8090
+
+grpc:
+  host: "localhost"
+  port: 50051
 
 archive:
   type: s3
@@ -86,7 +91,7 @@ server:
   cert: ""
   key: ""
   jwtpubkeypath: "/tmp/shared/keys/pub/"
-  jwtpubkeyurl: "http://oidc:8080/jwk"
+  jwtpubkeyurl: "http://localhost:8800/oidc/jwk"
 
 sync:
   api:

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 type ReEncConfig struct {
 	APIConf
 	Crypt4GHKey *[32]byte
+	Timeout     int
 }
 
 type Sync struct {
@@ -493,6 +494,11 @@ func NewConfig(app string) (*Config, error) {
 			return nil, err
 		}
 		c.configSchemas()
+
+		err = c.configReEncryptServer()
+		if err != nil {
+			return nil, err
+		}
 	case "auth":
 		c.Auth.Cega.AuthURL = viper.GetString("auth.cega.authUrl")
 		c.Auth.Cega.ID = viper.GetString("auth.cega.id")
@@ -901,6 +907,7 @@ func (c *Config) configOrchestrator() {
 }
 
 func (c *Config) configReEncryptServer() (err error) {
+	viper.SetDefault("grpc.timeout", 5) // set default to 5 seconds
 	if viper.IsSet("grpc.host") {
 		c.ReEncrypt.Host = viper.GetString("grpc.host")
 	}
@@ -915,6 +922,9 @@ func (c *Config) configReEncryptServer() (err error) {
 	}
 	if viper.IsSet("grpc.serverkey") {
 		c.ReEncrypt.ServerKey = viper.GetString("grpc.serverkey")
+	}
+	if viper.IsSet("grpc.timeout") {
+		c.ReEncrypt.Timeout = viper.GetInt("grpc.timeout")
 	}
 
 	if c.ReEncrypt.ServerCert != "" && c.ReEncrypt.ServerKey != "" {

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -992,9 +992,6 @@ func (c *Config) configReEncryptServer() (err error) {
 	if viper.IsSet("grpc.serverkey") {
 		c.ReEncrypt.ServerKey = viper.GetString("grpc.serverkey")
 	}
-	if viper.IsSet("grpc.timeout") {
-		c.ReEncrypt.Timeout = viper.GetInt("grpc.timeout")
-	}
 
 	if c.ReEncrypt.ServerCert != "" && c.ReEncrypt.ServerKey != "" {
 		c.ReEncrypt.Port = 50443

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -98,6 +98,7 @@ type APIConf struct {
 	DB         *database.SDAdb
 	MQ         *broker.AMQPBroker
 	INBOX      storage.Backend
+	Grpc       Grpc
 }
 
 type SessionConfig struct {
@@ -233,6 +234,7 @@ func NewConfig(app string) (*Config, error) {
 			"db.user",
 			"db.password",
 			"db.database",
+			"grpc.host",
 		}
 		switch viper.GetString("inbox.type") {
 		case S3:
@@ -508,7 +510,7 @@ func NewConfig(app string) (*Config, error) {
 		}
 		c.configSchemas()
 
-		err = c.configReEncryptServer()
+		c.API.Grpc, err = configReEncryptClient()
 		if err != nil {
 			return nil, err
 		}

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -229,12 +229,6 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 
 	// testing default values
 	ts.SetupTest()
-	keyPath, _ := os.MkdirTemp("", "key")
-	keyFile := keyPath + "/c4gh.key"
-	_, err = helper.CreatePrivateKeyFile(keyFile, "test")
-	viper.Set("c4gh.filepath", keyPath+"/c4gh.key")
-	viper.Set("c4gh.passphrase", "test")
-	assert.NoError(ts.T(), err)
 	config, err = NewConfig("api")
 	assert.NotNil(ts.T(), config)
 	assert.NoError(ts.T(), err)
@@ -247,6 +241,7 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 	assert.Equal(ts.T(), -1*time.Second, config.API.Session.Expiration)
 	rbac, _ := os.ReadFile(viper.GetString("api.rbacFile"))
 	assert.Equal(ts.T(), rbac, config.API.RBACpolicy)
+	assert.Equal(ts.T(), "reencrypt", config.API.Grpc.Host)
 
 	viper.Reset()
 	ts.SetupTest()
@@ -255,8 +250,6 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 	viper.Set("api.session.secure", false)
 	viper.Set("api.session.domain", "test")
 	viper.Set("api.session.expiration", 60)
-	viper.Set("c4gh.filepath", keyPath+"/c4gh.key")
-	viper.Set("c4gh.passphrase", "test")
 
 	config, err = NewConfig("api")
 	assert.NotNil(ts.T(), config)
@@ -267,8 +260,6 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 	assert.Equal(ts.T(), false, config.API.Session.Secure)
 	assert.Equal(ts.T(), "test", config.API.Session.Domain)
 	assert.Equal(ts.T(), 60*time.Second, config.API.Session.Expiration)
-
-	defer os.RemoveAll(keyPath)
 }
 
 func (ts *ConfigTestSuite) TestNotifyConfiguration() {

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -59,6 +59,7 @@ func (ts *ConfigTestSuite) SetupTest() {
 	viper.Set("db.user", "test")
 	viper.Set("db.password", "test")
 	viper.Set("db.database", "test")
+	viper.Set("grpc.host", "reencrypt")
 	viper.Set("inbox.url", "testurl")
 	viper.Set("inbox.accesskey", "testaccess")
 	viper.Set("inbox.secretkey", "testsecret")
@@ -491,6 +492,23 @@ func (ts *ConfigTestSuite) TestConfigReEncryptServer() {
 	assert.Equal(ts.T(), certPath+"/tls.crt", config.ReEncrypt.ServerCert)
 }
 
+func (ts *ConfigTestSuite) TestConfigReEncryptClient() {
+	ts.SetupTest()
+	conf, err := configReEncryptClient()
+	assert.NoError(ts.T(), err)
+	assert.Equal(ts.T(), "reencrypt", conf.Host)
+	assert.Nil(ts.T(), conf.ClientCreds)
+}
+
+func (ts *ConfigTestSuite) TestConfigReEncryptClient_withTLS() {
+	viper.Set("grpc.CACert", certPath+"/ca.crt")
+	viper.Set("grpc.clientCert", certPath+"/tls.crt")
+	viper.Set("grpc.clientKey", certPath+"/tls.key")
+	conf, err := configReEncryptClient()
+	assert.NoError(ts.T(), err)
+	assert.NotNil(ts.T(), conf.ClientCreds)
+	assert.Equal(ts.T(), 50443, conf.Port)
+}
 func (ts *ConfigTestSuite) TestConfigAuth_CEGA() {
 	ts.SetupTest()
 

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -226,8 +226,14 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 	assert.Error(ts.T(), err)
 	assert.Nil(ts.T(), config)
 
-	// testing deafult values
+	// testing default values
 	ts.SetupTest()
+	keyPath, _ := os.MkdirTemp("", "key")
+	keyFile := keyPath + "/c4gh.key"
+	_, err = helper.CreatePrivateKeyFile(keyFile, "test")
+	viper.Set("c4gh.filepath", keyPath+"/c4gh.key")
+	viper.Set("c4gh.passphrase", "test")
+	assert.NoError(ts.T(), err)
 	config, err = NewConfig("api")
 	assert.NotNil(ts.T(), config)
 	assert.NoError(ts.T(), err)
@@ -248,6 +254,8 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 	viper.Set("api.session.secure", false)
 	viper.Set("api.session.domain", "test")
 	viper.Set("api.session.expiration", 60)
+	viper.Set("c4gh.filepath", keyPath+"/c4gh.key")
+	viper.Set("c4gh.passphrase", "test")
 
 	config, err = NewConfig("api")
 	assert.NotNil(ts.T(), config)
@@ -258,6 +266,8 @@ func (ts *ConfigTestSuite) TestAPIConfiguration() {
 	assert.Equal(ts.T(), false, config.API.Session.Secure)
 	assert.Equal(ts.T(), "test", config.API.Session.Domain)
 	assert.Equal(ts.T(), 60*time.Second, config.API.Session.Expiration)
+
+	defer os.RemoveAll(keyPath)
 }
 
 func (ts *ConfigTestSuite) TestNotifyConfiguration() {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1346 


## Description


## How to test
#### Integration tests and unit tests pass.

#### If you want to test manually

1. Start the docker setup of the integration test
2. Upload two files, ingest one of the file using admin-API
3. Try to download and decrypt both of them by 

```sh
pubkey=$(base64 -w0 <your-pub-key-file>)
curl -v -H "Authorization: Bearer $ACCESS_TOKEN"  -H "C4GH-Public-Key: $pubkey" -X GET ${API_HOST}/users/${user}/file/${fileid}  -o  t1.txt.c4gh

sda-cli decrypt -key <your-private-key-file> t1.txt.c4gh
```