### PR TITLE
[release_v1] Backport config for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+version: "2"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+linters:
+  default: none
+  enable:
+    - bodyclose
+    - gocritic
+    - gosec
+    - govet
+    - nestif
+    - nlreturn
+    - revive
+    - rowserrcheck
+    - staticcheck
+  settings:
+    gosec:
+      excludes:
+        - G104
+        - G302
+        - G304
+        - G401
+        - G501
+    revive:
+      enable-all-rules: true
+      rules:
+      - name: add-constant
+        disabled: true
+      - name: bare-return
+        disabled: true
+      - name: cognitive-complexity # disable for now
+        disabled: true
+      - name: confusing-naming # disable for now
+        disabled: true
+      - name: confusing-results
+        disabled: true
+      - name: cyclomatic # disable for now, requires refactoring
+        disabled: true
+      - name: exported
+        disabled: true
+      - name: flag-parameter # this one requires refactoring
+        disabled: true
+      - name: function-length # this one requires refactoring
+        disabled: true
+      - name: get-return # this triggers on function names
+        disabled: true
+      - name: line-length-limit
+        disabled: true
+      - name: max-public-structs
+        disabled: true
+      - name: package-comments
+        disabled: true
+      - name: redundant-test-main-exit # disable for now (non-critical, needs checking)
+        disabled: true
+      - name: unchecked-type-assertion # disable for now
+        disabled: true
+      - name: unused-parameter # disable for now
+        disabled: true
+      - name: unused-receiver # disable for now
+        disabled: true


### PR DESCRIPTION
Backport the config so that the GO linter actions don't fail due to bad config with the new version of the linter.

