### PR TITLE
[reencrypt] handle multiple keys

### DIFF
--- a/charts/sda-svc/templates/re-encrypt-deploy.yaml
+++ b/charts/sda-svc/templates/re-encrypt-deploy.yaml
@@ -82,7 +82,7 @@ spec:
         - name: c4gh
           secret:
             defaultMode: 0440
-            secretName: {{ required "A secret for the c4gh key is required" .Values.global.c4gh.secretName }}
+            secretName: {{ required "A secret for the c4gh keys is required" .Values.global.c4gh.secretName }}
       {{- end }}
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/reencrypt-secrets.yaml
+++ b/charts/sda-svc/templates/reencrypt-secrets.yaml
@@ -9,10 +9,11 @@ type: Opaque
 stringData:
   config.yaml: |-
     c4gh:
-    {{- with (first .Values.global.c4gh.privateKeys) }}
-      filePath: {{ template "c4ghPath" $ }}/{{ .keyName }}
-      passphrase: {{ required "a passphrase for the c4gh key is required" .passphrase }}
-    {{-  end }}
+      privateKeys:
+      {{- range $k := .Values.global.c4gh.privateKeys }}
+        - filePath: {{ template "c4ghPath" $ }}/{{ $k.keyName }}
+          passphrase: {{ $k.passphrase }}
+      {{- end }}
     {{- if .Values.global.tls.enabled }}
     grpc:
       caCert: {{ template "tlsPath" . }}/ca.crt

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -49,7 +49,7 @@ var BrokerAPI string
 
 type server struct {
 	reencrypt.UnimplementedReencryptServer
-	c4ghPrivateKey *[32]byte
+	c4ghPrivateKeyList []*[32]byte
 }
 
 func (s *server) ReencryptHeader(ctx context.Context, req *reencrypt.ReencryptRequest) (*reencrypt.ReencryptResponse, error) {
@@ -532,7 +532,7 @@ func (s *TestSuite) SetupSuite() {
 	go func() {
 		var opts []grpc.ServerOption
 		s.GrpcListener.gs = grpc.NewServer(opts...)
-		reencrypt.RegisterReencryptServer(s.GrpcListener.gs, &server{c4ghPrivateKey: Conf.ReEncrypt.Crypt4GHKey})
+		reencrypt.RegisterReencryptServer(s.GrpcListener.gs, &server{c4ghPrivateKeyList: Conf.ReEncrypt.C4ghPrivateKeyList})
 		if err := s.GrpcListener.gs.Serve(s.GrpcListener.Listener); err != nil {
 			s.T().Fail()
 		}

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -66,8 +66,8 @@ type Grpc struct {
 
 type ReEncConfig struct {
 	Grpc
-	Crypt4GHKey *[32]byte
-	Timeout     int
+	C4ghPrivateKeyList []*[32]byte
+	Timeout            int
 }
 
 type Sync struct {
@@ -386,8 +386,7 @@ func NewConfig(app string) (*Config, error) {
 		}
 	case "reencrypt":
 		requiredConfVars = []string{
-			"c4gh.filepath",
-			"c4gh.passphrase",
+			"c4gh.privateKeys",
 		}
 	case "s3inbox":
 		requiredConfVars = []string{
@@ -1007,9 +1006,12 @@ func (c *Config) configReEncryptServer() (err error) {
 		c.ReEncrypt.Port = 50443
 	}
 
-	c.ReEncrypt.Crypt4GHKey, err = GetC4GHKey()
+	c.ReEncrypt.C4ghPrivateKeyList, err = GetC4GHprivateKeys()
 	if err != nil {
 		return err
+	}
+	if len(c.ReEncrypt.C4ghPrivateKeyList) == 0 {
+		return errors.New("no C4GH private keys configured")
 	}
 
 	return nil


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1241.


## Description
This PR configures the reencrypt service to be able to handle multiple encryption keys.

## How to test
