### PR TITLE
[charts] add job to remove submitter name from upload path

### DIFF
--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -10,6 +10,15 @@ Source repositories:
 Edit the values.yaml file and specify the relevant parts of the `global` section.
 If no shared credentials for the broker and database are used, the credentials for each service shuld be set in the `credentials` section.
 
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+### To 3.0.0
+
+This version adds a Job that cleans up the submission file paths in the database. Ensure that there is no ongoing work by either scaling down all deplpoyments to zero or uninstalling the chart before upgrade.
+Unless the same query is being exiecuted manually by a database adminitstrator a `Basic authentication Secret` containg the credentials to perform the upgrade needs to be created as well.
+
 ### Configuration
 
 The following table lists the configurable parameters of the `sda-svc` chart and their default values.
@@ -17,7 +26,7 @@ The following table lists the configurable parameters of the `sda-svc` chart and
 Parameter | Description | Default
 --------- | ----------- | -------
 `image.repository` | Repository URI | `ghcr.io/neicnordic/sensitive-data-archive`
-`image.tag` | Tag version to deploy | ``
+`image.tag` | Tag version to deploy | `chart appVersion`
 `image.pullPolicy` | Image pull policy, `Always` or `IfNotPresent` | `Always`
 `global.secretsPath` | Path where the sensitive files can be found | `/.secrets`
 `global.c4ghPath` | This path will be a subpath to the secretsPath | `c4gh`
@@ -102,6 +111,9 @@ Parameter | Description | Default
 `global.c4gh.keyFile` | Private C4GH key. |`c4gh.key`
 `global.c4gh.passphrase` | Passphrase for the private C4GH key. |`""`
 `global.c4gh.publicFile` | Public key corresponding to the private key, provided in /info endpoint. |`""`
+`global.db.admin.secretName` | Name of the secret that holds the database admin credentials. |`""`
+`global.db.admin.passKey` | Key in the secret that holds the password. |`""`
+`global.db.admin.userkey` | Key in the secret that holds the username. |`""`
 `global.db.host` | Hostname for the database. |`""`
 `global.db.name` | Database to connect to. |`lega`
 `global.db.passIngest` | Password used for `data in` services. |`""`

--- a/charts/sda-svc/templates/job-remove-user-name.yaml
+++ b/charts/sda-svc/templates/job-remove-user-name.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.jobs.removeUserName }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sda.fullname" . }}-remove-user-name-job
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+  annotations:
+    # This is what defines this resource as a hook.
+    # Without this line, the job is considered part of the release.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ template "sda.fullname" . }}-remove-user-name-job
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ template "sda.fullname" . }}-remove-user-name-job
+        command: ["/usr/local/bin/psql"]
+        args: [
+          "-qc",
+          "UPDATE sda.files SET submission_file_path = REPLACE(submission_file_path, CONCAT(REPLACE(submission_user, '@', '_'),'/'), '');"
+        ]
+        env:
+        - name: PGDATABASE
+          value: {{ .Values.global.db.name }}
+        - name: PGHOST
+          value: {{ .Values.global.db.host }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "a secret holding the DB admin credentials are needed" .Values.global.db.admin.secretName }}
+              key:  {{ default "password" .Values.global.db.admin.passKey }}
+        {{- if .Values.global.db.port }}
+        - name: PGPORT
+          value: {{ .Values.global.db.port | quote }}
+        {{- end }}
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "a secret holding the DB admin credentials are needed" .Values.global.db.admin.secretName }}
+              key:  {{ default "username" .Values.global.db.admin.userKey }}
+        image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}-postgres
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: "RuntimeDefault"
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 72
+        runAsGroup: 72
+        fsGroup: 72
+{{- end }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -199,6 +199,12 @@ global:
     - keyName:
       passphrase:
   db:
+    admin:
+  # These credentials need at least dbOwner permissions
+  # in order to perform schema migrations.
+      secretName: ""
+      passKey: ""
+      userKey: ""
     host: ""
     name: "sda"
     user: ""
@@ -617,3 +623,7 @@ verify:
   annotations: {}
   tls:
     secretName: ""
+
+jobs:
+# remove the username from the submission file path in the database
+  removeUserName: true


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR is related to #1601 .


## Description
This PR adds a job that runs a SQL query to remove the submitter name from the inbox file path.
The job is run *before* the rest of the stack is updated so that ingest can start processing messages directly once it starts without any issues.

## How to test
