### PR TITLE
increase mock ls-aai token ttl

### DIFF
--- a/.github/integration/sda/aai-mock/clients/aai-auth.yaml
+++ b/.github/integration/sda/aai-mock/clients/aai-auth.yaml
@@ -6,3 +6,6 @@ token-endpoint-auth-method: "client_secret_basic"
 scope: ["openid", "profile", "email", "ga4gh_passport_v1", "eduperson_entitlement"]
 grant-types: ["authorization_code"]
 post-logout-redirect-uris: ["http://localhost:8801/oidc/login"]
+
+# How many seconds is the access token valid #30days
+access-token-validity-seconds: 2592000


### PR DESCRIPTION
## Description
Increase the mock-ls-aai token lifetime from <1hr to 30 days for convenience.
