### PR TITLE
fix(storage-v2): fix check if s3 endpoint has http / https prefix

### DIFF
--- a/sda/internal/storage/v2/s3/reader/config.go
+++ b/sda/internal/storage/v2/s3/reader/config.go
@@ -58,9 +58,9 @@ func loadConfig(backendName string) ([]*endpointConfig, error) {
 			return nil, errors.New("missing required parameter: secret_key")
 		default:
 			switch {
-			case strings.HasPrefix(e.Endpoint, "http") && !e.DisableHTTPS:
+			case strings.HasPrefix(e.Endpoint, "http:") && !e.DisableHTTPS:
 				return nil, errors.New("http scheme in endpoint when using HTTPS")
-			case strings.HasPrefix(e.Endpoint, "https") && e.DisableHTTPS:
+			case strings.HasPrefix(e.Endpoint, "https:") && e.DisableHTTPS:
 				return nil, errors.New("https scheme in endpoint when HTTPS is disabled")
 			default:
 			}

--- a/sda/internal/storage/v2/s3/writer/config.go
+++ b/sda/internal/storage/v2/s3/writer/config.go
@@ -72,9 +72,9 @@ func loadConfig(backendName string) ([]*endpointConfig, error) {
 			return nil, errors.New("missing required parameter: bucket_prefix")
 		default:
 			switch {
-			case strings.HasPrefix(e.Endpoint, "http") && !e.DisableHTTPS:
+			case strings.HasPrefix(e.Endpoint, "http:") && !e.DisableHTTPS:
 				return nil, errors.New("http scheme in endpoint when using HTTPS")
-			case strings.HasPrefix(e.Endpoint, "https") && e.DisableHTTPS:
+			case strings.HasPrefix(e.Endpoint, "https:") && e.DisableHTTPS:
 				return nil, errors.New("https scheme in endpoint when HTTPS is disabled")
 			default:
 			}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #1910 


## Description
Bug in storage v2, s3 reader and writer, could not setup a reader / writer with tls as https has http as prefix, add ":" to prefix check to ensure we check for full scheme name
