### PR TITLE
Fix/workflow tag trigger by GitHub

### DIFF
--- a/.github/workflows/pr_merge_increment_version_tag_sda.yml
+++ b/.github/workflows/pr_merge_increment_version_tag_sda.yml
@@ -26,7 +26,7 @@ jobs:
       id: bump_tag
       uses: anothrNick/github-tag-action@1.75.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
         TAG_PREFIX: v
         DEFAULT_BUMP: patch
         TAG_CONTEXT: branch


### PR DESCRIPTION
# Description
Github ignores events that originates from the `secrets.GITHUB_TOKEN` user, meaning that the push of the tag does not trigger the release of the sda.

In the repo we have setup `GHCR_TOKEN` as a repository secret which will be used for the tagging.

## How to test
- Merge a PR where this is present
