### PR TITLE
bugfix fix sda-download range header issues

### DIFF
--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -286,18 +286,19 @@ func Download(c *gin.Context) {
 
 		return
 	}
+	start, end, err = calculateCoords(start, end, c.GetHeader("Range"), fileDetails, c.Param("type"))
+	if err != nil {
+		log.Errorf("Byte range coordinates invalid! %v", err)
+		c.String(http.StatusBadRequest, "Range header byte coordinates invalid")
+
+		return
+	}
 
 	wholeFile := true //nolint:staticcheck
 	if start != 0 || end != 0 {
 		wholeFile = false
 	}
 
-	start, end, err = calculateCoords(start, end, c.GetHeader("Range"), fileDetails, c.Param("type"))
-	if err != nil {
-		log.Errorf("Byte range coordinates invalid! %v", err)
-
-		return
-	}
 	if c.Param("type") != "encrypted" {
 		// set the content-length for unencrypted files
 		if start == 0 && end == 0 {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2125 


## Description
Fix issue with sda-download not respecting the start in the Range header, and return 400 if the range header can not be parsed as expected

## How to test
- Added and existing unit tests pass
