### PR TITLE
Change sda-svc helm chart to use config file instead of ENVs (v2.0.0)

### DIFF
--- a/charts/sda-db/Chart.yaml
+++ b/charts/sda-db/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-db
-version: 0.8.85
-appVersion: v0.5.16
+version: 2.0.0
+appVersion: v2.0.0
 kubeVersion: '>= 1.26.0'
 description: Database component for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-mq/Chart.yaml
+++ b/charts/sda-mq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-mq
-version: 0.7.86
-appVersion: v0.5.16
+version: 2.0.0
+appVersion: v2.0.0
 kubeVersion: '>= 1.26.0'
 description: RabbitMQ component for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-svc
-version: 0.30.16
-appVersion: v0.5.16
+version: 2.0.0
+appVersion: v2.0.0
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -236,8 +236,6 @@ Parameter | Description | Default
 `sync.resources.limits.cpu` | CPU limit for sync container. |`250m`
 `sync.deploy` | Set to true if the sync service should be active | `false`
 `doa.replicaCount` | desired number of replicas | `2`
-`doa.repository` | dataedge container image repository | `neicnordic/sda-doa`
-`doa.imageTag` | dataedge container image version | `"latest"`
 `doa.keystorePass` | keystore password | `changeit`
 `doa.annotations` | Specific annotation for the doa pod | `{}`
 `doa.resources.requests.memory` | Memory request for dataedge container. |`128Mi`
@@ -264,7 +262,6 @@ Parameter | Description | Default
 `ingest.resources.limits.cpu` | CPU limit for ingest container. |`2000m`
 `intercept.replicaCount` | desired number of intercept workers | `1`
 `intercept.annotations` | Specific annotation for the intercept pod | `{}`
-`intercept.deploy` | Set to false in a non federated deployment | `true`
 `intercept.resources.requests.memory` | Memory request for intercept container. |`32Mi`
 `intercept.resources.requests.cpu` | CPU request for intercept container. |`100m`
 `intercept.resources.limits.memory` | Memory limit for intercept container. |`128Mi`

--- a/charts/sda-svc/templates/_helpers.yaml
+++ b/charts/sda-svc/templates/_helpers.yaml
@@ -101,6 +101,10 @@ Create chart name and version as used by the chart label.
   {{- .Values.global.secretsPath -}}
 {{- end -}}
 
+{{- define "configPath" -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.confFilePath) (empty .Values.global.confFilePath) -}}
+{{- end -}}
+
 {{- define "c4ghPath" -}}
 {{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.c4ghPath) (empty .Values.global.c4ghPath) -}}
 {{- end -}}

--- a/charts/sda-svc/templates/_helpers.yaml
+++ b/charts/sda-svc/templates/_helpers.yaml
@@ -102,28 +102,28 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "configPath" -}}
-{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.confFilePath) (empty .Values.global.confFilePath) -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" (.Values.global.secretsPath | trimSuffix "/") (.Values.global.confFilePath | trimPrefix "/")) (empty .Values.global.confFilePath) -}}
 {{- end -}}
 
 {{- define "c4ghPath" -}}
-{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.c4ghPath) (empty .Values.global.c4ghPath) -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" (.Values.global.secretsPath | trimSuffix "/") (.Values.global.c4ghPath | trimPrefix "/")) (empty .Values.global.c4ghPath) -}}
 {{- end -}}
 
 {{- define "trustedIssPath" -}}
-{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.download.trusted.configPath) (empty .Values.global.download.trusted.configPath) -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" (.Values.global.secretsPath | trimSuffix "/") (.Values.global.download.trusted.configPath | trimPrefix "/")) (empty .Values.global.download.trusted.configPath) -}}
 {{- end -}}
 
 {{- define "tlsPath" -}}
-{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.tlsPath) (empty .Values.global.tlsPath) -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" (.Values.global.secretsPath | trimSuffix "/") (.Values.global.tlsPath | trimPrefix "/")) (empty .Values.global.tlsPath) -}}
 {{- end -}}
 
 {{- define "jwtPath" -}}
-{{- ternary .Values.global.secretsPath (printf "%s/%s" .Values.global.secretsPath .Values.global.jwtPath) (empty .Values.global.jwtPath) -}}
+{{- ternary .Values.global.secretsPath (printf "%s/%s" (.Values.global.secretsPath | trimSuffix "/") (.Values.global.jwtPath | trimPrefix "/")) (empty .Values.global.jwtPath) -}}
 {{- end -}}
 
 {{- define "confFile" -}}
   {{- if .Values.global.confFilePath -}}
-    {{- printf "%s/%s/%s" .Values.global.secretsPath .Values.global.confFilePath .Values.global.confFile }}
+    {{- printf "%s/%s/%s" (.Values.global.secretsPath | trimSuffix "/") (.Values.global.confFilePath | trimPrefix "/") .Values.global.confFile }}
   {{- else }}
     {{- printf "%s/%s" .Values.global.secretsPath .Values.global.confFile -}}
   {{ end }}

--- a/charts/sda-svc/templates/api-deploy.yaml
+++ b/charts/sda-svc/templates/api-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "sda.fullname" . }}-api
   labels:
     role: api
-    app: {{ template "sda.fullname" . }}
+    app: {{ template "sda.fullname" . }}-api
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: {{ template "sda.fullname" . }}-api
     release: {{ .Release.Name }}
@@ -71,137 +71,8 @@ spec:
 {{- end }}
         command: ["sda-api"]
         env:
