### PR TITLE
[HotFix] Ensure cryp4gh keys are loaded on startup.

### DIFF
--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -75,10 +76,9 @@ func main() {
 		panic(err)
 	}
 	app.ArchiveKeyList, err = config.GetC4GHprivateKeys()
-	if err != nil {
-		log.Error(err)
+	if err != nil || len(app.ArchiveKeyList) == 0 {
 		sigc <- syscall.SIGINT
-		panic(err)
+		panic(errors.New("no C4GH private keys configured"))
 	}
 	app.Archive, err = storage.NewBackend(app.Conf.Archive)
 	if err != nil {

--- a/sda/cmd/verify/verify.go
+++ b/sda/cmd/verify/verify.go
@@ -41,8 +41,8 @@ func main() {
 		log.Fatal(err)
 	}
 	archiveKeyList, err := config.GetC4GHprivateKeys()
-	if err != nil {
-		log.Fatal(err)
+	if err != nil || len(archiveKeyList) == 0 {
+		log.Fatal("no C4GH private keys configured")
 	}
 
 	defer mq.Channel.Close()


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1597  
This PR closes #1662.

## Description
This PR fixes a bug in the code where `Ingest` and `Verify` would happily start even when no crypt4gh keys have been configured.

## How to test
Remove the `c4gh.privateKeys` block from the config file and run `make sda-s3-up`

## Extra info

Chart tests will fail since the charts are not updated to handle multiple keys yet. (WIP to be completed once this is merged.)