### PR TITLE
[charts] New major release for sda-svc.

### DIFF
--- a/.github/integration/scripts/charts/dependencies.sh
+++ b/.github/integration/scripts/charts/dependencies.sh
@@ -109,7 +109,6 @@ yq -i '
 .global.backupArchive.s3AccessKey = strenv(MINIO_ACCESS) |
 .global.backupArchive.s3SecretKey = strenv(MINIO_SECRET) |
 .global.broker.password = strenv(MQPASSWORD) |
-.global.c4gh.passphrase = strenv(C4GHPASSPHRASE) |
 .global.c4gh.privateKeys[0].passphrase = strenv(C4GHPASSPHRASE) |
 .global.db.password = strenv(PGPASSWORD) |
 .global.inbox.s3AccessKey = strenv(MINIO_ACCESS) |

--- a/.github/integration/scripts/charts/values.yaml
+++ b/.github/integration/scripts/charts/values.yaml
@@ -56,13 +56,11 @@ global:
     user: PLACEHOLDER_VALUE
   c4gh:
     secretName: c4gh
-    keyFile: c4gh.sec.pem
-    publicFile: c4gh.pub.pem
-    passphrase: PLACEHOLDER_VALUE
-    syncPubKey: c4gh.pub.pem
+    publicKey: c4gh.pub.pem
     privateKeys:
       - keyName: c4gh.sec.pem
         passphrase: PLACEHOLDER_VALUE
+    syncPubKey: c4gh.pub.pem
   db:
     host: "postgres-sda-db"
     user: "postgres"

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 2.0.10
+version: 3.0.0
 appVersion: v2.1.5
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -10,6 +10,19 @@ Source repositories:
 Edit the values.yaml file and specify the relevant parts of the `global` section.
 If no shared credentials for the broker and database are used, the credentials for each service shuld be set in the `credentials` section.
 
+While it is possible to deploy this chart with the crypt4gh keys included in the values file as base64 encoded strings, it is advisable to create the secret containing the crypt4gh keys manually.
+
+## Upgrading an existing Release to a new version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+### To 3.0.0
+
+This version adds Jobs that migrates the dtabase schema from a V1 release and sets the first registered crypt4gh key to all ingested files that do not have a c4gh key referenced.  
+When upgrading from a V1 release *both* `upgradeFomV1` and `setKeyHash` should be run.
+
+Unless the same queries are being exiecuted manually by a database adminitstrator a `Basic authentication Secret` containg the credentials to perform the upgrade needs to be created.
+
 ### Configuration
 
 The following table lists the configurable parameters of the `sda-svc` chart and their default values.
@@ -99,9 +112,15 @@ Parameter | Description | Default
 `global.cega.host` | Full URI to the EGA user authentication service. |`""`
 `global.cega.user` | Username for the EGA user authentication service. |`""`
 `global.cega.password` | Password for the EGA user authentication service. |`""`
-`global.c4gh.keyFile` | Private C4GH key. |`c4gh.key`
-`global.c4gh.passphrase` | Passphrase for the private C4GH key. |`""`
-`global.c4gh.publicFile` | Public key corresponding to the private key, provided in /info endpoint. |`""`
+`global.c4gh.privateKeys` | List of Private C4GH keys. |``
+`global.c4gh.privateKeys.0.keyData` | The private crypt4gh key provided as a base64 encoded string. |`""`
+`global.c4gh.privateKeys.0.keyName` | Filename of the private C4GH key. |`""`
+`global.c4gh.privateKeys.0.passphrase` | Passphrase for the private C4GH key. |`""`
+`global.c4gh.publicKey` | Public key corresponding to the private key, provided in /info endpoint. |`""`
+`global.c4gh.publicKeyData` | Public key corresponding to the private key, provided as a base64 encoded string. |`""`
+`global.db.admin.secretName` | Name of the secret that holds the database admin credentials. |`""`
+`global.db.admin.passKey` | Key in the secret that holds the password. |`""`
+`global.db.admin.userkey` | Key in the secret that holds the username. |`""`
 `global.db.host` | Hostname for the database. |`""`
 `global.db.name` | Database to connect to. |`lega`
 `global.db.passIngest` | Password used for `data in` services. |`""`
