### PR TITLE
bugfix/correlation_id_deprecation_mig_fix

### DIFF
--- a/postgresql/migratedb.d/20_deprecate_files_event_log_correlation_id.sql
+++ b/postgresql/migratedb.d/20_deprecate_files_event_log_correlation_id.sql
@@ -12,70 +12,14 @@ BEGIN
     RAISE NOTICE 'Changes: %', changes;
     INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
 
-    -- Migrate data where files.id != file_event_log.correlation_id
-
-    -- First drop foreign key constraint so we can update values without constraint restriction
-    ALTER TABLE sda.file_event_log
-    DROP CONSTRAINT file_event_log_file_id_fkey;
-
-    ALTER TABLE sda.checksums
-    DROP CONSTRAINT checksums_file_id_fkey;
-
-    ALTER TABLE sda.file_dataset
-    DROP CONSTRAINT file_dataset_file_id_fkey;
-
-     -- Update all checksums which have a file_event_log where file_id != correlation_id
-    UPDATE sda.checksums AS cs
-    SET file_id = fel.correlation_id
-        FROM sda.file_event_log AS fel
-    WHERE cs.file_id = fel.file_id
-      AND fel.file_id != fel.correlation_id
-      AND fel.correlation_id IS NOT NULL;
-
-    -- Update all file_datasets which have a file_event_log where file_id != correlation_id
-    UPDATE sda.file_dataset AS fd
-    SET file_id = fel.correlation_id
-        FROM sda.file_event_log AS fel
-    WHERE fd.file_id = fel.file_id
-      AND fel.file_id != fel.correlation_id
-      AND fel.correlation_id IS NOT NULL;
-
-    -- Update all files which have a file_event_log where file_id != correlation_id
-    UPDATE sda.files AS f
-    SET id = fel.correlation_id
-        FROM sda.file_event_log AS fel
-    WHERE f.id = fel.file_id
-      AND fel.file_id != fel.correlation_id
-      AND fel.correlation_id IS NOT NULL;
-
-    -- Update all file_event_log where file_id != correlation_id
-    UPDATE sda.file_event_log AS f
-    SET file_id = fel.correlation_id
-        FROM sda.file_event_log AS fel
-    WHERE f.file_id = fel.file_id
-      AND fel.file_id != fel.correlation_id
-      AND fel.correlation_id IS NOT NULL;
-
-    -- Add back the foreign key constraint
-    ALTER TABLE sda.file_event_log
-        ADD CONSTRAINT file_event_log_file_id_fkey FOREIGN KEY (file_id)
-            REFERENCES sda.files(id);
-
-
-    ALTER TABLE sda.checksums
-        ADD CONSTRAINT checksums_file_id_fkey FOREIGN KEY (file_id)
-            REFERENCES sda.files(id);
-
-    ALTER TABLE sda.file_dataset
-        ADD CONSTRAINT file_dataset_file_id_fkey FOREIGN KEY (file_id)
-            REFERENCES sda.files(id);
-
-
+    -- Check that we have no file_event_log WHERE file_id != correlation_id before proceeding with migration
+    IF (SELECT COUNT(*) FROM sda.file_event_log WHERE file_id != correlation_id AND correlation_id IS NOT NULL) > 0 then
+        RAISE EXCEPTION 'Cannot proceed with migration since file_event_log rows exists where file_id != correlation_id';
+    END IF;
 
     -- Update RegisterFile func
     -- First drop it so we can create the updated version
     DROP FUNCTION IF EXISTS sda.register_file;
-
 
     -- Create updated function
     -- Function for registering files on upload


### PR DESCRIPTION
[PR](https://github.com/neicnordic/sensitive-data-archive/pull/2115) Introduced data migration for when correlation id differ from file_id, this migration had an issue and did not update the file_id in the `checksum` and `file_dataset` tables, but even with that addition the DB could end up in bad state after migration if for example a file has file_event_log entries with different correlation_ids per entry.

So instead just adding a prerequisite check to ensure we have no file_event_log rows WHERE file_id != correlation_id before proceeding with schema migration.
