### PR TITLE
[release_v1] Release v1.0.0 of the helm charts

### DIFF
--- a/charts/sda-db/Chart.yaml
+++ b/charts/sda-db/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-db
-version: 0.8.59
-appVersion: v0.3.121
+version: 1.0.0
+appVersion: v1.0.0
 kubeVersion: '>= 1.26.0'
 description: Database component for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-mq/Chart.yaml
+++ b/charts/sda-mq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-mq
-version: 0.7.60
-appVersion: v0.3.121
+version: 1.0.0
+appVersion: v1.0.0
 kubeVersion: '>= 1.26.0'
 description: RabbitMQ component for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sda-svc
-version: 0.28.3
-appVersion: v0.3.121
+version: 1.0.0
+appVersion: v1.0.0
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation
 home: https://neic-sda.readthedocs.io

--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -93,7 +93,7 @@ spec:
             type: "RuntimeDefault"
         env:
         - name: KEYSTORE_PASSWORD
-          value: {{ required "Keystore password is required" .Values.sftpInbox.keystorePass | quote }}
+          value: {{ required "Keystore password is required" .Values.global.doa.keystorePass | quote }}
         volumeMounts:
         - name: tls-certs
           mountPath: /tls-certs
@@ -102,7 +102,7 @@ spec:
     {{- end }}
       containers:
       - name: doa
-        image: "{{ .Values.doa.repository }}:{{ .Values.doa.imageTag }}"
+        image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}-doa"
         imagePullPolicy: {{ .Values.image.imagePullPolicy | quote }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -198,7 +198,7 @@ spec:
         - name: KEYSTORE_PATH
           value: {{ ternary (print "/etc/ssl/certs/java/doa.p12") (printf "%s/%s" .Values.global.secretsPath .Values.doa.tls.keyStore) (empty .Values.global.pkiService) }}
         - name: KEYSTORE_PASSWORD
-          value: {{ .Values.doa.keystorePass | quote }}
+          value: {{ .Values.global.doa.keystorePass | quote }}
         - name: ROOT_CERT_PATH
           value: {{ ternary (print "/etc/ssl/certs/java/ca.crt" ) (printf "%s/%s" .Values.global.secretsPath .Values.doa.tls.cacert) (empty .Values.global.pkiService) }}
         - name: CERT_PATH
@@ -211,6 +211,8 @@ spec:
           value: "{{ template "c4ghPath" . }}/passphrase"
         - name: OPENID_CONFIGURATION_URL
           value: "{{ .Values.global.oidc.provider }}/.well-known/openid-configuration"
+        - name: USERINFO_ENDPOINT_URL
+          value: "{{ .Values.global.oidc.provider }}/userinfo"
         - name: OUTBOX_ENABLED
           value: {{ .Values.global.doa.outbox.enabled | quote }}
       {{- if .Values.global.doa.outbox.enabled }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -207,6 +207,7 @@ global:
 
   doa:
     enabled: false
+    keystorePass: "changeit"
     outbox:
       enabled: false
       # MQ queue name for files/datasets export requests
@@ -394,9 +395,6 @@ auth:
 
 doa:
   name: doa
-  repository: ghcr.io/neicnordic/sda-doa
-  imageTag: v1.6.62
-  imagePullPolicy: IfNotPresent
   replicaCount: 2
   resources:
     requests:
@@ -405,9 +403,6 @@ doa:
     limits:
       memory: "1024Mi"
       cpu: "2000m"
-  debugPort: 1234
-  logpath: "/tmp/logs"
-  keystorePass: "changeit"
 # Extra annotations to attach to the service pods
 # This should be a multi-line string mapping directly to the a map of
 # the annotations to apply to the service pods


### PR DESCRIPTION
## Description
This releases version 1.0.0 of the helm charts with the corresponding container version as the default.

## How to test
In order to be able to test this the make file needs to manually modified in order for the deployments to be done with TLS activated. Other than that it is as per usual.

Closes #1697 