@@ -303,3 +322,9 @@ Parameter | Description | Default
 `releasetest.repository` | inbox container image repository | `neicnordic/sda-helm-test-support`
 `releasetest.imageTag` | inbox container image version | `latest`
 `releasetest.imagePullPolicy` | inbox container image pull policy | `Always`
+
+### Jobs
+
+`jobs.image` | Container image used for running the DB migration jobs | `postgres:15.4-alpine`
+`jobs.setKeyHash` | Populate the key_hash table after migration from V1 | `false`
+`jobs.upgradeFomV1` | Upgrade database schema from a version 1 release. | `false`

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -18,10 +18,10 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 ### To 3.0.0
 
-This version adds Jobs that migrates the dtabase schema from a V1 release and sets the first registered crypt4gh key to all ingested files that do not have a c4gh key referenced.  
-When upgrading from a V1 release *both* `upgradeFomV1` and `setKeyHash` should be run.
+This version adds Jobs that migrates the database schema from a V1 release and sets the first registered crypt4gh key to all ingested files that do not have a c4gh key referenced.  
+When upgrading from a V1 release *both* `upgradeFromV1` and `setKeyHash` should be run.
 
-Unless the same queries are being exiecuted manually by a database adminitstrator a `Basic authentication Secret` containg the credentials to perform the upgrade needs to be created.
+Unless the same queries are being executed manually by a database administrator a `Basic authentication Secret` containing the credentials to perform the upgrade needs to be created.
 
 ### Configuration
 
@@ -327,4 +327,4 @@ Parameter | Description | Default
 
 `jobs.image` | Container image used for running the DB migration jobs | `postgres:15.4-alpine`
 `jobs.setKeyHash` | Populate the key_hash table after migration from V1 | `false`
-`jobs.upgradeFomV1` | Upgrade database schema from a version 1 release. | `false`
+`jobs.upgradeFromV1` | Upgrade database schema from a version 1 release. | `false`

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -137,8 +137,8 @@ spec:
             defaultMode: 0440
             secretName: {{ required "A secret for the C4GH public key is needed" .Values.global.c4gh.secretName }}
             items:
-              - key: {{ required "The C4GH public key is needed" .Values.global.c4gh.publicFile }}
-                path: {{ .Values.global.c4gh.publicFile }}
+              - key: {{ required "The C4GH public key is needed" .Values.global.c4gh.publicKey }}
+                path: {{ .Values.global.c4gh.publicKey }}
       {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/auth-secrets.yaml
+++ b/charts/sda-svc/templates/auth-secrets.yaml
@@ -30,7 +30,7 @@ stringData:
         signaturealg: {{ .Values.global.auth.jwtAlg }}
         tokenttl: {{ .Values.global.auth.jwtTTL }}
     {{- end }}
-      publicfile: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.publicFile }}"
+      publicfile: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.publicKey }}"
       resignjwt: {{ .Values.global.auth.resignJwt }}
       s3Inbox: {{ .Values.global.ingress.hostName.s3Inbox }}
     db:

--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -206,7 +206,7 @@ spec:
         - name: CERT_KEY
           value: {{ ternary (printf "/etc/ssl/certs/java/tls.key.der" ) (printf "%s/%s" .Values.global.secretsPath .Values.doa.tls.keyFile) (empty .Values.global.pkiService) }}
         - name: CRYPT4GH_PRIVATE_KEY_PATH
-          value: "{{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}"
+          value: "{{ template "c4ghPath" . }}/{{ (first .Values.global.c4gh.privateKeys).keyName }}"
         - name: CRYPT4GH_PRIVATE_KEY_PASSWORD_PATH
           value: "{{ template "c4ghPath" . }}/passphrase"
         - name: OPENID_CONFIGURATION_URL
@@ -315,9 +315,19 @@ spec:
                     path: {{ .Values.global.oidc.pubKey }}
       {{- end }}
         - name: c4gh-key
-          secret:
-            secretName: {{ .Values.global.c4gh.secretName }}
+          projected:
             defaultMode: 0440
