### PR TITLE
fix(sda-admin): change sda-cli args order

### DIFF
--- a/tools/sda-admin
+++ b/tools/sda-admin
@@ -167,8 +167,7 @@ upload () {
 	# subdirectory of the user's S3 bucket.
 	#
 	if [ "$#" -gt 0 ]; then
-		"$SDA_CLI" upload \
-			-config "$S3_CONFIG" \
+		"$SDA_CLI" -config "$S3_CONFIG" upload \
 			${target_dir+-targetDir "$target_dir"} \
 			"$@"
 	fi


### PR DESCRIPTION
## Related issue(s) and PR(s)
Nothing related.

## Description
This `sda-admin` tool calls `sda-cli` and passed arguments in the wrong order.

According to the [source code of the `sda-cli`](https://github.com/NBISweden/sda-cli/blob/a53801fd3a69987b798b4d9283ed89fe0745c622/main.go#L26C1-L26C54), the latest version expects a `-config` argument before a (sub)command:
> `Usage: %s [-config <config-file>] <command> [OPTIONS]`

## How to test
Before patch, `sda-cli` complained about the arguments:
```
> sda-admin upload files/file-01
flag provided but not defined: -config
```
After the patch, the `sda-cli` and the `sda-admin` work as expected.