### PR TITLE
[release_v1][sda-doa] remove Github packages registry configuration

### DIFF
--- a/.github/integration/sda-doa-posix-outbox.yml
+++ b/.github/integration/sda-doa-posix-outbox.yml
@@ -130,7 +130,6 @@ services:
     volumes:
       - ../../sda-doa/src:/sda-doa/src
       - ../../sda-doa/pom.xml:/sda-doa/pom.xml
-      - ../../sda-doa/settings.xml:/root/.m2/settings.xml
       - test_file:/sda-doa/outbox
       - ./tests:/tests
       - encryption_files:/test

--- a/.github/integration/sda-doa-s3-outbox.yml
+++ b/.github/integration/sda-doa-s3-outbox.yml
@@ -159,7 +159,6 @@ services:
     volumes:
       - ../../sda-doa/src:/sda-doa/src
       - ../../sda-doa/pom.xml:/sda-doa/pom.xml
-      - ../../sda-doa/settings.xml:/root/.m2/settings.xml
       - ./tests:/tests
       - encryption_files:/test
       - client_certs:/certs

--- a/.github/workflows/build_pr_container.yaml
+++ b/.github/workflows/build_pr_container.yaml
@@ -189,21 +189,6 @@ jobs:
           sarif_file: 'inbox-results.sarif'
           category: sftp-inbox
 
-
-      - name: create maven settings.xml
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          servers: |
-            [{
-              "id":"github-fega-norway",
-              "username": "${{github.actor}}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
-
-      - name: Copy settings.xml to sda-doa root
-        shell: bash
-        run: cp /home/runner/.m2/settings.xml ./sda-doa/settings.xml
-
       - name: Build container for sda-doa
         uses: docker/build-push-action@v6
         with:
@@ -281,20 +266,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
-
-      - name: create maven settings.xml
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          servers: |
-            [{
-              "id":"github-fega-norway",
-              "username": "${{github.actor}}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
-
-      - name: Copy settings.xml to sda-doa root
-        shell: bash
-        run: cp /home/runner/.m2/settings.xml ./sda-doa/settings.xml
 
       - name: Test sda-doa for ${{ matrix.storage }} storage
         run: docker compose -f .github/integration/sda-doa-${{ matrix.storage }}-outbox.yml run integration_test

--- a/sda-doa/Dockerfile
+++ b/sda-doa/Dockerfile
@@ -5,8 +5,6 @@ COPY pom.xml .
 RUN mkdir -p /root/.m2 && \
     mkdir /root/.m2/repository
 
-COPY settings.xml /root/.m2
-
 RUN mvn dependency:go-offline --no-transfer-progress
 
 COPY src/ /src/

--- a/sda-doa/pom.xml
+++ b/sda-doa/pom.xml
@@ -136,13 +136,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>github-fega-norway</id>
-            <url>https://maven.pkg.github.com/ELIXIR-NO/FEGA-Norway</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Description
2 libs (crypt4gh and clearinghouse) that sda-doa uses used to be on github packages, so we had some extra config in place to pull them. Now they’re on Maven central, so we don’t need that config anymore. This pr removes all the github-auth related snippets.
