### PR TITLE
fix: add validator-orchestrator to docker pull loop

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Pull PR containers
         run : |
-          for t in -download -postgres -rabbitmq -sftp-inbox -doa; do
+          for t in -download -postgres -rabbitmq -sftp-inbox -doa -validator-orchestrator; do
             docker pull ghcr.io/${{ github.repository }}:PR${{ github.event.number }}$t
           done
           docker pull ghcr.io/${{ github.repository }}:PR${{ github.event.number }}


### PR DESCRIPTION
## Description
In publish_container workflow before the retagging steps, all images are being pulled in the "Pull PR containers" step. validator-orchestrator is missed in the loop to be pulled and in the "Retag PR image for sda-validator-orchestrator" step it cannot find the image and it fails. This pr fixes this bug.