-{{- if not .Values.global.vaultSecrets }}
-        - name: API_RBACFILE
-          value: {{ template "secretsPath" . }}/rbac.json
-    {{- if .Values.global.tls.enabled }}
-        - name: API_SERVERCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: API_SERVERKEY
-          value: {{ template "tlsPath" . }}/tls.key
-    {{- end }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-api
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-api
-                key: mqUser
-    {{- if .Values.global.tls.enabled }}
-        - name: BROKER_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-    {{- end }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.host | quote }}
-    {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-        {{- end }}
-        - name: DB_SSLMODE
-          value: {{ .Values.global.db.sslMode | quote }}
-    {{- else }}
-        - name: DB_SSLMODE
-          value: "disable"
-    {{- end }}
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-api
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-api
-                key: dbUser
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: INBOX_TYPE
-      {{- if eq "s3" .Values.global.inbox.storageType }}
-          value: "s3"
-        - name: INBOX_BUCKET
-          value: {{ required "S3 inbox bucket missing" .Values.global.inbox.s3Bucket }}
-      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
-        - name: INBOX_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- end }}
-        - name: INBOX_REGION
-          value: {{ default "us-east-1" .Values.global.inbox.s3Region }}
-        - name: INBOX_URL
-          value: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
-      {{- if .Values.global.inbox.s3Port }}
-        - name: INBOX_PORT
-          value: {{ .Values.global.inbox.s3Port | quote }}
-      {{- end }}
-      {{- else }}
-          value: "posix"
-        - name: INBOX_LOCATION
-          value: "{{ .Values.global.inbox.path }}/"
-      {{- end }}
-      {{- if eq "s3" .Values.global.inbox.storageType }}
-        - name: INBOX_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3inbox-keys
-              key: s3InboxAccessKey
-        - name: INBOX_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3inbox-keys
-              key: s3InboxSecretKey
-      {{- end }}
-    {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-    {{- end }}
-    {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-    {{- end }}
-        - name: SCHEMA_TYPE
-          value: {{ default "federated" .Values.global.schemaType }}
-    {{- if .Values.global.api.jwtPubKeyName }}
-        - name: SERVER_JWTPUBKEYPATH
-          value: {{ include "jwtPath" . }}
-    {{- else }}
-        - name: SERVER_JWTPUBKEYURL
-          value: {{ required "A oidc provider is required" .Values.global.oidc.provider }}{{ .Values.global.oidc.jwkPath }}
-    {{- end }}
-{{- else }}
-        - name: SERVER_CONFFILE
+        - name: CONFIGFILE
           value: {{ include "confFile" . }}
-{{- end }}
         ports:
         - name: api
           containerPort: 8080
@@ -229,13 +100,13 @@ spec:
         resources:
 {{ toYaml .Values.api.resources | trim | indent 10 }}
         volumeMounts:
-    {{- if .Values.global.api.jwtPubKeyName }}
+    {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "secretsPath" . }}
+      {{- if .Values.global.api.jwtPubKeyName }}
         - name: jwt
           mountPath: {{ include "jwtPath" . }}
-    {{- end }}
-    {{- if not .Values.global.vaultSecrets }}
-        - name: rbac
-          mountPath: {{ template "secretsPath" . }}
+      {{- end }}
     {{- end }}
     {{- if .Values.global.tls.enabled }}
         - name: tls
@@ -243,13 +114,18 @@ spec:
     {{- end }}
     {{- if eq "posix" .Values.global.inbox.storageType }}
         - name: inbox
-          mountPath: {{ .Values.global.inbox.path | quote }}
+          mountPath: "/inbox"
     {{- end }}
       volumes:
     {{- if not .Values.global.vaultSecrets }}
-        - name: rbac
+        - name: config
           projected:
             sources:
+            - secret:
+                name: {{ template "sda.fullname" . }}-api
+                items:
+                  - key: config.yaml
+                    path: config.yaml
             - secret:
                 name: {{ required "a secret containing the RBAC policy is required" .Values.global.api.rbacFileSecret }}
                 items:

--- a/charts/sda-svc/templates/api-secrets.yaml
+++ b/charts/sda-svc/templates/api-secrets.yaml
@@ -6,11 +6,79 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-api
 type: Opaque
-data:
-  dbPassword: {{ required "DB password is required" (include "dbPassAPI" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserAPI" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassAPI" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserAPI" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    api:
+      rbacFile: {{ template "secretsPath" . }}/rbac.json
+      {{- if .Values.global.tls.enabled }}
+      serverCert: {{ template "tlsPath" . }}/tls.crt
+      serverKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassAPI" .) }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserAPI" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if eq "verify-full" .Values.global.db.sslMode}}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "DB user is required" (include "dbPassAPI" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserAPI" .) }}
+    inbox:
+      type: {{ required "Inbox storage type is not set" .Values.global.inbox.storageType }}
+    {{- if eq "s3" .Values.global.inbox.storageType }}
+      accessKey: {{ required "Accesskey required for inbox" .Values.global.inbox.s3AccessKey }}
+      bucket: {{ required "S3 inbox bucket not set" .Values.global.inbox.s3Bucket }}
+      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.inbox.s3ChunkSize }}
+      {{- if .Values.global.inbox.s3Port }}
+      port: {{ .Values.global.inbox.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.inbox.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for inbox" .Values.global.inbox.s3SecretKey }}
+      url: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
+    {{- else }}
+      location: /inbox/
+    {{- end }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    schema:
+      type: {{ default "federated" .Values.global.schemaType }}
+    server:
+      {{- if .Values.global.api.jwtPubKeyName }}
+      jwtpubkeypath: {{ include "jwtPath" . }}
+      {{- else }}
+      jwtpubkeyurl: "{{ required "A oidc provider is required" .Values.global.oidc.provider  | trimSuffix "/" }}/{{ .Values.global.oidc.jwkPath | trimPrefix "/" }}"
+      {{- end }}
 ---
 {{- if not .Values.global.api.adminsFileSecret }}
 apiVersion: v1

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -72,124 +72,8 @@ spec:
 {{- end }}
         command: ["sda-auth"]
         env:
-      {{- if not .Values.global.vaultSecrets }}
-        {{- if and (ne "" .Values.global.oidc.id) (ne "" .Values.global.oidc.secret) }}
-        - name: OIDC_ID
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-auth
-              key: oidcID
-        - name: OIDC_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-auth
-              key: oidcSecret
-        {{- end }}
-        {{- if or ( eq "federated" .Values.global.schemaType) ( eq "" .Values.global.schemaType) }}
-        - name: AUTH_CEGA_ID
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-auth
-              key: cegaID
-        - name: AUTH_CEGA_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-auth
-              key: cegaSecret
-        {{- end }}
-      {{- else }}
-        - name: SERVER_CONFFILE
+        - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
-        {{- if or ( eq "federated" .Values.global.schemaType) ( eq "" .Values.global.schemaType) }}
-        - name: AUTH_CEGA_AUTHURL
-          value: {{ .Values.global.cega.host | quote }}
-        {{- end }}
-        {{- if .Values.global.auth.corsOrigins }}
-        - name: AUTH_CORS_ORIGINS
-          value: {{ .Values.global.auth.corsOrigins | quote }}
-        - name: AUTH_CORS_METHODS
-          value: {{ .Values.global.auth.corsMethods | quote }}
-        - name: AUTH_CORS_CREDENTIALS
-          value: {{ .Values.global.auth.corsCreds | quote }}
-        {{- end }}
-        - name: AUTH_INFOTEXT
-          value: {{ .Values.global.auth.infoText }}
-        - name: AUTH_INFOURL
-          value: {{ .Values.global.auth.inforURL }}
-      {{- if .Values.global.auth.resignJwt }}
-        - name: AUTH_JWT_ISSUER
-        {{- if .Values.global.tls.enabled }}
-          value: "https://{{ .Values.global.ingress.hostName.auth }}"
-        {{- else }}
-          value: "http://{{ .Values.global.ingress.hostName.auth }}"
-        {{- end }}
-        - name: AUTH_JWT_PRIVATEKEY
-          value: "{{ template "jwtPath" . }}/{{ .Values.global.auth.jwtKey }}"
-        - name: AUTH_JWT_SIGNATUREALG
-          value: {{ .Values.global.auth.jwtAlg }}
-        - name: AUTH_JWT_TOKENTTL
-          value: {{ .Values.global.auth.jwtTTL | quote }}
-      {{- end }}
-        - name: AUTH_PUBLICFILE
-          value: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.publicFile }}"
-        - name: AUTH_RESIGNJWT
-          value: {{ .Values.global.auth.resignJwt | quote }}
-        - name: AUTH_S3INBOX
-          value: {{ .Values.global.ingress.hostName.s3Inbox }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-        {{- if and (ne "" .Values.global.oidc.id) (ne "" .Values.global.oidc.secret) }}
-        - name: OIDC_REDIRECTURL
-          value: {{ template "authRedirect" .}}
-        - name: OIDC_PROVIDER
-          value: "{{ .Values.global.oidc.provider }}"
-        - name: OIDC_JWKPATH
-          value: {{ .Values.global.oidc.jwkPath | quote }}
-        {{- end }}
-        {{- if .Values.global.tls.enabled}}
-        - name: SERVER_CERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: SERVER_KEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-    {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-        {{- end }}
-        - name: DB_SSLMODE
-          value: {{ .Values.global.db.sslMode | quote }}
-    {{- else }}
-        - name: DB_SSLMODE
-          value: "disable"
-    {{- end }}
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-api
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-api
-                key: dbUser
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
         ports:
         - name: auth
           containerPort: 8080
@@ -226,11 +110,14 @@ spec:
           mountPath: {{ template "jwtPath" . }}
       {{- end }}
       {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
       {{- end }}
       volumes:
-      {{- if and (.Values.global.auth.resignJwt) (not .Values.global.vaultSecrets) }}
+      {{- if not .Values.global.vaultSecrets }}
+        {{- if and (.Values.global.auth.resignJwt) (not .Values.global.vaultSecrets) }}
         - name: jwt
           projected:
             defaultMode: 0440
@@ -240,8 +127,11 @@ spec:
                 items:
                   - key: {{ required "The name of the JWT signing key is needed" .Values.global.auth.jwtKey }}
                     path: {{ .Values.global.auth.jwtKey }}
-      {{- end }}
-      {{- if not .Values.global.vaultSecrets }}
+        {{- end }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-auth
         - name: c4gh
           secret:
             defaultMode: 0440

--- a/charts/sda-svc/templates/auth-secrets.yaml
+++ b/charts/sda-svc/templates/auth-secrets.yaml
@@ -6,17 +6,61 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-auth
 type: Opaque
-data:
-  {{- if and (ne "" .Values.global.oidc.id) (ne "" .Values.global.oidc.secret) }}
-  oidcID: {{ .Values.global.oidc.id | quote | trimall "\"" | b64enc }}
-  oidcSecret: {{ .Values.global.oidc.secret | quote | trimall "\"" | b64enc }}
-  {{- end }}
-  {{- if or ( eq "federated" .Values.global.schemaType) ( eq "" .Values.global.schemaType) }}
-  cegaID: {{ .Values.global.cega.user | quote | trimall "\"" | b64enc }}
-  cegaSecret: {{ .Values.global.cega.password | quote | trimall "\"" | b64enc }}
-  {{- end }}
-  dbPassword: {{ required "DB password is required" (include "dbPassAuth" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserAuth" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    auth:
+    {{- if eq "federated" .Values.global.schemaType }}
+      cega:
+        authURL: {{ required "C-EGA NSS host is required" .Values.global.cega.host }}
+        id: {{ required "C-EGA NSS user is required" .Values.global.cega.user }}
+        secret: {{ required "C-EGA NSS password is required" .Values.global.cega.password }}
+    {{- end }}
+    {{- if .Values.global.auth.corsOrigins }}
+      cors:
+        credentials: {{ .Values.global.auth.corsCreds }}
+        methods: {{ .Values.global.auth.corsMethods }}
+        orogins: {{ .Values.global.auth.corsOrigins }}
+    {{- end }}
+      infotext: {{ .Values.global.auth.infoText }}
+      infoURL: {{ .Values.global.auth.infoURL }}
+    {{- if .Values.global.auth.resignJwt }}
+      jwt:
+        issuer: {{ ternary "https://" "http://" .Values.global.tls.enabled}}{{ .Values.global.ingress.hostName.auth }}
+        privatekey: "{{ template "jwtPath" . }}/{{ .Values.global.auth.jwtKey }}"
+        signaturealg: {{ .Values.global.auth.jwtAlg }}
+        tokenttl: {{ .Values.global.auth.jwtTTL }}
+    {{- end }}
+      publicfile: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.publicFile }}"
+      resignjwt: {{ .Values.global.auth.resignJwt }}
+      s3Inbox: {{ .Values.global.ingress.hostName.s3Inbox }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "DB user is required" (include "dbPassAuth" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserAuth" .) }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    {{- if and (ne "" .Values.global.oidc.id) (ne "" .Values.global.oidc.secret) }}
+    oidc:
+      id: {{ .Values.global.oidc.id }}
+      jwkPath: {{ .Values.global.oidc.jwkPath }}
+      provider: {{ .Values.global.oidc.provider }}
+      redirectURL: {{ template "authRedirect" .}}
+      secret: {{ .Values.global.oidc.secret }}
+    {{- end }}
+    {{- if .Values.global.tls.enabled}}
+    server:
+      cert: {{ template "tlsPath" . }}/tls.crt
+      key: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -69,128 +69,8 @@ spec:
             type: "RuntimeDefault"
         command: ["sda-download"]
         env:
-        - name: ARCHIVE_TYPE
-      {{- if eq "s3" .Values.global.archive.storageType }}
-          value: "s3"
-        - name: ARCHIVE_URL
-          value: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
-        {{- if .Values.global.archive.s3Port }}
-        - name: ARCHIVE_PORT
-          value: {{ .Values.global.archive.s3Port | quote }}
-        {{- end }}
-        - name: ARCHIVE_BUCKET
-          value: {{ required "S3 archive bucket missing" .Values.global.archive.s3Bucket }}
-        - name: ARCHIVE_REGION
-          value: {{ default "us-east-1" .Values.global.archive.s3Region }}
-        - name: ARCHIVE_CHUNKSIZE
-          value: {{ .Values.global.archive.s3ChunkSize | quote }}
-        {{- if .Values.global.archive.s3CaFile }}
-        - name: ARCHIVE_CACERT
-          value: {{ template "tlsPath" . }}/{{ .Values.global.archive.s3CaFile }}
-        {{- end }}
-      {{- else }}
-          value: "posix"
-        - name: ARCHIVE_LOCATION
-          value: "{{ .Values.global.archive.volumePath }}"
-      {{- end }}
-        - name: OIDC_CONFIGURATION_URL
-          value: "{{ .Values.global.oidc.provider | trimSuffix "/" }}/.well-known/openid-configuration"
-      {{- if .Values.global.download.trusted.iss }}
-        - name: OIDC_TRUSTED_ISS
-          value: {{ include "trustedIssPath" . }}/{{ default "iss.json" .Values.global.download.trusted.configFile }}
-      {{- end }}
-      {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-        {{- end }}
-        - name: DB_SSLMODE
-          value: {{ .Values.global.db.sslMode | quote }}
-      {{- else }}
-        - name: DB_SSLMODE
-          value: "disable"
-      {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: GRPC_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        - name: GRPC_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: GRPC_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-      {{- end }}
-        - name: GRPC_HOST
-          value: {{ required "A valid grpc host is required" .Values.global.reencrypt.host | quote }}
-        - name: GRPC_PORT
-          value: {{ .Values.global.reencrypt.port | quote }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-      {{- if .Values.global.download.serveDecrypted.c4ghKeyFile }}
-        - name: C4GH_TRANSIENTKEYPATH
-          value: {{ template "c4ghPath" . }}/{{ .Values.global.download.serveDecrypted.c4ghKeyFile }}
-        - name: C4GH_TRANSIENTPASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ required "A secret for the transient c4gh key is required" .Values.global.download.serveDecrypted.secretName }}
-              key: passphrase
-      {{- end }}
-      {{- if .Values.global.tls.enabled }}
-        - name: APP_PORT
-          value: "8443"
-        - name: APP_SERVERCERT
-          value: "{{ template "tlsPath" . }}/tls.crt"
-        - name: APP_SERVERKEY
-          value: "{{ template "tlsPath" . }}/tls.key"
-      {{- else }}
-        - name: SESSION_SECURE
-          value: "false"
-      {{- end }}
-        - name: SESSION_DOMAIN
-          value: {{ .Values.global.ingress.hostName.download | quote }}
-        - name: SESSION_EXPIRATION
-          value: {{ .Values.global.download.sessionExpiration | quote }}
-      {{- if not .Values.global.vaultSecrets }}
-        {{- if eq "s3" .Values.global.archive.storageType }}
-        - name: ARCHIVE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveAccessKey
-        - name: ARCHIVE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveSecretKey
-        {{- end }}
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-download
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-download
-                key: dbUser
-      {{- else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
         ports:
         - name: download
           containerPort: {{ ternary 8443 8080 .Values.global.tls.enabled }}
@@ -228,22 +108,24 @@ spec:
         resources:
 {{ toYaml .Values.download.resources | trim | indent 10 }}
         volumeMounts:
-        {{- if not .Values.global.vaultSecrets }}
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
         {{- if .Values.global.download.serveDecrypted.c4ghKeyFile }}
         - name: c4gh-transient
           mountPath: {{ template "c4ghPath" . }}
         {{- end }}
         - name: iss
           mountPath: {{ template "trustedIssPath" . }}
-        {{- end }}
-        {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
+      {{- end }}
+      {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
           mountPath: {{ template "tlsPath" . }}
-        {{- end }}
-        {{- if eq "posix" .Values.global.archive.storageType }}
+      {{- end }}
+      {{- if eq "posix" .Values.global.archive.storageType }}
         - name: archive
           mountPath: {{ .Values.global.archive.volumePath | quote }}
-        {{- end }}
+      {{- end }}
       volumes:
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
@@ -258,7 +140,11 @@ spec:
         {{- end }}
       {{- end }}
       {{- if not .Values.global.vaultSecrets }}
-      {{- if .Values.global.download.serveDecrypted.c4ghKeyFile }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-download
+        {{- if .Values.global.download.serveDecrypted.c4ghKeyFile }}
         - name: c4gh-transient
           secret:
             defaultMode: 0440
@@ -266,7 +152,7 @@ spec:
             items:
             - key: {{ .Values.global.download.serveDecrypted.c4ghKeyFile }}
               path: {{ .Values.global.download.serveDecrypted.c4ghKeyFile }}
-      {{- end }}
+        {{- end }}
         - name: iss
           secret:
             defaultMode: 0440

--- a/charts/sda-svc/templates/download-secrets.yaml
+++ b/charts/sda-svc/templates/download-secrets.yaml
@@ -5,10 +5,70 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-download
 type: Opaque
-data:
-  dbPassword: {{ required "DB password is required" (include "dbPassDownload" .) | b64enc }}
-  c4ghPassphrase: {{ .Values.global.c4gh.passphrase | b64enc }}
-  dbUser: {{ required "MQ user is required" (include "dbUserDownload" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    app:
+    {{- if .Values.global.tls.enabled }}
+      port: 8443
+      serverCert: {{ template "tlsPath" . }}/tls.crt
+      serverKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+    archive:
+      type: {{ required "Archive storage type is not set" .Values.global.archive.storageType }}
+    {{- if eq "s3" .Values.global.archive.storageType }}
+      accessKey: {{ required "Accesskey required for archive" .Values.global.archive.s3AccessKey }}
+      bucket: {{ required "S3 archive bucket not set" .Values.global.archive.s3Bucket }}
+      {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.archive.s3ChunkSize }}
+      {{- if .Values.global.archive.s3Port }}
+      port: {{ .Values.global.archive.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.archive.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for archive" .Values.global.archive.s3SecretKey }}
+      url: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
+    {{- else }}
+      location: /archive/
+    {{- end }}
+    {{- if .Values.global.download.serveDecrypted.c4ghKeyFile }}
+    c4gh:
+      transientKeyPath: {{ template "c4ghPath" . }}/{{ .Values.global.download.serveDecrypted.c4ghKeyFile }}
+      transientKeyPassphrase: {{ .Values.global.download.serveDecrypted.passphrade }}
+    {{- end }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "DB pass is required" (include "dbPassDownload" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserDownload" .) }}
+    grpc:
+      host: {{ required "A valid grpc host is required" .Values.global.reencrypt.host }}
+      port: {{ ternary 50443 50051 .Values.global.tls.enabled }}
+      timeout: {{ default 30 .Values.global.reencrypt.timeout }}
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    oidc:
+      configuration:
+        url: {{ required "A oidc provider is required" .Values.global.oidc.provider  | trimSuffix "/" }}/.well-known/openid-configuration
+      trusted:
+        iss: {{ include "trustedIssPath" . }}/{{ default "iss.json" .Values.global.download.trusted.configFile }}
+    session:
+      domain: {{ .Values.global.ingress.hostName.download }}
+      expiration: {{ .Values.global.download.sessionExpiration }}
+      secure: {{ ternary true false .Values.global.tls.enabled }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/sda-svc/templates/finalize-deploy.yaml
+++ b/charts/sda-svc/templates/finalize-deploy.yaml
@@ -71,166 +71,15 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
         env:
-{{- if .Values.global.backupArchive.storageType }}
-        - name: ARCHIVE_TYPE
-  {{- if eq "s3" .Values.global.archive.storageType }}
-          value: "s3"
-        - name: ARCHIVE_URL
-          value: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
-    {{- if .Values.global.archive.s3Port }}
-        - name: ARCHIVE_PORT
-          value: {{ .Values.global.archive.s3Port | quote }}
-    {{- end }}
-        - name: ARCHIVE_BUCKET
-          value: {{ required "S3 archive bucket missing" .Values.global.archive.s3Bucket }}
-        - name: ARCHIVE_REGION
-          value: {{ default "us-east-1" .Values.global.archive.s3Region }}
-        - name: ARCHIVE_CHUNKSIZE
-          value: {{ .Values.global.archive.s3ChunkSize | quote }}
-    {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
-        - name: ARCHIVE_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-    {{- end }}
-  {{- else }}
-          value: "posix"
-        - name: ARCHIVE_LOCATION
-          value: "{{ .Values.global.archive.volumePath }}"
-  {{- end }}
-        - name: BACKUP_TYPE
-  {{- if eq "s3" .Values.global.backupArchive.storageType }}
-          value: "s3"
-        - name: BACKUP_URL
-          value: {{ required "S3 backup archive URL missing" .Values.global.backupArchive.s3Url }}
-      {{- if .Values.global.backupArchive.s3Port }}
-        - name: BACKUP_PORT
-          value: {{ .Values.global.backupArchive.s3Port | quote }}
-      {{- end }}
-        - name: BACKUP_BUCKET
-          value: {{ required "S3 backup archive bucket missing" .Values.global.backupArchive.s3Bucket }}
-        - name: BACKUP_REGION
-          value: {{ default "us-east-1" .Values.global.backupArchive.s3Region }}
-        - name: BACKUP_CHUNKSIZE
-          value: {{ .Values.global.backupArchive.s3ChunkSize | quote }}
-    {{- if and .Values.global.backupArchive.s3CaFile .Values.global.tls.enabled }}
-        - name: BACKUP_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-    {{- end }}
-  {{- else }}
-          value: "posix"
-        - name: BACKUP_LOCATION
-          value: "{{ .Values.global.backupArchive.volumePath }}"
-  {{- end }}
-{{- end }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_QUEUE
-          value: "accession"
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_ROUTINGKEY
-          value: "completed"
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.host | quote }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-        - name: BROKER_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-        {{- end }}
-      {{- end }}
-      {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-        {{- end }}
-      {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "sda" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: DB_SSLMODE
-          value: {{ template "dbSSLmode" . }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-        - name: SCHEMA_TYPE
-          value: {{ default "federated" .Values.global.schemaType }}
-    {{- if not .Values.global.vaultSecrets }}
-      {{- if eq "s3" .Values.global.archive.storageType }}
-        - name: ARCHIVE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveAccessKey
-        - name: ARCHIVE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveSecretKey
-      {{- end }}
-      {{- if eq "s3" .Values.global.backupArchive.storageType }}
-        - name: BACKUP_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3backup-keys
-              key: s3BackupAccessKey
-        - name: BACKUP_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3backup-keys
-              key: s3BackupSecretKey
-      {{- end }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-finalize
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-finalize
-                key: mqUser
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-finalize
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-finalize
-                key: dbUser
-    {{ else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-    {{- end }}
         resources:
 {{ toYaml .Values.finalize.resources | trim | indent 10 }}
         volumeMounts:
+    {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
+    {{- end }}
     {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
           mountPath: {{ template "tlsPath" . }}
@@ -244,6 +93,12 @@ spec:
           mountPath: {{ .Values.global.backupArchive.volumePath | quote }}
     {{- end }}
       volumes:
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-finalize
+      {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
         {{- if or .Values.global.tls.clusterIssuer .Values.global.tls.issuer }}

--- a/charts/sda-svc/templates/finalize-secrets.yaml
+++ b/charts/sda-svc/templates/finalize-secrets.yaml
@@ -6,10 +6,86 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-finalize
 type: Opaque
-data:
-  dbPassword: {{ required "DB password is required" (include "dbPassFinalize" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserFinalize" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassFinalize" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserFinalize" .) | b64enc }}
+stringData:
+  config.yaml: |-
+  {{- if .Values.global.backupArchive.storageType }}
+    archive:
+      type: {{ required "Archive storage type is not set" .Values.global.archive.storageType }}
+    {{- if eq "s3" .Values.global.archive.storageType }}
+      accessKey: {{ required "Accesskey required for archive" .Values.global.archive.s3AccessKey }}
+      bucket: {{ required "S3 archive bucket not set" .Values.global.archive.s3Bucket }}
+      {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.archive.s3ChunkSize }}
+      {{- if .Values.global.archive.s3Port }}
+      port: {{ .Values.global.archive.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.archive.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for archive" .Values.global.archive.s3SecretKey }}
+      url: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
+    {{- else }}
+      location: /archive/
+    {{- end }}
+    backup:
+      type: {{ .Values.global.backupArchive.storageType }}
+    {{- if eq "s3" .Values.global.backupArchive.storageType }}
+      accessKey: {{ required "Accesskey required for backup archive" .Values.global.backupArchive.s3AccessKey }}
+      bucket: {{ required "S3 backup archive bucket not set" .Values.global.backupArchive.s3Bucket }}
+      {{- if and .Values.global.backupArchive.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.backupArchive.s3ChunkSize }}
+      {{- if .Values.global.backupArchive.s3Port }}
+      port: {{ .Values.global.backupArchive.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.backupArchive.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for backup archive" .Values.global.backupArchive.s3SecretKey }}
+      url: {{ required "S3 backup archive URL missing" .Values.global.backupArchive.s3Url }}
+    {{- else }}
+      location: /backup/
+    {{- end }}
+  {{- end }}
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassFinalize" .) }}
+      queue: {{ default "accession" .Values.global.broker.finalizeQueue }}
+      routingKey: {{ default "completed" .Values.global.broker.finalizeRoutingKey }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserFinalize" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "MQ password is required" (include "dbPassFinalize" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserFinalize" .) }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    schema:
+      type: {{ default "federated" .Values.global.schemaType }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/ingest-deploy.yaml
+++ b/charts/sda-svc/templates/ingest-deploy.yaml
@@ -72,168 +72,14 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
         env:
-        - name: ARCHIVE_TYPE
-      {{- if eq "s3" .Values.global.archive.storageType }}
-          value: "s3"
-        - name: ARCHIVE_URL
-          value: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
-      {{- if .Values.global.archive.s3Port }}
-        - name: ARCHIVE_PORT
-          value: {{ .Values.global.archive.s3Port | quote }}
-      {{- end }}
-        - name: ARCHIVE_BUCKET
-          value: {{ required "S3 archive bucket missing" .Values.global.archive.s3Bucket }}
-        - name: ARCHIVE_REGION
-          value: {{ default "us-east-1" .Values.global.archive.s3Region }}
-        - name: ARCHIVE_CHUNKSIZE
-          value: {{ .Values.global.archive.s3ChunkSize | quote }}
-      {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
-        - name: ARCHIVE_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- end }}
-      {{- else }}
-          value: "posix"
-        - name: ARCHIVE_LOCATION
-          value: "{{ .Values.global.archive.volumePath }}/"
-      {{- end }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: BROKER_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-      {{- end }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_QUEUE
-          value: "ingest"
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_ROUTINGKEY
-          value: "archived"
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.host | quote }}
-        - name: C4GH_FILEPATH
-          value: {{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}
-      {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-      {{- end }}
-      {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: DB_SSLMODE
-          value: {{ template "dbSSLmode" . }}
-        - name: INBOX_TYPE
-      {{- if eq "s3" .Values.global.inbox.storageType }}
-          value: "s3"
-        - name: INBOX_BUCKET
-          value: {{ required "S3 inbox bucket missing" .Values.global.inbox.s3Bucket }}
-      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
-        - name: INBOX_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- end }}
-        - name: INBOX_REGION
-          value: {{ default "us-east-1" .Values.global.inbox.s3Region }}
-        - name: INBOX_URL
-          value: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
-      {{- if .Values.global.inbox.s3Port }}
-        - name: INBOX_PORT
-          value: {{ .Values.global.inbox.s3Port | quote }}
-      {{- end }}
-      {{- else }}
-          value: "posix"
-        - name: INBOX_LOCATION
-          value: "{{ .Values.global.inbox.path }}/"
-      {{- end }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-      {{- if not .Values.global.vaultSecrets }}
-      {{- if eq "s3" .Values.global.archive.storageType }}
-        - name: ARCHIVE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveAccessKey
-        - name: ARCHIVE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveSecretKey
-      {{- end }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-ingest
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-ingest
-                key: mqUser
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-ingest
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-ingest
-                key: dbUser
-        - name: C4GH_PASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-              key: passphrase
-      {{- if eq "s3" .Values.global.inbox.storageType }}
-        - name: INBOX_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3inbox-keys
-              key: s3InboxAccessKey
-        - name: INBOX_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3inbox-keys
-              key: s3InboxSecretKey
-      {{- end }}
-      {{- else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
         resources:
 {{ toYaml .Values.ingest.resources | trim | indent 10 }}
         volumeMounts:
       {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
       {{- end }}
@@ -251,6 +97,10 @@ spec:
       {{- end }}
       volumes:
     {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-ingest
         - name: c4gh
           secret:
             defaultMode: 0440

--- a/charts/sda-svc/templates/ingest-secrets.yaml
+++ b/charts/sda-svc/templates/ingest-secrets.yaml
@@ -6,11 +6,86 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-ingest
 type: Opaque
-data:
-  c4ghPassphrase: {{ .Values.global.c4gh.passphrase | b64enc }}
-  dbPassword: {{ required "DB password is required" (include "dbPassIngest" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserIngest" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassIngest" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserIngest" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    archive:
+      type: {{ required "Archive storage type is not set" .Values.global.archive.storageType }}
+    {{- if eq "s3" .Values.global.archive.storageType }}
+      accessKey: {{ required "Accesskey required for archive" .Values.global.archive.s3AccessKey }}
+      bucket: {{ required "S3 archive bucket not set" .Values.global.archive.s3Bucket }}
+      {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.archive.s3ChunkSize }}
+      {{- if .Values.global.archive.s3Port }}
+      port: {{ .Values.global.archive.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.archive.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for archive" .Values.global.archive.s3SecretKey }}
+      url: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
+    {{- else }}
+      location: /archive/
+    {{- end }}
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassIngest" .) }}
+      queue: {{ default "ingest" .Values.global.broker.ingestQueue }}
+      routingKey: {{ default "archived" .Values.global.broker.routingKey }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserIngest" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    c4gh:
+      privateKeys:
+      {{- range $k := .Values.global.c4gh.privateKeys }}
+        - filePath: {{ template "c4ghPath" $ }}/{{ $k.keyName }}
+          passphrase: {{ $k.passphrase }}
+      {{- end }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "DB user is required" (include "dbPassIngest" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserIngest" .) }}
+    inbox:
+      type: {{ required "Inbox storage type is not set" .Values.global.inbox.storageType }}
+    {{- if eq "s3" .Values.global.inbox.storageType }}
+      accessKey: {{ required "Accesskey required for inbox" .Values.global.inbox.s3AccessKey }}
+      bucket: {{ required "S3 inbox bucket not set" .Values.global.inbox.s3Bucket }}
+      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.inbox.s3ChunkSize }}
+      {{- if .Values.global.inbox.s3Port }}
+      port: {{ .Values.global.inbox.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.inbox.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for inbox" .Values.global.inbox.s3SecretKey }}
+      url: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
+    {{- else }}
+      location: /inbox/
+    {{- end }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/intercept-deploy.yaml
+++ b/charts/sda-svc/templates/intercept-deploy.yaml
@@ -58,74 +58,36 @@ spec:
 {{- toYaml .Values.global.extraSecurityContext | nindent 10 -}}
 {{- end }}
         env:
-      {{- if not .Values.global.vaultSecrets }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-intercept
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-intercept
-                key: mqUser
-      {{- else }}
         - name: CONFIGFILE
           value: {{ template "confFile" . }}
-      {{- end }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: BROKER_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-      {{- end }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange | quote}}
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_QUEUE
-          value: "from_cega"
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
         resources:
 {{ toYaml .Values.intercept.resources | trim | indent 10 }}
-  {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
+    {{- if not .Values.global.vaultSecrets }}
         volumeMounts:
-        - name: tls
-          mountPath: {{ template "tlsPath" . }}
-      volumes:
+        - name: config
+          mountPath: {{ template "configPath" . }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
-        {{- if or .Values.global.tls.clusterIssuer .Values.global.tls.issuer }}
+          mountPath: {{ template "tlsPath" . }}
+      {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+            - secret:
+                name: {{ template "sda.fullname" . }}-intercept
+        {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
+        - name: tls
+          {{- if or .Values.global.tls.clusterIssuer .Values.global.tls.issuer }}
           secret:
             defaultMode: 0440
             secretName: {{ template "sda.fullname" . }}-intercept-certs
-        {{- else }}
+          {{- else }}
           secret:
             defaultMode: 0440
             secretName: {{ required "An certificate issuer or a TLS secret name is required for intercept" .Values.intercept.tls.secretName }}
+          {{- end }}
         {{- end }}
-      {{- end }}
     {{- end }}
       restartPolicy: Always
 {{- end }}

--- a/charts/sda-svc/templates/intercept-secrets.yaml
+++ b/charts/sda-svc/templates/intercept-secrets.yaml
@@ -7,9 +7,34 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-intercept
 type: Opaque
-data:
-  mqPassword: {{ required "MQ password is required" (include "mqPassInterceptor" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserInterceptor" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassInterceptor" .) }}
+      queue: "from_cega"
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserInterceptor" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/mapper-deploy.yaml
+++ b/charts/sda-svc/templates/mapper-deploy.yaml
@@ -54,133 +54,30 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
         env:
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_QUEUE
-          value: "mappings"
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.host | quote }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-        - name: BROKER_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-      {{- end }}
-      {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-      {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: DB_SSLMODE
-          value: {{ template "dbSSLmode" . }}
-        - name: INBOX_TYPE
-      {{- if eq "s3" .Values.global.inbox.storageType }}
-          value: "s3"
-        - name: INBOX_BUCKET
-          value: {{ required "S3 inbox bucket missing" .Values.global.inbox.s3Bucket }}
-      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
-        - name: INBOX_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- end }}
-        - name: INBOX_REGION
-          value: {{ default "us-east-1" .Values.global.inbox.s3Region }}
-        - name: INBOX_URL
-          value: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
-      {{- if .Values.global.inbox.s3Port }}
-        - name: INBOX_PORT
-          value: {{ .Values.global.inbox.s3Port | quote }}
-      {{- end }}
-      {{- else }}
-          value: "posix"
-        - name: INBOX_LOCATION
-          value: "{{ .Values.global.inbox.path }}/"
-      {{- end }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-        - name: SCHEMA_TYPE
-          value: {{ default "federated" .Values.global.schemaType }}
-      {{- if not .Values.global.vaultSecrets }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-mapper
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-mapper
-                key: mqUser
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-mapper
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-mapper
-                key: dbUser
-      {{- if eq "s3" .Values.global.inbox.storageType }}
-        - name: INBOX_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3inbox-keys
-              key: s3InboxAccessKey
-        - name: INBOX_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3inbox-keys
-              key: s3InboxSecretKey
-      {{- end }}
-      {{- else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
         resources:
 {{ toYaml .Values.mapper.resources | trim | indent 10 }}
         volumeMounts:
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
         {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
           mountPath: {{ template "tlsPath" . }}
         {{- end }}
-        {{- if eq "posix" .Values.global.inbox.storageType }}
+      {{- end }}
+      {{- if eq "posix" .Values.global.inbox.storageType }}
         - name: inbox
           mountPath: {{ .Values.global.inbox.path | quote }}
-        {{- end }}
+      {{- end }}
       volumes:
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-mapper
+      {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
         {{- if or .Values.global.tls.clusterIssuer .Values.global.tls.issuer }}

--- a/charts/sda-svc/templates/mapper-secrets.yaml
+++ b/charts/sda-svc/templates/mapper-secrets.yaml
@@ -6,10 +6,65 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-mapper
 type: Opaque
-data:
-  dbPassword: {{ required "DB password is required" (include "dbPassMapper" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserMapper" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassMapper" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserMapper" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassMapper" .) }}
+      queue: {{ default "mappings" .Values.global.broker.finalizeQueue }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserMapper" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "MQ password is required" (include "dbPassMapper" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserMapper" .) }}
+    inbox:
+      type: {{ required "Inbox storage type is not set" .Values.global.inbox.storageType }}
+    {{- if eq "s3" .Values.global.inbox.storageType }}
+      accessKey: {{ required "Accesskey required for inbox" .Values.global.inbox.s3AccessKey }}
+      bucket: {{ required "S3 inbox bucket not set" .Values.global.inbox.s3Bucket }}
+      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.inbox.s3ChunkSize }}
+      {{- if .Values.global.inbox.s3Port }}
+      port: {{ .Values.global.inbox.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.inbox.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for inbox" .Values.global.inbox.s3SecretKey }}
+      url: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
+    {{- else }}
+      location: /inbox/
+    {{- end }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    schema:
+      type: {{ default "federated" .Values.global.schemaType }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/re-encrypt-deploy.yaml
+++ b/charts/sda-svc/templates/re-encrypt-deploy.yaml
@@ -51,26 +51,8 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
         env:
-        - name: C4GH_FILEPATH
-          value: {{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}
-      {{- if not .Values.global.vaultSecrets }}
-        - name: C4GH_PASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-              key: passphrase
-      {{- else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
-      {{- if .Values.global.tls.enabled}}
-        - name: GRPC_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        - name: GRPC_SERVERCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: GRPC_SERVERKEY
-          value: {{ template "tlsPath" . }}/tls.key
-      {{- end }}
         ports:
           - name: grpc
             containerPort: {{ ternary 50443 50051 ( .Values.global.tls.enabled ) }}
@@ -86,6 +68,8 @@ spec:
 {{ toYaml .Values.reencrypt.resources | trim | indent 10 }}
         volumeMounts:
         {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
         {{- end }}
@@ -95,6 +79,10 @@ spec:
         {{- end }}
       volumes:
       {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-reencrypt
         - name: c4gh
           secret:
             defaultMode: 0440

--- a/charts/sda-svc/templates/reencrypt-secrets.yaml
+++ b/charts/sda-svc/templates/reencrypt-secrets.yaml
@@ -1,0 +1,26 @@
+{{- if or (or (eq "all" .Values.global.deploymentType) (eq "internal" .Values.global.deploymentType) ) (not .Values.global.deploymentType)}}
+{{- if not .Values.global.vaultSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sda.fullname" . }}-reencrypt
+type: Opaque
+stringData:
+  config.yaml: |-
+    c4gh:
+    {{- with (first .Values.global.c4gh.privateKeys) }}
+      filePath: {{ template "c4ghPath" $ }}/{{ .keyName }}
+      passphrase: {{ required "a passphrase for the c4gh key is required" .passphrase }}
+    {{-  end }}
+    {{- if .Values.global.tls.enabled }}
+    grpc:
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      serverCert: {{ template "tlsPath" . }}/tls.crt
+      serverKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+{{- end }}
+{{- end }}

--- a/charts/sda-svc/templates/s3-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/s3-inbox-deploy.yaml
@@ -90,124 +90,8 @@ spec:
 {{- toYaml .Values.global.extraSecurityContext | nindent 10 -}}
 {{- end }}
         env:
-      {{- if not .Values.global.vaultSecrets }}
-        - name: INBOX_ACCESSKEY
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-s3inbox-keys
-                key: s3InboxAccessKey
-        - name: INBOX_SECRETKEY
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-s3inbox-keys
-                key: s3InboxSecretKey
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-inbox
-                key: mqPassword
-        - name: BROKER_USER
-          value: {{ include "mqUserInbox" . | quote }}
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-inbox
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-inbox
-                key: dbUser
-      {{- else }}
-        - name: SERVER_CONFFILE
+        - name: CONFIGFILE
           value: {{ include "confFile" .}}
-      {{- end }}
-        - name: INBOX_URL
-          value: {{ .Values.global.inbox.s3Url | quote }}
-      {{- if .Values.global.inbox.s3Port }}
-        - name: INBOX_PORT
-          value: {{ .Values.global.inbox.s3Port | quote }}
-      {{- end }}
-      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
-        - name: INBOX_CACERT
-          value: "{{ include "tlsPath" . }}/ca.crt"
-      {{- end }}
-      {{- if .Values.global.inbox.s3Region }}
-        - name: INBOX_REGION
-          value: {{ .Values.global.inbox.s3Region | quote }}
-      {{- end }}
-        - name: INBOX_BUCKET
-          value: {{ .Values.global.inbox.s3Bucket | quote }}
-      {{- if .Values.global.inbox.s3ReadyPath }}
-        - name: INBOX_READYPATH
-          value: {{ .Values.global.inbox.s3ReadyPath }}
-      {{- end }}
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_VHOST
-          value: {{ include "brokerVhost" . | quote }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_ROUTINGKEY
-          value: "inbox"
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-        - name: BROKER_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-        {{- end }}
-      {{- end }}
-       {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-      {{- end }}
-    {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: DB_SSLMODE
-          value: {{ template "dbSSLmode" . }}
-      {{- if .Values.global.tls.enabled }}
-        - name: SERVER_CERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: SERVER_KEY
-          value: {{ include "tlsPath" . }}/tls.key
-      {{- end }}
-      {{- if .Values.global.auth.jwtPub }}
-        - name: SERVER_JWTPUBKEYPATH
-          value: {{ include "jwtPath" . }}
-      {{- end }}
-      {{- if .Values.global.auth.resignJwt }}
-        {{- $_ := required "The signing pub key is required for s3inbox when auth resigns tokens" .Values.global.auth.jwtPub }}
-      {{- else }}
-        - name: SERVER_JWTPUBKEYURL
-          value: {{ .Values.global.oidc.provider }}{{ .Values.global.oidc.jwkPath }}
-      {{- end }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
         ports:
         - name: inbox
           containerPort: 8000
@@ -233,9 +117,13 @@ spec:
         - name: tls
           mountPath: {{ include "tlsPath" . }}
       {{- end }}
-      {{- if .Values.global.auth.jwtPub }}
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
+        {{- if or .Values.global.auth.jwtPub .Values.global.oidc.jwtPub }}
         - name: jwt
           mountPath: {{ include "jwtPath" . }}
+        {{- end }}
       {{- end }}
       volumes:
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
@@ -250,15 +138,18 @@ spec:
             secretName: {{ required "An certificate issuer or a TLS secret name is required for s3inbox" .Values.s3Ibox.tls.secretName }}
         {{- end }}
       {{- end }}
-      {{- if .Values.global.auth.jwtPub }}
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-inbox
+        {{- if or .Values.global.auth.jwtPub .Values.global.oidc.jwtPub }}
         - name: jwt
-          projected:
-            sources:
-            - secret:
-                name: {{ .Values.global.auth.jwtSecret }}
-                items:
-                  - key: {{ required "The name of the JWT signing key is needed" .Values.global.auth.jwtPub }}
-                    path: "{{ .Values.global.ingress.hostName.auth }}.pub"
+          secret:
+            defaultMode: 0440
+            secretName: {{ ternary .Values.global.auth.jwtSecret .Values.global.oidc.jwtSecret .Values.global.auth.resignJwt }}
+
+        {{- end }}
       {{- end }}
       restartPolicy: Always
 {{- end }}

--- a/charts/sda-svc/templates/s3-inbox-secrets.yaml
+++ b/charts/sda-svc/templates/s3-inbox-secrets.yaml
@@ -6,11 +6,79 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-inbox
 type: Opaque
-data:
-  dbPassword: {{ required "DB password is required" (include "dbPassInbox" .) | quote | trimall "\"" | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserInbox" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassInbox" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserInbox" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassInbox" .) }}
+      routingKey: {{ default "inbox" .Values.global.broker.inboxRoutingKey }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserInbox" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "MQ password is required" (include "dbPassInbox" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserInbox" .) }}
+    inbox:
+      type: {{ required "Inbox storage type is not set" .Values.global.inbox.storageType }}
+    {{- if eq "s3" .Values.global.inbox.storageType }}
+      accessKey: {{ required "Accesskey required for inbox" .Values.global.inbox.s3AccessKey }}
+      bucket: {{ required "S3 inbox bucket not set" .Values.global.inbox.s3Bucket }}
+      {{- if and .Values.global.inbox.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.inbox.s3ChunkSize }}
+      {{- if .Values.global.inbox.s3Port }}
+      port: {{ .Values.global.inbox.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.inbox.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for inbox" .Values.global.inbox.s3SecretKey }}
+      url: {{ required "S3 inbox URL missing" .Values.global.inbox.s3Url }}
+    {{- else }}
+      location: /inbox/
+    {{- end }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    schema:
+      type: {{ default "federated" .Values.global.schemaType }}
+    server:
+    {{- if .Values.global.tls.enabled }}
+      cert: {{ include "tlsPath" . }}/tls.crt
+      key: {{ include "tlsPath" . }}/tls.key
+    {{- end }}
+    {{- if or .Values.global.oidc.jwtPub .Values.global.auth.resignJwt }}
+      jwtpubkeypath: {{ include "jwtPath" . }}
+      {{- if .Values.global.auth.resignJwt }}
+        {{- $_ := required "The signing pub key is required for s3inbox when auth resigns tokens" .Values.global.auth.jwtPub }}
+      {{- end }}
+    {{- else }}
+      jwtpubkeyurl: {{ required "A oidc provider is required" .Values.global.oidc.provider  | trimSuffix "/" }}/{{ required "A oidc jwk path is required" .Values.global.oidc.jwkPath | trimPrefix "/" }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/s3-inbox-secrets.yaml
+++ b/charts/sda-svc/templates/s3-inbox-secrets.yaml
@@ -77,7 +77,7 @@ stringData:
         {{- $_ := required "The signing pub key is required for s3inbox when auth resigns tokens" .Values.global.auth.jwtPub }}
       {{- end }}
     {{- else }}
-      jwtpubkeyurl: {{ required "A oidc provider is required" .Values.global.oidc.provider  | trimSuffix "/" }}/{{ required "A oidc jwk path is required" .Values.global.oidc.jwkPath | trimPrefix "/" }}
+      jwtpubkeyurl: {{ required "An OIDC provider is required" .Values.global.oidc.provider  | trimSuffix "/" }}/{{ required "An OIDC JWK path is required" .Values.global.oidc.jwkPath | trimPrefix "/" }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/sync-deploy.yaml
+++ b/charts/sda-svc/templates/sync-deploy.yaml
@@ -73,184 +73,16 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
         env:
-        - name: ARCHIVE_TYPE
-  {{- if eq "s3" .Values.global.archive.storageType }}
-          value: "s3"
-        - name: ARCHIVE_URL
-          value: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
-      {{- if .Values.global.archive.s3Port }}
-        - name: ARCHIVE_PORT
-          value: {{ .Values.global.archive.s3Port | quote }}
-      {{- end }}
-        - name: ARCHIVE_BUCKET
-          value: {{ required "S3 archive bucket missing" .Values.global.archive.s3Bucket }}
-        - name: ARCHIVE_REGION
-          value: {{ default "us-east-1" .Values.global.archive.s3Region }}
-        - name: ARCHIVE_CHUNKSIZE
-          value: {{ .Values.global.archive.s3ChunkSize | quote }}
-    {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
-        - name: ARCHIVE_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-    {{- end }}
-  {{- else }}
-          value: "posix"
-        - name: ARCHIVE_LOCATION
-          value: "{{ .Values.global.archive.volumePath }}"
-  {{- end }}
-        - name: SYNC_CENTERPREFIX
-          value: {{ .Values.global.sync.centerPrefix}}
-        - name: SYNC_DESTINATION_TYPE
-  {{- if eq "s3" .Values.global.sync.destination.storageType }}
-          value: "s3"
-        - name: SYNC_DESTINATION_URL
-          value: {{ required "S3 sync archive URL missing" .Values.global.sync.destination.url }}
-      {{- if .Values.global.sync.destination.port }}
-        - name: SYNC_DESTINATION_PORT
-          value: {{ .Values.global.sync.destination.port | quote }}
-      {{- end }}
-        - name: SYNC_DESTINATION_BUCKET
-          value: {{ required "S3 sync archive bucket missing" .Values.global.sync.destination.bucket }}
-        - name: SYNC_DESTINATION_REGION
-          value: {{ default "us-east-1" .Values.global.sync.destination.region }}
-        - name: SYNC_DESTINATION_CHUNKSIZE
-          value: {{ .Values.global.sync.destination.s3ChunkSize | quote }}
-    {{- if and .Values.global.sync.destination.s3CaFile .Values.global.tls.enabled }}
-        - name: SYNC_DESTINATION_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-    {{- end }}
-  {{- end }}
-        - name: C4GH_FILEPATH
-          value: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}"
-        - name: C4GH_SYNCPUBKEYPATH
-          value: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.syncPubKey }}"
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_QUEUE
-          value: {{ default "sync" .Values.global.sync.brokerQueue }}
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.host | quote }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-    {{- if .Values.global.tls.enabled }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-        - name: BROKER_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-    {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-    {{- end }}
-  {{- end }}
-  {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-    {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-    {{- end }}
-  {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "sda" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: DB_SSLMODE
-          value: {{ template "dbSSLmode" . }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-        - name: SCHEMA_TYPE
-          value: {{ default "isolated" .Values.global.schemaType }}
-        - name: SYNC_REMOTE_HOST
-          value: {{ .Values.global.sync.remote.host }}
-  {{- if not .Values.global.vaultSecrets }}
-    {{- if eq "s3" .Values.global.archive.storageType }}
-        - name: ARCHIVE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveAccessKey
-        - name: ARCHIVE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveSecretKey
-    {{- end }}
-    {{- if eq "s3" .Values.global.sync.destination.storageType }}
-        - name: SYNC_DESTINATION_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-sync
-              key: s3AccessKey
-        - name: SYNC_DESTINATION_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-sync
-              key: s3SecretKey
-    {{- end }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-sync
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-sync
-                key: mqUser
-        - name: C4GH_PASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-              key: passphrase
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-sync
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-sync
-                key: dbUser
-        - name: SYNC_REMOTE_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-sync
-              key: restUser
-        - name: SYNC_REMOTE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-sync
-              key: restPassword
-  {{ else }}
-        - name: CONFIGFILE
-          value: {{ include "confFile" . }}
-  {{- end }}
+          - name: CONFIGFILE
+            value: {{ include "confFile" . }}
         resources:
 {{ toYaml .Values.sync.resources | trim | indent 10 }}
         volumeMounts:
       {{- if not .Values.global.vaultSecrets }}
           - name: c4gh
             mountPath: {{ template "c4ghPath" . }}
+          - name: config
+            mountPath: {{ template "configPath" . }}
       {{- end }}
   {{- if eq "posix" .Values.global.archive.storageType }}
           - name: archive
@@ -283,6 +115,10 @@ spec:
               path: {{ .Values.global.c4gh.keyFile }}
             - key: {{ .Values.global.c4gh.syncPubKey }}
               path: {{ .Values.global.c4gh.syncPubKey }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-sync
     {{- end }}
   {{- if eq "posix" .Values.global.archive.storageType }}
         - name: archive

--- a/charts/sda-svc/templates/sync-secrets.yaml
+++ b/charts/sda-svc/templates/sync-secrets.yaml
@@ -8,18 +8,90 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-sync
 type: Opaque
-data:
-  c4ghPassphrase: {{ required "Crypt4gh passphrase is required" .Values.global.c4gh.passphrase | b64enc }}
-  dbPassword: {{ required "DB password is required" (include "dbPassSync" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserSync" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassSync" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserSync" .) | b64enc }}
-  restPassword: {{ required "REST password is required" .Values.global.sync.remote.password | b64enc }}
-  restUser: {{ required "REST user is required" .Values.global.sync.remote.user | b64enc }}
-  {{- if eq "s3" .Values.global.sync.destination.storageType }}
-  s3AccessKey: {{ required "Accesskey required for sync destination" .Values.global.sync.destination.accessKey | quote | trimall "\"" | b64enc }}
-  s3SecretKey: {{ required "Secretkey required for sync destination" .Values.global.sync.destination.secretKey | quote | trimall "\"" | b64enc }}
-  {{- end }}
+stringData:
+  config.yaml: |-
+    archive:
+      type: {{ required "Archive storage type is not set" .Values.global.archive.storageType }}
+    {{- if eq "s3" .Values.global.archive.storageType }}
+      accessKey: {{ required "Accesskey required for archive" .Values.global.archive.s3AccessKey }}
+      bucket: {{ required "S3 archive bucket not set" .Values.global.archive.s3Bucket }}
+      {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.archive.s3ChunkSize }}
+      {{- if .Values.global.archive.s3Port }}
+      port: {{ .Values.global.archive.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.archive.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for archive" .Values.global.archive.s3SecretKey }}
+      url: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
+    {{- else }}
+      location: /archive/
+    {{- end }}
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassMapper" .) }}
+      queue: {{ default "mappings" .Values.global.broker.finalizeQueue }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserMapper" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    c4gh:
+      filePath: {{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}
+      passphrase: {{ .Values.global.c4gh.passphrase }}
+      syncPubKeyPath: {{ template "c4ghPath" . }}/{{ required "remote sync public c4gh key is missing" .Values.global.c4gh.syncPubKey }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "MQ password is required" (include "dbPassMapper" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserMapper" .) }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    sync:
+      centerPrefix: {{ .Values.global.sync.centerPrefix }}
+      destination:
+        type: s3
+        url: {{ required "S3 sync archive URL missing" .Values.global.sync.destination.url }}
+      {{- if not (empty .Values.global.sync.destination.port) }}
+        port: {{ .Values.global.sync.destination.port }}
+      {{- end }}
+      {{- if not (empty .Values.global.sync.destination.readypath) }}
+        readypath: {{ .Values.global.sync.destination.readypath }}
+      {{- end }}
+        accessKey: {{ required "Accesskey required for sync destination" .Values.global.sync.destination.accessKey }}
+        secretKey: {{ required "SecretKey required for sync destination" .Values.global.sync.destination.secretKey }}
+        bucket: {{ required "S3 sync destination bucket missing" .Values.global.sync.destination.bucket }}
+        region: {{ default "us-east-1" .Values.global.sync.destination.region }}
+      remote:
+        host: {{ required "remote sync API host is required" .Values.global.sync.remote.host }}
+        password: {{ required "remote sync API password is required" .Values.global.sync.remote.password }}
+      {{- if not (empty .Values.global.sync.remote.port) }}
+        port: {{ .Values.global.sync.remote.port }}
+      {{- end }}
+        user: {{ required "remote sync API user is required" .Values.global.sync.remote.user }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/syncapi-deploy.yaml
+++ b/charts/sda-svc/templates/syncapi-deploy.yaml
@@ -73,83 +73,8 @@ spec:
 {{- toYaml .Values.global.extraSecurityContext | nindent 10 -}}
 {{- end }}
         env:
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-      {{- if not .Values.global.vaultSecrets }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-syncapi
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-syncapi
-                key: mqUser
-        - name: SYNC_API_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-syncapi
-              key: password
-        - name: SYNC_API_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-syncapi
-              key: user
-      {{- else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.host | quote }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-    {{- if .Values.global.tls.enabled }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-        - name: BROKER_CACERT
-          value: {{ include "tlsPath" . }}/ca.crt
-      {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ include "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ include "tlsPath" . }}/tls.key
-      {{- end }}
-    {{- end }}
-        {{- if .Values.global.tls.enabled }}
-        - name: SERVER_CERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: SERVER_KEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-        {{- if .Values.global.sync.api.accessionRouting }}
-        - name: SYNC_API_ACCESSIONROUTING
-          value: {{ .Values.global.sync.api.accessionRouting | quote }}
-        {{- end }}
-        {{- if .Values.global.sync.api.ingestRouting }}
-        - name: SYNC_API_INGESTROUTING
-          value: {{ .Values.global.sync.api.ingestRouting | quote }}
-        {{- end }}
-        {{- if .Values.global.sync.api.mappingRouting }}
-        - name: SYNC_API_MAPPINGROUTING
-          value: {{ .Values.global.sync.api.mappingRouting | quote }}
-        {{- end }}
         ports:
         - name: syncapi
           containerPort: 8080
@@ -162,11 +87,21 @@ spec:
         resources:
 {{ toYaml .Values.syncapi.resources | trim | indent 10 }}
         volumeMounts:
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
+      {{- end }}
       {{- if .Values.global.tls.enabled }}
         - name: tls
           mountPath: {{ template "tlsPath" . }}
       {{- end }}
       volumes:
+      {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-syncapi
+      {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls
         {{- if or .Values.global.tls.clusterIssuer .Values.global.tls.issuer }}

--- a/charts/sda-svc/templates/syncapi-secrets.yaml
+++ b/charts/sda-svc/templates/syncapi-secrets.yaml
@@ -8,11 +8,50 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-syncapi
 type: Opaque
-data:
-  mqPassword: {{ required "MQ password is required" (include "mqPassSync" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserSync" .) | b64enc }}
-  password: {{ required "Sync API password is required" .Values.global.sync.api.password | b64enc }}
-  user: {{ required "Sync API username is required" .Values.global.sync.api.user | b64enc }}
+stringData:
+  config.yaml: |-
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassMapper" .) }}
+      queue: {{ default "mappings" .Values.global.broker.finalizeQueue }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserMapper" .) }}
+    {{- if .Values.global.tls.enabled }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+    {{- end }}
+      vhost: {{ include "brokerVhost" . }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
+    {{- if .Values.global.tls.enabled }}
+    server:
+      cert: {{ template "tlsPath" . }}/tls.crt
+      key: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+    sync:
+      api:
+        password: {{ required "sync API password is required" .Values.global.sync.api.password }}
+        user: {{ required "sync API user is required" .Values.global.sync.api.user }}
+      brokerQueue: {{ default "mappings" .Values.global.sync.brokerQueue }}
+      centerPrefix: {{ .Values.global.sync.centerPrefix }}
+      remote:
+        host: {{ required "remote sync API host is required" .Values.global.sync.remote.host }}
+        password: {{ required "remote sync API password is required" .Values.global.sync.remote.password }}
+        port: {{ .Values.global.sync.remote.port }}
+        user: {{ required "remote sync API user is required" .Values.global.sync.remote.user }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/verify-deploy.yaml
+++ b/charts/sda-svc/templates/verify-deploy.yaml
@@ -55,136 +55,14 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
         env:
-        - name: ARCHIVE_TYPE
-      {{- if eq "s3" .Values.global.archive.storageType }}
-          value: "s3"
-        - name: ARCHIVE_URL
-          value: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
-      {{- if .Values.global.archive.s3Port }}
-        - name: ARCHIVE_PORT
-          value: {{ .Values.global.archive.s3Port | quote }}
-      {{- end }}
-        - name: ARCHIVE_BUCKET
-          value: {{ required "S3 archive bucket missing" .Values.global.archive.s3Bucket }}
-        - name: ARCHIVE_REGION
-          value: {{ default "us-east-1" .Values.global.archive.s3Region }}
-        - name: ARCHIVE_CHUNKSIZE
-          value: {{ .Values.global.archive.s3ChunkSize | quote }}
-        {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
-        - name: ARCHIVE_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- end }}
-      {{- else }}
-          value: "posix"
-        - name: ARCHIVE_LOCATION
-          value: "{{ .Values.global.archive.volumePath }}"
-      {{- end }}
-        - name: BROKER_SSL
-          value: {{ .Values.global.tls.enabled | quote }}
-      {{- if .Values.global.tls.enabled }}
-        - name: BROKER_VERIFYPEER
-          value: {{ .Values.global.broker.verifyPeer | quote }}
-        - name: BROKER_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-        {{- if .Values.global.broker.verifyPeer }}
-        - name: BROKER_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: BROKER_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-        {{- end }}
-      {{- end }}
-        - name: BROKER_EXCHANGE
-          value: {{ default "sda" .Values.global.broker.exchange }}
-        - name: BROKER_HOST
-          value: {{ required "A valid MQ host is required" .Values.global.broker.host | quote }}
-        - name: BROKER_PORT
-          value: {{ .Values.global.broker.port | quote }}
-        - name: BROKER_PREFETCHCOUNT
-          value: {{ .Values.global.broker.prefetchCount | quote }}
-        - name: BROKER_QUEUE
-          value: "archived"
-        - name: BROKER_ROUTINGKEY
-          value: "verified"
-      {{- if .Values.global.broker.serverName }}
-        - name: BROKER_SERVERNAME
-          value: {{ .Values.global.broker.serverName | quote }}
-      {{- end }}
-        - name: BROKER_VHOST
-          value: {{ .Values.global.broker.vhost | quote }}
-        - name: C4GH_FILEPATH
-          value: {{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}
-    {{- if .Values.global.tls.enabled }}
-        - name: DB_CACERT
-          value: {{ template "tlsPath" . }}/ca.crt
-      {{- if ne "verify-none" .Values.global.db.sslMode }}
-        - name: DB_CLIENTCERT
-          value: {{ template "tlsPath" . }}/tls.crt
-        - name: DB_CLIENTKEY
-          value: {{ template "tlsPath" . }}/tls.key
-      {{- end }}
-    {{- end }}
-        - name: DB_DATABASE
-          value: {{ default "lega" .Values.global.db.name | quote }}
-        - name: DB_HOST
-          value: {{ required "A valid DB host is required" .Values.global.db.host | quote }}
-        - name: DB_PORT
-          value: {{ .Values.global.db.port | quote }}
-        - name: DB_SSLMODE
-          value: {{ template "dbSSLmode" . }}
-      {{- if .Values.global.log.format }}
-        - name: LOG_FORMAT
-          value: {{ .Values.global.log.format | quote }}
-      {{- end }}
-      {{- if .Values.global.log.level }}
-        - name: LOG_LEVEL
-          value: {{ .Values.global.log.level | quote }}
-      {{- end }}
-      {{- if not .Values.global.vaultSecrets }}
-        {{- if eq "s3" .Values.global.archive.storageType }}
-        - name: ARCHIVE_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveAccessKey
-        - name: ARCHIVE_SECRETKEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "sda.fullname" . }}-s3archive-keys
-              key: s3ArchiveSecretKey
-        {{- end }}
-        - name: BROKER_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-verify
-                key: mqPassword
-        - name: BROKER_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-verify
-                key: mqUser
-        - name: C4GH_PASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-              key: passphrase
-        - name: DB_PASSWORD
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-verify
-                key: dbPassword
-        - name: DB_USER
-          valueFrom:
-              secretKeyRef:
-                name: {{ template "sda.fullname" . }}-verify
-                key: dbUser
-      {{- else }}
         - name: CONFIGFILE
           value: {{ include "confFile" . }}
-      {{- end }}
         resources:
 {{ toYaml .Values.verify.resources | trim | indent 10 }}
         volumeMounts:
         {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          mountPath: {{ template "configPath" . }}
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
         {{- end }}
@@ -210,6 +88,10 @@ spec:
         {{- end }}
       {{- end }}
       {{- if not .Values.global.vaultSecrets }}
+        - name: config
+          secret:
+            defaultMode: 0440
+            secretName: {{ template "sda.fullname" . }}-ingest
         - name: c4gh
           secret:
             defaultMode: 0440

--- a/charts/sda-svc/templates/verify-secrets.yaml
+++ b/charts/sda-svc/templates/verify-secrets.yaml
@@ -7,10 +7,68 @@ kind: Secret
 metadata:
   name: {{ template "sda.fullname" . }}-verify
 type: Opaque
-data:
-  dbPassword: {{ required "DB password is required" (include "dbPassVerify" .) | b64enc }}
-  dbUser: {{ required "DB user is required" (include "dbUserVerify" .) | b64enc }}
-  mqPassword: {{ required "MQ password is required" (include "mqPassVerify" .) | b64enc }}
-  mqUser: {{ required "MQ user is required" (include "mqUserVerify" .) | b64enc }}
+stringData:
+  config.yaml: |-
+    archive:
+      type: {{ required "Archive storage type is not set" .Values.global.archive.storageType }}
+    {{- if eq "s3" .Values.global.archive.storageType }}
+      accessKey: {{ required "Accesskey required for archive" .Values.global.archive.s3AccessKey }}
+      bucket: {{ required "S3 archive bucket not set" .Values.global.archive.s3Bucket }}
+      {{- if and .Values.global.archive.s3CaFile .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{ end }}
+      chunksize: {{ default 15 .Values.global.archive.s3ChunkSize }}
+      {{- if .Values.global.archive.s3Port }}
+      port: {{ .Values.global.archive.s3Port }}
+      {{- end }}
+      readypath: {{ .Values.global.archive.s3ReadyPath }}
+      secretKey: {{ required "Secretkey required for archive" .Values.global.archive.s3SecretKey }}
+      url: {{ required "S3 archive URL missing" .Values.global.archive.s3Url }}
+    {{- else }}
+      location: /archive/
+    {{- end }}
+    broker:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      {{- if .Values.global.broker.verifyPeer }}
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
+    {{- end }}
+      exchange: {{ default "sda" .Values.global.broker.exchange }}
+      host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
+      port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
+      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      password: {{ required "MQ password is required" (include "mqPassIngest" .) }}
+      queue: {{ default "archived" .Values.global.broker.verifyQueue }}
+      routingKey: {{ default "verified" .Values.global.broker.routingKey }}
+    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
+      serverName: {{.Values.global.broker.serverName }}
+    {{- end }}
+      ssl: {{ .Values.global.tls.enabled }}
+      user: {{ required "MQ user is required" (include "mqUserIngest" .) }}
+      verifyPeer: {{ .Values.global.broker.verifyPeer }}
+      vhost: {{ include "brokerVhost" . }}
+    c4gh:
+      privateKeys:
+      {{- range $k := .Values.global.c4gh.privateKeys }}
+        - filePath: {{ template "c4ghPath" $ }}/{{ $k.keyName }}
+          passphrase: {{ $k.passphrase }}
+      {{- end }}
+    db:
+    {{- if .Values.global.tls.enabled }}
+      caCert: {{ template "tlsPath" . }}/ca.crt
+      clientCert: {{ template "tlsPath" . }}/tls.crt
+      clientKey: {{ template "tlsPath" . }}/tls.key
+    {{- end }}
+      host: {{ .Values.global.db.host }}
+      database: {{ .Values.global.db.name }}
+      password: {{ required "DB user is required" (include "dbPassVerify" .) }}
+      port: {{ .Values.global.db.port }}
+      sslmode: {{ ternary .Values.global.db.sslMode "disable" .Values.global.tls.enabled }}
+      user: {{ required "DB user is required" (include "dbUserVerify" .) }}
+    log:
+      format: {{ .Values.global.log.format }}
+      level: {{ .Values.global.log.level }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -9,7 +9,7 @@ global:
 # Path where the sensitive files can be found, default is "/.secrets".
 # TLS certificates or C4GH key locations can be set using global.tlsPath or global.c4ghPath respectively,
 # this path will be a subpath to the secretsPath.
-  secretsPath: /.secrets
+  secretsPath: "/.secrets"
   c4ghPath: "c4gh"
   tlsPath: "tls"
   jwtPath: "jwt"
@@ -195,7 +195,9 @@ global:
     publicFile: ""
     passphrase: ""
     backupPubKey: ""
-
+    privateKeys:
+    - keyName:
+      passphrase:
   db:
     host: ""
     name: "sda"

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -401,8 +401,6 @@ auth:
 
 doa:
   name: doa
-  repository: ghcr.io/neicnordic/sda-doa
-  imageTag: v1.6.62
   imagePullPolicy: IfNotPresent
   replicaCount: 2
   resources:
@@ -474,7 +472,6 @@ ingest:
     secretName: ""
 
 intercept:
-  deploy: true
   name: ingest
   replicaCount: 1
   resources:
@@ -606,7 +603,6 @@ releasetest:
 verify:
   replicaCount: 1
   repository: ghcr.io/neicnordic/sda-pipeline
-  imageTag: v0.4.27
   imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1593 .

This PR should be merged after PR https://github.com/neicnordic/sensitive-data-archive/pull/1700 has been merged.

## Description
This PR changes the SDA helm chart to use config file instead of ENVs for configuring each service.
Each of the GO services are given a secret that holds the config file for that particular service.

## How to test
Due to the changes done and the requirement to get a new chart version deployed the tests are updated in a separate PR.