### PR TITLE
[api] More efficient  db queries used by /users and /files

### DIFF
--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -742,7 +742,7 @@ func (dbs *SDAdb) ListActiveUsers() ([]string, error) {
 	db := dbs.DB
 
 	var users []string
-	rows, err := db.Query("SELECT DISTINCT submission_user FROM sda.files WHERE id NOT IN (SELECT f.id FROM sda.files f RIGHT JOIN sda.file_dataset d ON f.id = d.file_id) ORDER BY submission_user ASC;")
+	rows, err := db.Query("SELECT DISTINCT submission_user FROM sda.files f1 WHERE NOT EXISTS (SELECT 1 FROM sda.file_dataset d WHERE f1.id = d.file_id) ORDER BY submission_user ASC;")
 	if err != nil {
 		return nil, err
 	}

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -677,7 +677,7 @@ func (dbs *SDAdb) getUserFiles(userID string) ([]*SubmissionFileInfo, error) {
 	// select all files (that are not part of a dataset) of the user, each one annotated with its latest event
 	const query = "SELECT f.id, f.submission_file_path, e.event, f.created_at FROM sda.files f " +
 		"LEFT JOIN (SELECT DISTINCT ON (file_id) file_id, started_at, event FROM sda.file_event_log ORDER BY file_id, started_at DESC) e ON f.id = e.file_id WHERE f.submission_user = $1 " +
-		"AND f.id NOT IN (SELECT f.id FROM sda.files f RIGHT JOIN sda.file_dataset d ON f.id = d.file_id); "
+		"AND NOT EXISTS (SELECT 1 FROM sda.file_dataset d WHERE f.id = d.file_id);"
 
 	// nolint:rowserrcheck
 	rows, err := db.Query(query, userID)


### PR DESCRIPTION
This is for book-keeping, not meant to merge since it is a split-off branch from TAG1188

## Description
The db has grown and the API struggles to satisfy requests because of inefficient queries to the db.
Fixes from here have been built and pushed to harbor.

## How to test