+            sources:
+            - secret:
+                name: {{ .Values.global.c4gh.secretName }}
+                items:
+                  - key: {{ (first .Values.global.c4gh.privateKeys).keyName }}
+                    path: {{ (first .Values.global.c4gh.privateKeys).keyName }}
+            - secret:
+                name: {{ template "sda.fullname" . }}-doa
+                items:
+                  - key: c4ghPassphrase
+                    path: passphrase
       {{- end }}
       {{- if eq "posix" .Values.global.archive.storageType }}
         - name: archive

--- a/charts/sda-svc/templates/doa-secrets.yaml
+++ b/charts/sda-svc/templates/doa-secrets.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ template "sda.fullname" . }}-doa
 type: Opaque
 data:
+  c4ghPassphrase: {{ (first .Values.global.c4gh.privateKeys).passphrase }}
   dbPassword: {{ include "dbPassDoa" . | b64enc }}
 {{- if and .Values.global.doa.outbox.enabled }}
   mqPassword: {{ include "mqPassDoa" . | b64enc }}

--- a/charts/sda-svc/templates/ingest-deploy.yaml
+++ b/charts/sda-svc/templates/ingest-deploy.yaml
@@ -105,9 +105,6 @@ spec:
           secret:
             defaultMode: 0440
             secretName: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-            items:
