### PR TITLE
docs(adr): fix ADR-0002 typo, naming, and missing index entry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,6 @@ This PR closes [issue number].
 
 - [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
   - [ ] A decision record has been added or updated in `docs/decisions/`
+  - [ ] The decision record is listed in the `docs/decisions/README.md` index table
 
 ## How to test

--- a/docs/decisions/0002-merge-dependabot-package-managers.md
+++ b/docs/decisions/0002-merge-dependabot-package-managers.md
@@ -5,7 +5,7 @@ decision-makers:
   - "@neicnordic/sensitive-data-development-collaboration"
 ---
 
-# Merge Dependapot package managers
+# Merge Dependabot package managers
 
 ## Context and Problem Statement
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -93,6 +93,7 @@ superseded-by: "0005-use-new-approach.md"
 | # | Decision | Status |
 | --- | --- | --- |
 | [0000](0000-use-markdown-architectural-decision-records.md) | Use Markdown Architectural Decision Records | accepted |
+| [0002](0002-merge-dependabot-package-managers.md) | Merge Dependabot package managers | accepted |
 
 ## More information
 


### PR DESCRIPTION
## Summary

- Fix "Dependapot" → "Dependabot" typo in ADR-0002 title
- Rename file from underscores to dashes per `NNNN-title-with-dashes.md` convention
- Add ADR-0002 to `docs/decisions/README.md` index table (was missing after merge of #2293)
- Add index table checklist item to PR template to prevent this gap recurring