### PR TITLE
feat(download): add support for Htsget-Context-Public-Key header with…

### DIFF
--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -579,13 +579,13 @@ func getPublicKeyFromRequest(c *gin.Context) (string, error) {
 		return "", errors.New("both Htsget-Context-Public-Key, and Client-Public-Key headers are set")
 	case htsgetRsPublicKeyHeader != "":
 		if _, err := base64.StdEncoding.DecodeString(htsgetRsPublicKeyHeader); err != nil {
-			return "", fmt.Errorf("invalid base64 encoding for Htsget-Context-Public-Key header")
+			return "", errors.New("invalid base64 encoding for Htsget-Context-Public-Key header")
 		}
 
 		return htsgetRsPublicKeyHeader, nil
 	case clientPublicKeyHeader != "":
 		if _, err := base64.StdEncoding.DecodeString(clientPublicKeyHeader); err != nil {
-			return "", fmt.Errorf("invalid base64 encoding for Client-Public-Key header")
+			return "", errors.New("invalid base64 encoding for Client-Public-Key header")
 		}
 
 		return clientPublicKeyHeader, nil

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -364,7 +364,7 @@ func TestDownload_Fail_UnencryptedDownloadNotAllowed(t *testing.T) {
 	defer response.Body.Close()
 	body, _ = io.ReadAll(response.Body)
 	expectedStatusCode = 400
-	expectedBody = []byte("downloading encrypted data is not supported")
+	expectedBody = []byte("invalid base64 encoding for Client-Public-Key header")
 
 	assert.Equal(t, expectedStatusCode, response.StatusCode, "Unexpected status code from download")
 	assert.Equal(t, expectedBody, body, "Unexpected body from download")


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2225.

## Description
Add support for Htsget-Context-Public-Key header with takes precedence over Client-Public-Key header