-            - key: {{ .Values.global.c4gh.keyFile }}
-              path: {{ .Values.global.c4gh.keyFile }}
       {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/job-set-missing-keyhash.yaml
+++ b/charts/sda-svc/templates/job-set-missing-keyhash.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.jobs.setKeyHash }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sda.fullname" . }}-set-key-hash-job
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+  annotations:
+    # This is what defines this resource as a hook.
+    # Without this line, the job is considered part of the release.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ template "sda.fullname" . }}-set-key-hash-job
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ template "sda.fullname" . }}-set-key-hash-job
+        command: ["/usr/local/bin/psql"]
+        args: [
+          "-qf",
+          "/migratedb/set-key-hash.sql"
+        ]
+        env:
+        - name: PGDATABASE
+          value: {{ .Values.global.db.name }}
+        - name: PGHOST
+          value: {{ .Values.global.db.host }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "a secret holding the DB admin credentials are needed" .Values.global.db.admin.secretName }}
+              key:  {{ default "password" .Values.global.db.admin.passKey }}
+        {{- if .Values.global.db.port }}
+        - name: PGPORT
+          value: {{ .Values.global.db.port | quote }}
+        {{- end }}
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "a secret holding the DB admin credentials are needed" .Values.global.db.admin.secretName }}
+              key:  {{ default "username" .Values.global.db.admin.userKey }}
+        image: {{ .Values.jobs.image }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: "RuntimeDefault"
+        volumeMounts:
+        - name: sql
+          mountPath: /migratedb
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 72
+        runAsGroup: 72
+        fsGroup: 72
+      volumes:
+      - name: sql
+        configMap:
+          name: set-key-hash
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: set-key-hash
+data:
+  set-key-hash.sql: |
+    DO
+    $$
+    BEGIN
+      IF (select max(version) from sda.dbschema_version) > 11 then
+        RAISE NOTICE 'Fixing c4gh key references';
+        UPDATE sda.files SET key_hash = (SELECT key_hash FROM sda.encryption_keys WHERE deprecated_at IS NULL ORDER BY created_at ASC LIMIT 1)
+        WHERE header IS NOT NULL AND key_hash IS NULL;
+      END IF;
+    END
+    $$
+{{- end }}

--- a/charts/sda-svc/templates/job-upgrade-from-v1.yaml
+++ b/charts/sda-svc/templates/job-upgrade-from-v1.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.jobs.upgradeFomV1 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sda.fullname" . }}-upgrade-from-v1-job
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+  annotations:
+    # This is what defines this resource as a hook.
+    # Without this line, the job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ template "sda.fullname" . }}-upgrade-from-v1-job
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ template "sda.fullname" . }}-upgrade-from-v1-job
+        command: ["/usr/local/bin/psql"]
+        args: [
+          "-qf",
+          "/migratedb/upgrade-from-v1.sql"
+        ]
+        env:
+        - name: PGDATABASE
+          value: {{ .Values.global.db.name }}
+        - name: PGHOST
+          value: {{ .Values.global.db.host }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "a secret holding the DB admin credentials are needed" .Values.global.db.admin.secretName }}
+              key:  {{ default "password" .Values.global.db.admin.passKey }}
+        {{- if .Values.global.db.port }}
+        - name: PGPORT
+          value: {{ .Values.global.db.port | quote }}
+        {{- end }}
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "a secret holding the DB admin credentials are needed" .Values.global.db.admin.secretName }}
+              key:  {{ default "username" .Values.global.db.admin.userKey }}
+        image: {{ .Values.jobs.image }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: "RuntimeDefault"
+        volumeMounts:
+        - name: sql
+          mountPath: /migratedb
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 72
+        runAsGroup: 72
+        fsGroup: 72
+      volumes:
+      - name: sql
+        configMap:
+          name: upgrade-from-v1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upgrade-from-v1
+data:
+  upgrade-from-v1.sql: |
+    DO
+    $$
+    BEGIN
+      IF (select max(version) from sda.dbschema_version) = 11 then
+        RAISE NOTICE 'Doing migration from schema version 11 to 17';
+
+        INSERT INTO sda.dbschema_version VALUES(12, now(), 'Add key hash table');
+        CREATE TABLE IF NOT EXISTS sda.encryption_keys (
+            key_hash          TEXT PRIMARY KEY,
+            created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+            deprecated_at     TIMESTAMP WITH TIME ZONE,
+            description       TEXT
+        );
+        ALTER TABLE sda.files ADD COLUMN IF NOT EXISTS key_hash TEXT,
+        ADD CONSTRAINT fk_files_key_hash FOREIGN KEY (key_hash) REFERENCES sda.encryption_keys(key_hash);
+
+        INSERT INTO sda.dbschema_version VALUES(14, now(), 'Add userinfo table');
+        CREATE TABLE IF NOT EXISTS sda.userinfo (
+            id          TEXT PRIMARY KEY,
+            name        TEXT,
+            email       TEXT,
+            groups      TEXT[]
+        );
+
+        INSERT INTO sda.dbschema_version VALUES(17, now(), 'Add submission user to constraint');
+        ALTER TABLE sda.files DROP CONSTRAINT unique_ingested;
+        ALTER TABLE sda.files ADD CONSTRAINT unique_ingested UNIQUE(submission_file_path, archive_file_path, submission_user);
+
+      ELSE
+        RAISE NOTICE 'Schema migration from 11 does not apply now, skipping';
+      END IF;
+    END
+    $$
+{{- end }}

--- a/charts/sda-svc/templates/job-upgrade-from-v1.yaml
+++ b/charts/sda-svc/templates/job-upgrade-from-v1.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jobs.upgradeFomV1 }}
+{{- if .Values.jobs.upgradeFromV1 }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/sda-svc/templates/re-encrypt-deploy.yaml
+++ b/charts/sda-svc/templates/re-encrypt-deploy.yaml
@@ -87,9 +87,6 @@ spec:
           secret:
             defaultMode: 0440
             secretName: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-            items:
-            - key: {{ .Values.global.c4gh.keyFile }}
-              path: {{ .Values.global.c4gh.keyFile }}
       {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/shared-secrets.yaml
+++ b/charts/sda-svc/templates/shared-secrets.yaml
@@ -32,4 +32,22 @@ data:
   s3InboxAccessKey: {{ required "Accesskey required for inbox" .Values.global.inbox.s3AccessKey | quote | trimall "\"" | b64enc }}
   s3InboxSecretKey: {{ required "Secretkey required for inbox" .Values.global.inbox.s3SecretKey | quote | trimall "\"" | b64enc }}
 {{- end }}
+{{- if and .Values.global.c4gh.publicKeyData (first .Values.global.c4gh.privateKeys).keyData }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.c4gh.secretName }}
+type: Opaque
+data:
+  {{ .Values.global.c4gh.publicKey }}: {{ .Values.global.c4gh.publicKeyData }}
+{{- range $pk := .Values.global.c4gh.privateKeys }}
+  {{- if and $pk.keyName $pk.keyData $pk.passphrase }}
+  {{ $pk.keyName }}: {{ $pk.keyData }}
+  {{- end }}
+{{- end }}
+  {{- if and .Values.global.c4gh.syncPubKey .Values.global.c4gh.syncPubKeyData }}
+  {{ .Values.global.c4gh.syncPubKey }}: {{ .Values.global.c4gh.syncPubKeyData }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/sync-deploy.yaml
+++ b/charts/sda-svc/templates/sync-deploy.yaml
@@ -111,8 +111,8 @@ spec:
             defaultMode: 0440
             secretName: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
             items:
-            - key: {{ .Values.global.c4gh.keyFile }}
-              path: {{ .Values.global.c4gh.keyFile }}
+            - key: {{ (first .Values.global.c4gh.privateKeys).keyName }}
+              path: {{ (first .Values.global.c4gh.privateKeys).keyName }}
             - key: {{ .Values.global.c4gh.syncPubKey }}
               path: {{ .Values.global.c4gh.syncPubKey }}
         - name: config

--- a/charts/sda-svc/templates/sync-secrets.yaml
+++ b/charts/sda-svc/templates/sync-secrets.yaml
@@ -52,8 +52,8 @@ stringData:
     {{- end }}
       vhost: {{ include "brokerVhost" . }}
     c4gh:
-      filePath: {{ template "c4ghPath" . }}/{{ .Values.global.c4gh.keyFile }}
-      passphrase: {{ .Values.global.c4gh.passphrase }}
+      filePath: {{ template "c4ghPath" . }}/{{ (first .Values.global.c4gh.privateKeys).keyName }}
+      passphrase: {{ (first .Values.global.c4gh.privateKeys).passphrase }}
       syncPubKeyPath: {{ template "c4ghPath" . }}/{{ required "remote sync public c4gh key is missing" .Values.global.c4gh.syncPubKey }}
     db:
     {{- if .Values.global.tls.enabled }}

--- a/charts/sda-svc/templates/verify-deploy.yaml
+++ b/charts/sda-svc/templates/verify-deploy.yaml
@@ -96,9 +96,6 @@ spec:
           secret:
             defaultMode: 0440
             secretName: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
-            items:
-            - key: {{ .Values.global.c4gh.keyFile }}
-              path: {{ .Values.global.c4gh.keyFile }}
       {{- end }}
       {{- if eq "posix" .Values.global.archive.storageType }}
         - name: archive

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -626,3 +626,4 @@ verify:
 jobs:
   image: postgres:15.4-alpine
   setKeyHash: false
+  upgradeFomV1: false

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -188,16 +188,15 @@ global:
     password: ""
 
   c4gh:
-    secretName: ""
-  # name of the c4gh key file.
-    keyFile: ""
-  # name of the public file, required for testing
-    publicFile: ""
-    passphrase: ""
-    backupPubKey: ""
+    secretName:
+    publicKey:
+    publicKeyData:
     privateKeys:
     - keyName:
       passphrase:
+      keyData:
+    syncPubKey:
+    syncPubKeyData:
   db:
     host: ""
     name: "sda"

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -198,6 +198,12 @@ global:
     syncPubKey:
     syncPubKeyData:
   db:
+    admin:
+  # These credentials need at least dbOwner permissions
+  # in order to perform schema migrations.
+      secretName: ""
+      passKey: ""
+      userKey: ""
     host: ""
     name: "sda"
     user: ""
@@ -616,3 +622,7 @@ verify:
   annotations: {}
   tls:
     secretName: ""
+
+jobs:
+  image: postgres:15.4-alpine
+  setKeyHash: false

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -626,4 +626,4 @@ verify:
 jobs:
   image: postgres:15.4-alpine
   setKeyHash: false
-  upgradeFomV1: false
+  upgradeFromV1: false


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR is related to #1794 In the sense that it simplifies bootstrapping a deployment with all components generated by the charts.

It also allows for an upgrade from a V1 deployment by performing the necessary database schema migrations.

## Description
* Allows for the creation of the secret containing the crypt4gh keys directly from the values file.
* Adds a job that will perform the necessary schema migration from a V1 deployment.
* Adds a job that will set the c4gh key hash in the files table when upgrading from an previous version of the stack.
* Removes outdated parts from the values file and the corresponding sections in the deployment manifests.
* Adds a note to the readme that while it is possible to create the c4gh secret from the values file it is advisable to do it separately.
* Updates the readme with a section about upgrading to this version from a previous one.

## How to test
