### PR TITLE
docs: add rotatekey to overview and fix doc gaps for reencrypt/rotatekey

### DIFF
--- a/sda/cmd/reencrypt/Reencrypt.md
+++ b/sda/cmd/reencrypt/Reencrypt.md
@@ -54,6 +54,11 @@ These settings control which crypt4gh keyfile is loaded.
   - `fatal`
   - `panic`
 
+### GRPC server settings
+
+- `GRPC_HOST`: hostname or IP the gRPC server will listen on (default: `0.0.0.0`)
+- `GRPC_PORT`: port the gRPC server will listen on (default: `50051`, changes to `50443` when TLS is enabled)
+
 ### TLS settings
 
 - `GRPC_CACERT`: Certificate Authority (CA) certificate for validating incoming request

--- a/sda/cmd/rotatekey/rotatekey.md
+++ b/sda/cmd/rotatekey/rotatekey.md
@@ -55,7 +55,7 @@ This setting controls which crypt4gh keyfile is loaded.
 
 ### RabbitMQ broker settings
 
-These settings control how sync connects to the RabbitMQ message broker.
+These settings control how `rotatekey` connects to the RabbitMQ message broker.
 
 - `BROKER_HOST`: hostname of the rabbitmq server
 - `BROKER_PORT`: rabbitmq broker port (commonly `5671` with TLS and `5672` without)
@@ -63,6 +63,7 @@ These settings control how sync connects to the RabbitMQ message broker.
 - `BROKER_USER`: username to connect to rabbitmq
 - `BROKER_PASSWORD`: password to connect to rabbitmq
 - `BROKER_ROUTINGKEY`: routing from a rabbitmq exchange to the rotatekey queue
+- `BROKER_PREFETCHCOUNT`: Number of messages to pull from the message server at the time (default to `2`)
 
 ### PostgreSQL Database settings
 

--- a/sda/sda.md
+++ b/sda/sda.md
@@ -23,3 +23,4 @@ There are also additional support services:
 4. [s3inbox](cmd/s3inbox/s3inbox.md) proxies uploads to the an S3 compatible storage backend.
 5. [sync](cmd/sync/sync.md) mirrors ingested data between sites in the [Bigpicture](https://bigpicture.eu/) project.
 6. [syncapi](cmd/syncapi/syncapi.md) is used in the [Bigpicture](https://bigpicture.eu/) project for mirroring data between two installations of SDA.
+7. [RotateKey](cmd/rotatekey/rotatekey.md) re-encrypts file headers with a configured target key.


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2237.
Companion PR: [neicnordic/neic-sda](https://github.com/neicnordic/neic-sda/pull/179) (adds nav entries + aggregation mapping)

## Description
- Add rotatekey as support service #7 in `sda/sda.md`
- Fix copy-paste error in `rotatekey.md` ("sync" → "rotatekey" in RabbitMQ section)
- Add `BROKER_PREFETCHCOUNT` to `rotatekey.md` (matching ingest/verify pattern)
- Add `GRPC_HOST` and `GRPC_PORT` to `Reencrypt.md`

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`

## How to test
Verify markdown renders correctly and links resolve.