### PR TITLE
[sda-doa] remove Github packages registry configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  maven-github-elixir-no:
-    type: maven-repository
-    url: 'https://maven.pkg.github.com/ELIXIR-NO'
-    username: '${{secrets.DOA_MAVEN_GITHUB_USERNAME}}'
-    password: '${{secrets.DOA_MAVEN_GITHUB_TOKEN}}'
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -91,7 +85,6 @@ updates:
 
   - package-ecosystem: maven
     directory: "/sda-doa"
-    registries: "*"
     groups:
       all-modules:
         patterns:
@@ -192,7 +185,6 @@ updates:
   - package-ecosystem: maven
     target-branch: release_v1
     directory: "/sda-doa"
-    registries: "*"
     groups:
       all-modules:
         patterns:

--- a/.github/integration/sda-doa-posix-outbox.yml
+++ b/.github/integration/sda-doa-posix-outbox.yml
@@ -130,7 +130,6 @@ services:
     volumes:
       - ../../sda-doa/src:/sda-doa/src
       - ../../sda-doa/pom.xml:/sda-doa/pom.xml
-      - ../../sda-doa/settings.xml:/root/.m2/settings.xml
       - test_file:/sda-doa/outbox
       - ./tests:/tests
       - encryption_files:/test

--- a/.github/integration/sda-doa-s3-outbox.yml
+++ b/.github/integration/sda-doa-s3-outbox.yml
@@ -157,7 +157,6 @@ services:
     volumes:
       - ../../sda-doa/src:/sda-doa/src
       - ../../sda-doa/pom.xml:/sda-doa/pom.xml
-      - ../../sda-doa/settings.xml:/root/.m2/settings.xml
       - ./tests:/tests
       - encryption_files:/test
       - client_certs:/certs

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -189,21 +189,6 @@ jobs:
           sarif_file: 'inbox-results.sarif'
           category: sftp-inbox
 
-
-      - name: create maven settings.xml
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          servers: |
-            [{
-              "id":"github-fega-norway",
-              "username": "${{github.actor}}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
-
-      - name: Copy settings.xml to sda-doa root
-        shell: bash
-        run: cp /home/runner/.m2/settings.xml ./sda-doa/settings.xml
-
       - name: Build container for sda-doa
         uses: docker/build-push-action@v6
         with:
@@ -300,20 +285,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
-
-      - name: create maven settings.xml
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          servers: |
-            [{
-              "id":"github-fega-norway",
-              "username": "${{github.actor}}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
-
-      - name: Copy settings.xml to sda-doa root
-        shell: bash
-        run: cp /home/runner/.m2/settings.xml ./sda-doa/settings.xml
 
       - name: Test sda-doa for ${{ matrix.storage }} storage
         run: docker compose -f .github/integration/sda-doa-${{ matrix.storage }}-outbox.yml run integration_test

--- a/README.md
+++ b/README.md
@@ -46,29 +46,6 @@ To build the `sda-admin` CLI tool:
 ```sh
 $ make build-sda-admin
 ```
-
-To build the `sda-doa`:
-
-SDA-DOA uses two JARs hosted on Github Packages. To build the Docker image successfully , you need to provide authentication credentials to access the GitHub package registry.
-####  Required Setup: `settings.xml`
-
-Create a `settings.xml` file in the root directory (next to the Dockerfile in /sda-doa), and include the following content:
-
-```xml
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <servers>
-    <server>
-      <id>github-fega-norway</id>
-      <username>YOUR_GITHUB_USERNAME</username>
-      <password>YOUR_GITHUB_PERSONAL_ACCESS_TOKEN</password>
-    </server>
-  </servers>
-</settings>
-```
-Replace `YOUR_GITHUB_USERNAME` and `YOUR_GITHUB_PERSONAL_ACCESS_TOKEN` with your actual GitHub username and personal access token, respectively. The personal access token should have the `read:packages` scope.
-
 ```sh
 $ make build-sda-doa
 ```

--- a/sda-doa/Dockerfile
+++ b/sda-doa/Dockerfile
@@ -5,8 +5,6 @@ COPY pom.xml .
 RUN mkdir -p /root/.m2 && \
     mkdir /root/.m2/repository
 
-COPY settings.xml /root/.m2
-
 RUN mvn dependency:go-offline --no-transfer-progress
 
 COPY src/ /src/

--- a/sda-doa/pom.xml
+++ b/sda-doa/pom.xml
@@ -136,13 +136,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>github-fega-norway</id>
-            <url>https://maven.pkg.github.com/ELIXIR-NO/FEGA-Norway</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Description
2 libs (crypt4gh and clearinghouse) that sda-doa uses used to be on github packages, so we had some extra config in place to pull them. Now they’re on Maven central, so we don’t need that config anymore. This pr removes all the github-auth related snippets.