### PR TITLE
Feature add markdownlint for decision records

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,29 @@
+name: Lint Markdown
+
+on:
+  merge_group:
+  pull_request:
+    paths:
+      - "docs/decisions/**"
+      - ".github/workflows/lint-markdown.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/decisions/**"
+      - ".github/workflows/lint-markdown.yml"
+  workflow_dispatch:
+
+jobs:
+  markdownlint:
+    name: Decision records
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Lint decision records
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: |
+            docs/decisions/**/*.md

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,19 @@
+default: true
+
+# Allow arbitrary line length
+#
+# Reason: We apply the one-sentence-per-line rule. A sentence may get longer than 80 characters, especially if links are contained.
+#
+# Details: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013---line-length
+MD013: false
+
+# Allow duplicate headings
+#
+# Reasons:
+#
+# - The chosen option is considerably often used as title of the decision record (e.g., "Use MADR 4.0.0" appears in both the title and the decision outcome).
+# - We use "Examples" or similar headings multiple times in some records.
+# - Markdown lint should support the user and not annoy them.
+#
+# Details: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md024---multiple-headings-with-the-same-content
+MD024: false

--- a/docs/decisions/0000-use-markdown-architectural-decision-records.md
+++ b/docs/decisions/0000-use-markdown-architectural-decision-records.md
@@ -95,7 +95,7 @@ been implemented.
 ### Conventions Established by This ADR
 
 | Convention | Detail |
-|---|---|
+| --- | --- |
 | Directory | `docs/decisions/` |
 | File naming | `NNNN-title-with-dashes.md` — zero-padded, lowercase, dashes between words |
 | Numbering | Starts at 0000; numbers are never reused, even for rejected or superseded decisions |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,9 +39,11 @@ includes a checkbox as a reminder.
 ## How to create a decision record
 
 1. Copy the template:
+
    ```sh
    cp docs/decisions/template.md docs/decisions/NNNN-title-with-dashes.md
    ```
+
    Use the next available number, zero-padded to four digits.
 
 2. Fill in the sections. Remove any optional sections (marked by HTML comments)
@@ -68,7 +70,7 @@ includes a checkbox as a reminder.
 ## Status lifecycle
 
 | Status | Meaning |
-|---|---|
+| --- | --- |
 | `proposed` | Under discussion in a PR |
 | `accepted` | Merged and in effect |
 | `rejected` | Considered but not adopted |
@@ -89,7 +91,7 @@ superseded-by: "0005-use-new-approach.md"
 ## Index
 
 | # | Decision | Status |
-|---|----------|--------|
+| --- | --- | --- |
 | [0000](0000-use-markdown-architectural-decision-records.md) | Use Markdown Architectural Decision Records | accepted |
 
 ## More information


### PR DESCRIPTION
## Related issue(s) and PR(s)

Builds on #2239a (ADR bootstrap).

## Description

Adds automated markdown linting for decision records in `docs/decisions/` using
[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2).

**Why?** Decision records should follow consistent markdown formatting to ensure
readability and maintain professional quality. Automated linting catches
formatting issues early, reduces review friction, and enforces standards without
manual checking.

**What's included:**

| File | Purpose |
| --- | --- |
| `.markdownlint.yml` | Linting rules with MADR-appropriate exceptions (MD013 line length, MD024 duplicate headings) |
| `.github/workflows/lint-markdown.yml` | CI workflow that runs on PRs, pushes to main, merge queue, and manual dispatch |
| `docs/decisions/*.md` | Formatting fixes to pass linting (table pipes, code block spacing) |

**Configuration choices:**

- **MD013 (line length) disabled** — following MADR's approach, we use
  one-sentence-per-line which can exceed 80 characters when links are included
- **MD024 (duplicate headings) disabled** — decision records naturally repeat
  headings (e.g., option titles appear in both "Considered Options" and
  "Pros and Cons")
- **Path filters** — workflow only runs when `docs/decisions/**` or the workflow
  itself changes, avoiding unnecessary CI on unrelated PRs
- **Merge queue support** — includes `merge_group` trigger for compatibility with
  GitHub merge queues

**Background reading:**

- [markdownlint rules reference](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
- [MADR's linting setup](https://github.com/adr/madr/blob/main/.markdownlint.yml) — we follow the same rule exceptions



## How to test

1. Check that the "Lint Markdown" workflow passes in the CI checks for this PR
2. Verify locally by running:
   ```sh
   npx markdownlint-cli2 "docs/decisions/**/*.md"
   ```
   Should report `Summary: 0 error(s)`
3. Introduce a formatting error (e.g., remove spaces around table pipes in
   `docs/decisions/README.md`) and verify the linter catches it
