### PR TITLE
[release_v1] Fix linter action argument

### DIFF
--- a/.github/workflows/code-linter.yaml
+++ b/.github/workflows/code-linter.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
-          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck -e G401,G501,G107 --timeout 5m
+          args: --timeout 5m
           working-directory: sda-download
 
   lint_sda:
@@ -51,5 +51,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
-          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,rowserrcheck --timeout 5m
+          args: --timeout 5m
           working-directory: sda


### PR DESCRIPTION
Arguments are not needed since we have the `.golagnci.yml` config file.

This should fix the issue with the golang linter not running due to obsolete arguments.