### PR TITLE
K3d minor improvements and fixes

### DIFF
--- a/.github/integration/scripts/charts/dependencies.yaml
+++ b/.github/integration/scripts/charts/dependencies.yaml
@@ -91,6 +91,14 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        volumeMounts:
+          - mountPath: /shared/keys
+            name: jwt
+      volumes:
+        - name: jwt
+          secret:
+            defaultMode: 288
+            secretName: jwk
 ---
 apiVersion: v1
 kind: Service

--- a/.github/integration/sda/rbac.json
+++ b/.github/integration/sda/rbac.json
@@ -69,6 +69,9 @@
        {
           "role": "testu@lifescience-ri.eu",
           "rolebinding": "admin"
-       }
+       }, {
+        "role": "requester@demo.org",
+        "rolebinding": "admin"
+      }
     ]
  }

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 3.0.2
+version: 3.0.3
 appVersion: v2.1.7
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -172,7 +172,7 @@ Parameter | Description | Default
 `global.inbox.s3ReadyPath` | Endpoint to verify that the inbox is respondig. |`""`
 `global.sync.api.password` | Password for authenticating to the syncAPI server | `null`
 `global.sync.api.user` | User for authenticating to the syncAPI server | `null`
-`global.sync.brokerQueue` | Queue to read messages from | `sync`
+`global.sync.brokerQueue` | Queue to read messages from | `mapping_stream`
 `global.sync.centerPrefix` | Prefix for locally generated datasets | `null`
 `global.sync.destination.storageType` | Storage type for the sync destination, currently only supports S3 | `s3`
 `global.sync.destination.accesskey` | Access key to S3 sync destination | `null`

--- a/charts/sda-svc/templates/sync-secrets.yaml
+++ b/charts/sda-svc/templates/sync-secrets.yaml
@@ -41,7 +41,7 @@ stringData:
       port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
       prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
       password: {{ required "MQ password is required" (include "mqPassMapper" .) }}
