### PR TITLE
[charts][sda-svc] Parameterize all probes

### DIFF
--- a/.github/integration/scripts/charts/deploy_charts.sh
+++ b/.github/integration/scripts/charts/deploy_charts.sh
@@ -8,9 +8,13 @@ fi
 
 MQ_PORT=5672
 PROTOCOL=http
+SCHEME=HTTP
+GRPC_PORT=50051
 if [ "$3" == "true" ]; then
     MQ_PORT=5671
     PROTOCOL=https
+    SCHEME=HTTPS
+    GRPC_PORT=50443
 fi
 
 dir=".github/integration/scripts/charts"
@@ -69,6 +73,12 @@ if [ "$1" == "sda-svc" ]; then
         --set global.sync.api.password="$sync_api_pass" \
         --set global.sync.api.user="$sync_api_user" \
         --set global.sync.remote.host="$sync_host" \
+        --set api.readinessProbe.httpGet.scheme:="$SCHEME" \
+        --set auth.readinessProbe.httpGet.scheme:="$SCHEME" \
+        --set download.readinessProbe.httpGet.scheme:="$SCHEME" \
+        --set s3inbox.readinessProbe.httpGet.scheme:="$SCHEME" \
+        --set syncAPI.readinessProbe.httpGet.scheme:="$SCHEME" \
+        --set reencrypt.readinessProbe.grpc.port="$GRPC_PORT" \
         -f "$dir/values.yaml" \
         --wait
 fi

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 3.0.3
+version: 3.0.4
 appVersion: v2.1.7
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/README.md
+++ b/charts/sda-svc/README.md
@@ -239,6 +239,8 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `api.replicaCount` | Desired number of replicas | `2`
 `api.annotations` | Specific annotation for the auth pod | `{}`
+`api.livenessProbe` | Liveness definition for the api pod. |`{}`
+`api.readinessProbe` | Rediness definition for the api pod. |`{}`
 `api.resources.requests.memory` | Memory request for container. |`128Mi`
 `api.resources.requests.cpu` | CPU request for container. |`100m`
 `api.resources.limits.memory` | Memory limit for container. |`256Mi`
@@ -246,19 +248,17 @@ Parameter | Description | Default
 `api.tls.secretName` | Secret holding the application TLS certificates |``
 `auth.replicaCount` | desired number of replicas | `2`
 `auth.annotations` | Specific annotation for the auth pod | `{}`
+`auth.livenessProbe` | Liveness definition for the auth pod. |`{}`
+`auth.readinessProbe` | Rediness definition for the auth pod. |`{}`
 `auth.resources.requests.memory` | Memory request for container. |`128Mi`
 `auth.resources.requests.cpu` | CPU request for container. |`100m`
 `auth.resources.limits.memory` | Memory limit for container. |`256Mi`
 `auth.resources.limits.cpu` | CPU limit for container. |`250m`
-`sync.annotations` | Specific annotation for the sync pod | `{}`
-`sync.resources.requests.memory` | Memory request for sync container. |`128Mi`
-`sync.resources.requests.cpu` | CPU request for sync container. |`100m`
-`sync.resources.limits.memory` | Memory limit for sync container. |`256Mi`
-`sync.resources.limits.cpu` | CPU limit for sync container. |`250m`
-`sync.deploy` | Set to true if the sync service should be active | `false`
 `doa.replicaCount` | desired number of replicas | `2`
 `doa.keystorePass` | keystore password | `changeit`
 `doa.annotations` | Specific annotation for the doa pod | `{}`
+`doa.livenessProbe` | Liveness definition for the doa pod. |`{}`
+`doa.readinessProbe` | Rediness definition for the doa pod. |`{}`
 `doa.resources.requests.memory` | Memory request for dataedge container. |`128Mi`
 `doa.resources.requests.cpu` | CPU request for dataedge container. |`100m`
 `doa.resources.limits.memory` | Memory limit for dataedge container. |`1024Mi`
@@ -266,6 +266,8 @@ Parameter | Description | Default
 `download.replicaCount` | desired number of replicas | `2`
 `download.keystorePass` | keystore password | `changeit`
 `download.annotations` | Specific annotation for the dataedge pod | `{}`
