### PR TITLE
[SDA] Prevent starting with an old DB schema

### DIFF
--- a/sda/cmd/finalize/finalize.go
+++ b/sda/cmd/finalize/finalize.go
@@ -37,6 +37,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if db.Version < 21 {
+		log.Error("database schema v21 is required")
+		db.Close()
+		panic(err)
+	}
 
 	if conf.Backup.Type != "" && conf.Archive.Type != "" {
 		log.Debugln("initiating storage backends")

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -70,8 +70,8 @@ func main() {
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	if app.DB.Version < 8 {
-		log.Error("database schema v8 is required")
+	if app.DB.Version < 21 {
+		log.Error("database schema v21 is required")
 		sigc <- syscall.SIGINT
 		panic(err)
 	}

--- a/sda/cmd/s3inbox/s3inbox.go
+++ b/sda/cmd/s3inbox/s3inbox.go
@@ -51,8 +51,8 @@ func main() {
 		sigc <- syscall.SIGINT
 		panic(err)
 	}
-	if sdaDB.Version < 4 {
-		log.Error("database schema v4 is required")
+	if sdaDB.Version < 21 {
+		log.Error("database schema v21 is required")
 		sigc <- syscall.SIGINT
 		panic(err)
 	}

--- a/sda/cmd/verify/verify.go
+++ b/sda/cmd/verify/verify.go
@@ -36,6 +36,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if db.Version < 21 {
+		log.Error("database schema v21 is required")
+		db.Close()
+		panic(err)
+	}
 	archive, err := storage.NewBackend(conf.Archive)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Components that create or interact with the correlation IDs are tightly bound to the DB schema and as such needs to only start on the correct version they can work with.


## How to test
