### PR TITLE
[sda-download] fix all non S3 related linter issues

### DIFF
--- a/sda-download/api/api_test.go
+++ b/sda-download/api/api_test.go
@@ -1,3 +1,4 @@
+// nolint:revive
 package api
 
 import (

--- a/sda-download/api/s3/s3.go
+++ b/sda-download/api/s3/s3.go
@@ -72,7 +72,7 @@ func GetBucketLocation(c *gin.Context) {
 		return
 	}
 	c.XML(http.StatusAccepted, LocationConstraint{
-		XMLns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		XMLns:    "https://s3.amazonaws.com/doc/2006-03-01/",
 		Location: "us-west-2",
 	})
 }

--- a/sda-download/api/s3/s3_test.go
+++ b/sda-download/api/s3/s3_test.go
@@ -72,7 +72,7 @@ func (ts *S3TestSuite) TestGetBucketLocation() {
 	assert.Nil(ts.T(), err, "failed to parse body from location response")
 	defer response.Body.Close()
 
-	expected := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">us-west-2</LocationConstraint>"
+	expected := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LocationConstraint xmlns=\"https://s3.amazonaws.com/doc/2006-03-01/\">us-west-2</LocationConstraint>"
 
 	assert.Equal(ts.T(), expected, string(body), "Wrong location from S3")
 }

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -1157,6 +1157,9 @@ func TestDownload_Range_FromStartOfFile(t *testing.T) {
 	config.Config.Reencrypt.Timeout = 10
 
 	privateKeyFilePath, err := GenerateTestC4ghKey(t)
+	if err != nil {
+		t.FailNow()
+	}
 	viper.Set("c4gh.transientKeyPath", privateKeyFilePath)
 	viper.Set("c4gh.transientPassphrase", "password")
 	config.Config.C4GH.PrivateKey, config.Config.C4GH.PublicKeyB64, err = config.GetC4GHKeys()
@@ -1263,6 +1266,9 @@ func TestDownload_Range_FromMiddleOfFile(t *testing.T) {
 	config.Config.Reencrypt.Timeout = 10
 
 	privateKeyFilePath, err := GenerateTestC4ghKey(t)
+	if err != nil {
+		t.FailNow()
+	}
 	viper.Set("c4gh.transientKeyPath", privateKeyFilePath)
 	viper.Set("c4gh.transientPassphrase", "password")
 	config.Config.C4GH.PrivateKey, config.Config.C4GH.PublicKeyB64, err = config.GetC4GHKeys()


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2069 .


## Description
All remaining linter errors are related to the deprecated version of the S3 library.

## How to test
