### PR TITLE
[charts] require a pubkey for s3inbox when resigning jwt

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 0.30.14
+version: 0.30.15
 appVersion: v0.5.14
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/templates/s3-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/s3-inbox-deploy.yaml
@@ -190,14 +190,16 @@ spec:
         - name: SERVER_KEY
           value: {{ include "tlsPath" . }}/tls.key
       {{- end }}
-        {{- if.Values.global.auth.jwtPub }}
+      {{- if .Values.global.auth.jwtPub }}
         - name: SERVER_JWTPUBKEYPATH
           value: {{ include "jwtPath" . }}
-        {{- end }}
-        {{- if not .Values.global.auth.resignJwt }}
+      {{- end }}
+      {{- if .Values.global.auth.resignJwt }}
+        {{- $_ := required "The signing pub key is required for s3inbox when auth resigns tokens" .Values.global.auth.jwtPub }}
+      {{- else }}
         - name: SERVER_JWTPUBKEYURL
           value: {{ .Values.global.oidc.provider }}{{ .Values.global.oidc.jwkPath }}
-        {{- end }}
+      {{- end }}
       {{- if .Values.global.log.format }}
         - name: LOG_FORMAT
           value: {{ .Values.global.log.format | quote }}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #722 .


## How to test
Deploy charts locally using make commands. Then `helm uninstall pipeline` and `vi /tmp/values.yaml` and comment out the `jwtPub` line and redeploy the pipeline stack. You should see an explanatory error message.