+`download.livenessProbe` | Liveness definition for the download pod. |`{}`
+`download.readinessProbe` | Rediness definition for the download pod. |`{}`
 `download.resources.requests.memory` | Memory request for dataedge container. |`256Mi`
 `download.resources.requests.cpu` | CPU request for dataedge container. |`100m`
 `download.resources.limits.memory` | Memory limit for dataedge container. |`512Mi`
@@ -289,6 +291,8 @@ Parameter | Description | Default
 `intercept.resources.limits.cpu` | CPU limit for intercept container. |`2000m`
 `s3Inbox.replicaCount`| desired number of S3inbox containers | `2`
 `s3Inbox.annotations` | Specific annotation for the S3inbox pod | `{}`
+`s3Inbox.livenessProbe` | Liveness definition for the s3Inbox pod. |`{}`
+`s3Inbox.readinessProbe` | Rediness definition for the S3inbox pod. |`{}`
 `s3Inbox.resources.requests.memory` | Memory request for s3Inbox container. |`128Mi`
 `s3Inbox.resources.requests.cpu` | CPU request for s3Inbox container. |`100m`
 `s3Inbox.resources.limits.memory` | Memory limit for s3Inbox container. |`1024Mi`
@@ -297,18 +301,22 @@ Parameter | Description | Default
 `sftpInbox.keystorePass` | sftp inbox keystore password | `changeit`
 `sftpInbox.nodeHostname` | Node name if the sftp inbox  needs to be deployed on a specific node | `""`
 `sftpInbox.annotations` | Specific annotation for the sftp inbox pod | `{}`
+`sftpInbox.livenessProbe` | Liveness definition for the sftpInbox pod. |`{}`
+`sftpInbox.readinessProbe` | Rediness definition for the sftpInbox pod. |`{}`
 `sftpInbox.resources.requests.memory` | Memory request for sftpInbox container. |`128Mi`
 `sftpInbox.resources.requests.cpu` | CPU request for sftpInbox container. |`100m`
 `sftpInbox.resources.limits.memory` | Memory limit for sftpInbox container. |`256Mi`
 `sftpInbox.resources.limits.cpu` | CPU limit for sftpInbox container. |`250m`
-`sync.replicaCount`| desired number of sync containers | `1`
 `sync.annotations` | Specific annotation for the sync pod | `{}`
+`sync.deploy` | Set to true if the sync service should be active | `false`
+`sync.replicaCount`| desired number of sync containers | `1`
 `sync.resources.requests.memory` | Memory request for sync container. |`128Mi`
 `sync.resources.requests.cpu` | CPU request for sync container. |`100m`
 `sync.resources.limits.memory` | Memory limit for sync container. |`512Mi`
 `sync.resources.limits.cpu` | CPU limit for sync container. |`500m`
 `syncAPI.replicaCount`| desired number of syncAPI containers | `1`
 `syncAPI.annotations` | Specific annotation for the syncAPI pod | `{}`
+`syncAPI.readinessProbe` | Rediness definition for the syncAPI pod. |`{}`
 `syncAPI.resources.requests.memory` | Memory request for syncAPI container. |`64Mi`
 `syncAPI.resources.requests.cpu` | CPU request for syncAPI container. |`100m`
 `syncAPI.resources.limits.memory` | Memory limit for syncAPI container. |`256Mi`

--- a/charts/sda-svc/templates/api-deploy.yaml
+++ b/charts/sda-svc/templates/api-deploy.yaml
@@ -78,25 +78,9 @@ spec:
           containerPort: 8080
           protocol: TCP
         livenessProbe:
-          httpGet:
-            port: api
-            path: /ready
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.api }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
+{{ toYaml .Values.api.livenessProbe | trim | indent 10 }}
         readinessProbe:
