### PR TITLE
fix: Remove merge_group trigger

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,6 +1,5 @@
 name: Scan Images
 on:
-  merge_group:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This workflow shouldnt be triggered by merge_group.
