### PR TITLE
[Hotfix][charts] disable servicelinks

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 3.0.12
+version: 3.0.13
 appVersion: v3.0.14
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/templates/api-deploy.yaml
+++ b/charts/sda-svc/templates/api-deploy.yaml
@@ -100,6 +100,7 @@ spec:
         - name: inbox
           mountPath: "/inbox"
     {{- end }}
+      enableServiceLinks: false
       volumes:
     {{- if not .Values.global.vaultSecrets }}
         - name: config

--- a/charts/sda-svc/templates/auth-deploy.yaml
+++ b/charts/sda-svc/templates/auth-deploy.yaml
@@ -99,6 +99,7 @@ spec:
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if not .Values.global.vaultSecrets }}
         {{- if and (.Values.global.auth.resignJwt) (not .Values.global.vaultSecrets) }}

--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -281,6 +281,7 @@ spec:
         - name: archive
           mountPath: {{ .Values.global.archive.volumePath | quote }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/sda-svc/templates/download-deploy.yaml
+++ b/charts/sda-svc/templates/download-deploy.yaml
@@ -100,6 +100,7 @@ spec:
         - name: archive
           mountPath: {{ .Values.global.archive.volumePath | quote }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/finalize-deploy.yaml
+++ b/charts/sda-svc/templates/finalize-deploy.yaml
@@ -92,6 +92,7 @@ spec:
         - name: backup
           mountPath: {{ .Values.global.backupArchive.volumePath | quote }}
     {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if not .Values.global.vaultSecrets }}
         - name: config

--- a/charts/sda-svc/templates/ingest-deploy.yaml
+++ b/charts/sda-svc/templates/ingest-deploy.yaml
@@ -95,6 +95,7 @@ spec:
         - name: inbox
           mountPath: {{ .Values.global.inbox.path | quote }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
     {{- if not .Values.global.vaultSecrets }}
         - name: config

--- a/charts/sda-svc/templates/intercept-deploy.yaml
+++ b/charts/sda-svc/templates/intercept-deploy.yaml
@@ -70,6 +70,7 @@ spec:
         - name: tls
           mountPath: {{ template "tlsPath" . }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
         - name: config
           projected:

--- a/charts/sda-svc/templates/mapper-deploy.yaml
+++ b/charts/sda-svc/templates/mapper-deploy.yaml
@@ -71,6 +71,7 @@ spec:
         - name: inbox
           mountPath: {{ .Values.global.inbox.path | quote }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if not .Values.global.vaultSecrets }}
         - name: config

--- a/charts/sda-svc/templates/re-encrypt-deploy.yaml
+++ b/charts/sda-svc/templates/re-encrypt-deploy.yaml
@@ -73,6 +73,7 @@ spec:
         - name: tls
           mountPath: {{ template "tlsPath" . }}
         {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if not .Values.global.vaultSecrets }}
         - name: config

--- a/charts/sda-svc/templates/release-test-deploy.yml
+++ b/charts/sda-svc/templates/release-test-deploy.yml
@@ -89,6 +89,7 @@ spec:
       command: [ "/bin/bash" ]
       args:
         - "/release-test-app/release-test.sh"
+  enableServiceLinks: false
   volumes:
     {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
       - name: certs

--- a/charts/sda-svc/templates/s3-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/s3-inbox-deploy.yaml
@@ -115,6 +115,7 @@ spec:
           mountPath: {{ include "jwtPath" . }}
         {{- end }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/sftp-inbox-deploy.yaml
+++ b/charts/sda-svc/templates/sftp-inbox-deploy.yaml
@@ -164,6 +164,7 @@ spec:
           mountPath: "/etc/ssl/certs/java"
         - name: tmp
           mountPath: /tmp/
+      enableServiceLinks: false
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/sda-svc/templates/sync-deploy.yaml
+++ b/charts/sda-svc/templates/sync-deploy.yaml
@@ -92,6 +92,7 @@ spec:
           - name: tls
             mountPath: {{ template "tlsPath" . }}
   {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls

--- a/charts/sda-svc/templates/syncapi-deploy.yaml
+++ b/charts/sda-svc/templates/syncapi-deploy.yaml
@@ -92,6 +92,7 @@ spec:
         - name: tls
           mountPath: {{ template "tlsPath" . }}
       {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if not .Values.global.vaultSecrets }}
         - name: config

--- a/charts/sda-svc/templates/verify-deploy.yaml
+++ b/charts/sda-svc/templates/verify-deploy.yaml
@@ -74,6 +74,7 @@ spec:
         - name: archive
           mountPath: {{ .Values.global.archive.volumePath | quote }}
         {{- end }}
+      enableServiceLinks: false
       volumes:
       {{- if and (not .Values.global.pkiService) .Values.global.tls.enabled }}
         - name: tls


### PR DESCRIPTION
## Description
This solves an issue when existing ENVs match our expected config ENVs while we rely on the config file for everything.

## How to test
Deploy RabbitMQ with the service name `BROKER` and try to deploy the SDA stack using the chart that targets another MQ deployment.