-          httpGet:
-            port: api
-            path: /ready
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.api }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
+{{ toYaml .Values.api.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.api.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -79,25 +79,9 @@ spec:
           containerPort: 8080
           protocol: TCP
         livenessProbe:
-          httpGet:
-            port: auth
-            path: /
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.auth }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
+{{ toYaml .Values.auth.livenessProbe | trim | indent 10 }}
         readinessProbe:
-          httpGet:
-            port: auth
-            path: /
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.auth }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
+{{ toYaml .Values.auth.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.auth.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -257,15 +257,9 @@ spec:
           containerPort: 8080
           protocol: TCP
         livenessProbe:
-          tcpSocket:
-            port: doa
-          initialDelaySeconds: 120
-          periodSeconds: 30
+{{ toYaml .Values.doa.livenessProbe | trim | indent 10 }}
         readinessProbe:
-          tcpSocket:
-            port: doa
-          initialDelaySeconds: 30
-          periodSeconds: 15
+{{ toYaml .Values.doa.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.doa.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -76,35 +76,9 @@ spec:
           containerPort: {{ ternary 8443 8080 .Values.global.tls.enabled }}
           protocol: TCP
         livenessProbe:
-          httpGet:
-            port: download
-            path: /health
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.download }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
+{{ toYaml .Values.download.livenessProbe | trim | indent 10 }}
         readinessProbe:
-          httpGet:
-            port: download
-            path: /health
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.download }}
-          initialDelaySeconds: 20
-          periodSeconds: 10
-        startupProbe:
-          httpGet:
-            path: /health
-            port: download
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled) }}
-            httpHeaders:
-            - name: Host
-              value: {{ .Values.global.ingress.hostName.download }}
-          failureThreshold: 30
-          periodSeconds: 10
+{{ toYaml .Values.download.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.download.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/templates/re-encrypt-deploy.yaml
+++ b/charts/sda-svc/templates/re-encrypt-deploy.yaml
@@ -59,11 +59,7 @@ spec:
           - name: grpchealth
             containerPort: {{add ( ternary 50443 50051 ( .Values.global.tls.enabled ) ) 1 }}
         readinessProbe:
-          initialDelaySeconds: 5
-          timeoutSeconds: 2
-          grpc:
-            port: {{add ( ternary 50443 50051 ( .Values.global.tls.enabled ) ) 1 }}
-            service: "reencrypt.Reencrypt"
+{{ toYaml .Values.reencrypt.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.reencrypt.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/templates/s3-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/s3-inbox-deploy.yaml
@@ -97,19 +97,9 @@ spec:
           containerPort: 8000
           protocol: TCP
         livenessProbe:
-          httpGet:
-            path: /health
-            port: inbox
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
-          failureThreshold: 1
-          periodSeconds: 10
+{{ toYaml .Values.s3Inbox.livenessProbe | trim | indent 10 }}
         readinessProbe:
-          httpGet:
-            path: /health
-            port: inbox
-            scheme: {{ ternary "HTTPS" "HTTP" ( .Values.global.tls.enabled ) }}
-          failureThreshold: 1
-          periodSeconds: 5
+{{ toYaml .Values.s3Inbox.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.s3Inbox.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -154,21 +154,9 @@ spec:
           containerPort: 2222
           protocol: TCP
         livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - netstat -an | grep -q ':2222 '
-          initialDelaySeconds: 120
-          periodSeconds: 5
+{{ toYaml .Values.sftpInbox.livenessProbe | trim | indent 10 }}
         readinessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - netstat -an | grep -q ':2222 '
-          initialDelaySeconds: 30
-          periodSeconds: 5
+{{ toYaml .Values.sftpInbox.readinessProbe | trim | indent 10 }}
         volumeMounts:
         - name: inbox
           mountPath: "/ega/inbox"

--- a/charts/sda-svc/templates/syncapi-deploy.yaml
+++ b/charts/sda-svc/templates/syncapi-deploy.yaml
@@ -80,10 +80,7 @@ spec:
           containerPort: 8080
           protocol: TCP
         readinessProbe:
-          tcpSocket:
-            port: syncapi
-          initialDelaySeconds: 10
-          periodSeconds: 5
+{{ toYaml .Values.syncapi.readinessProbe | trim | indent 10 }}
         resources:
 {{ toYaml .Values.syncapi.resources | trim | indent 10 }}
         volumeMounts:

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -373,6 +373,21 @@ credentials:
 api:
   name: api
   replicaCount: 2
+  livenessProbe:
+    # httpGet:
+    #   port: api
+    #   path: /ready
+    #   scheme: "HTTPS"
+    # initialDelaySeconds: 20
+    # periodSeconds: 60
+    # timeoutSeconds: 30
+  readinessProbe:
+    httpGet:
+      port: api
+      path: /ready
+      scheme: "HTTPS"
+    periodSeconds: 10
+    timeoutSeconds: 9
   resources:
     requests:
       memory: "128Mi"
@@ -390,6 +405,22 @@ api:
 auth:
   name: auth
   replicaCount: 2
+  livenessProbe:
+    # httpGet:
+    #   port: auth
+    #   path: /
+    #   scheme: "HTTPS"
+    #   httpHeaders:
+    # initialDelaySeconds: 20
+    # periodSeconds: 60
+    # timeoutSeconds: 30
+  readinessProbe:
+    httpGet:
+      port: auth
+      path: /
+      scheme: "HTTPS"
+    periodSeconds: 10
+    timeoutSeconds: 9
   resources:
     requests:
       memory: "128Mi"
@@ -408,6 +439,15 @@ doa:
   name: doa
   imagePullPolicy: IfNotPresent
   replicaCount: 2
+  livenessProbe:
+    # tcpSocket:
+    #   port: doa
+    # initialDelaySeconds: 120
+    # periodSeconds: 30
+  readinessProbe:
+    tcpSocket:
+      port: doa
+    periodSeconds: 15
   resources:
     requests:
       memory: "256Mi"
@@ -428,6 +468,21 @@ doa:
 download:
   name: download
   replicaCount: 2
+  livenessProbe:
+    # httpGet:
+    #   path: /health
+    #   port: download
+    #   scheme: "HTTPS"
+    # initialDelaySeconds: 20
+    # periodSeconds: 60
+    # timeoutSeconds: 30
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: download
+      scheme: "HTTPS"
+    periodSeconds: 10
+    timeoutSeconds: 9
   resources:
     requests:
       memory: "256Mi"
@@ -511,6 +566,12 @@ mapper:
 
 reencrypt:
   replicaCount: 1
+  readinessProbe:
+    periodSeconds: 10
+    timeoutSeconds: 2
+    grpc:
+      port: 50443
+      service: "reencrypt.Reencrypt"
   resources:
     requests:
       memory: "128Mi"
@@ -528,6 +589,22 @@ reencrypt:
 s3Inbox:
   name: s3Inbox
   replicaCount: 2
+  livenessProbe:
+    # httpGet:
+    #   path: /health
+    #   port: inbox
+    #   scheme: "HTTPS"
+    # failureThreshold: 1
+    # periodSeconds: 60
+    # timeoutSeconds: 55
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: inbox
+      scheme: "HTTPS"
+    failureThreshold: 1
+    periodSeconds: 10
+    timeoutSeconds: 9
   resources:
     requests:
       memory: "128Mi"
@@ -545,6 +622,22 @@ s3Inbox:
 sftpInbox:
   name: sftpInbox
   replicaCount: 2
+  livenessProbe:
+    # exec:
+    #   command:
+    #   - /bin/sh
+    #   - -c
+    #   - netstat -an | grep -q ':2222 '
+    # initialDelaySeconds: 120
+    # periodSeconds: 30
+    # timeoutSeconds: 25
+  readinessProbe:
+    exec:
+      command:
+      - /bin/sh
+      - -c
+      - netstat -an | grep -q ':2222 '
+    periodSeconds: 5
   resources:
     requests:
       memory: "128Mi"
@@ -581,6 +674,10 @@ sync:
 syncapi:
   name: sync-api
   replicaCount: 1
+  readinessProbe:
+    tcpSocket:
+      port: syncapi
+    periodSeconds: 5
   resources:
     requests:
       memory: "64Mi"


### PR DESCRIPTION
## Description
This allows for better control when dealing with sluggish network connections for external services.
It also allows for the administrator to determine which probes to run for a given service.