-      queue: {{ default "mappings" .Values.global.broker.finalizeQueue }}
+      queue: {{ default "mapping_stream" .Values.global.broker.finalizeQueue }}
     {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
       serverName: {{.Values.global.broker.serverName }}
     {{- end }}

--- a/charts/sda-svc/templates/sync-secrets.yaml
+++ b/charts/sda-svc/templates/sync-secrets.yaml
@@ -41,7 +41,7 @@ stringData:
       port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
       prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
       password: {{ required "MQ password is required" (include "mqPassMapper" .) }}
-      queue: {{ default "mapping_stream" .Values.global.broker.finalizeQueue }}
+      queue: {{ default "mapping_stream" .Values.global.sync.brokerQueue }}
     {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
       serverName: {{.Values.global.broker.serverName }}
     {{- end }}

--- a/charts/sda-svc/templates/syncapi-secrets.yaml
+++ b/charts/sda-svc/templates/syncapi-secrets.yaml
@@ -45,13 +45,6 @@ stringData:
       api:
         password: {{ required "sync API password is required" .Values.global.sync.api.password }}
         user: {{ required "sync API user is required" .Values.global.sync.api.user }}
-      brokerQueue: {{ default "mapping_stream" .Values.global.sync.brokerQueue }}
-      centerPrefix: {{ .Values.global.sync.centerPrefix }}
-      remote:
-        host: {{ required "remote sync API host is required" .Values.global.sync.remote.host }}
-        password: {{ required "remote sync API password is required" .Values.global.sync.remote.password }}
-        port: {{ .Values.global.sync.remote.port }}
-        user: {{ required "remote sync API user is required" .Values.global.sync.remote.user }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sda-svc/templates/syncapi-secrets.yaml
+++ b/charts/sda-svc/templates/syncapi-secrets.yaml
@@ -45,7 +45,7 @@ stringData:
       api:
         password: {{ required "sync API password is required" .Values.global.sync.api.password }}
         user: {{ required "sync API user is required" .Values.global.sync.api.user }}
-      brokerQueue: {{ default "mappings" .Values.global.sync.brokerQueue }}
+      brokerQueue: {{ default "mapping_stream" .Values.global.sync.brokerQueue }}
       centerPrefix: {{ .Values.global.sync.centerPrefix }}
       remote:
         host: {{ required "remote sync API host is required" .Values.global.sync.remote.host }}

--- a/charts/sda-svc/templates/verify-deploy.yaml
+++ b/charts/sda-svc/templates/verify-deploy.yaml
@@ -91,7 +91,7 @@ spec:
         - name: config
           secret:
             defaultMode: 0440
-            secretName: {{ template "sda.fullname" . }}-ingest
+            secretName: {{ template "sda.fullname" . }}-verify
         - name: c4gh
           secret:
             defaultMode: 0440

--- a/charts/sda-svc/templates/verify-secrets.yaml
+++ b/charts/sda-svc/templates/verify-secrets.yaml
@@ -47,7 +47,9 @@ stringData:
     {{- end }}
       ssl: {{ .Values.global.tls.enabled }}
       user: {{ required "MQ user is required" (include "mqUserIngest" .) }}
+      {{- if .Values.global.tls.enabled }}
       verifyPeer: {{ .Values.global.broker.verifyPeer }}
+      {{- end }}
       vhost: {{ include "brokerVhost" . }}
     c4gh:
       privateKeys:

--- a/charts/sda-svc/templates/verify-secrets.yaml
+++ b/charts/sda-svc/templates/verify-secrets.yaml
@@ -39,14 +39,14 @@ stringData:
       host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
       port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
       prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
-      password: {{ required "MQ password is required" (include "mqPassIngest" .) }}
+      password: {{ required "MQ password is required" (include "mqPassVerify" .) }}
       queue: {{ default "archived" .Values.global.broker.verifyQueue }}
       routingKey: {{ default "verified" .Values.global.broker.routingKey }}
     {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
       serverName: {{.Values.global.broker.serverName }}
     {{- end }}
       ssl: {{ .Values.global.tls.enabled }}
-      user: {{ required "MQ user is required" (include "mqUserIngest" .) }}
+      user: {{ required "MQ user is required" (include "mqUserVerify" .) }}
       {{- if .Values.global.tls.enabled }}
       verifyPeer: {{ .Values.global.broker.verifyPeer }}
       {{- end }}


### PR DESCRIPTION
## Description

This PR aims to fix and increase the amount of working functionalities when running the system with k3d.

Bumps version of sda-svc helm chart from 3.0.2 -> 3.0.3

Fixes: 
* Setting default value of broker.Queue of [sda-sync secret](charts/sda-svc/templates/sync-secrets.yaml) to mapping_stream (as documented in [sync.md](sda/cmd/sync/sync.md)) and populate from .Values.global.sync.brokerQueue instead of .Values.global.broker.finalizeQueue
* Fix [sda-verify deployment template](charts/sda-svc/templates/verify-deploy.yaml) to load in the verify secret instead of ingest secret
* Fix [sda-verify secret template](charts/sda-svc/templates/verify-secrets.yaml) to only set broker.VerifyPeer if .Values.global.tls.enabled is true

Impovements:
* Add the requestor@demo.org user as admin in the [rbac](.github/integration/sda/rbac.json) config
* Mount the JWT keys to the [oidc deployment](.github/integration/scripts/charts/dependencies.yaml) such that the tokens can be signed with the private key associated to the the public key services will use to authenticate requests


## How to test

Follow the the k3d [Makefile](Makefile) commands 
``` bash
k3d-create-cluster
k3d-deploy-dependencies-isolated
k3d-import-images
k3d-deploy-postgres
k3d-deploy-rabbitmq-isolated
k3d-deploy-sda-s3-isolated
```

Then confirm that the upload, ingest, verification, accession, etc functionalities are operational