### PR TITLE
feat(download): add lightweight dev compose for v2 API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,17 @@ integrationtest-sda-download-v2-up: build-all
 integrationtest-sda-download-v2-down:
 	@PR_NUMBER=$$(date +%F) docker compose -f .github/integration/sda-download-v2-integration.yml down -v --remove-orphans
 
+# Lightweight dev stack for download API v2 (webapp development)
+dev-download-v2-up: build-all
+	@PR_NUMBER=$$(date +%F) docker compose -f dev-tools/download-v2-dev/compose.yml up -d
+	@echo ""
+	@echo "Download API v2 ready at http://localhost:8085"
+	@echo "Get a token:  TOKEN=\$$(curl -s http://localhost:8000/tokens | jq -r '.[0]')"
+	@echo "Try it:       curl -H \"Authorization: Bearer \$$TOKEN\" http://localhost:8085/datasets"
+
+dev-download-v2-down:
+	@PR_NUMBER=$$(date +%F) docker compose -f dev-tools/download-v2-dev/compose.yml down -v --remove-orphans
+
 # Download benchmark (compares old vs new public endpoints)
 # Uses sda-benchmark.yml which extends sda-s3-integration.yml with benchmark services
 # The benchmark runs in a container with auto-configuration from the environment

--- a/dev-tools/download-v2-dev/README.md
+++ b/dev-tools/download-v2-dev/README.md
@@ -84,7 +84,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 The stack is pre-seeded with:
 
 - **Dataset**: `EGAD00000000001` ("Test Dataset")
-- **File**: `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived, 500 bytes decrypted)
+- **File**: `EGAF00000000001` (`test-file.c4gh`)
 - **User**: `integration_test@example.org` (file owner)
 
 ## Using with sda-auth

--- a/dev-tools/download-v2-dev/README.md
+++ b/dev-tools/download-v2-dev/README.md
@@ -1,0 +1,117 @@
+# Download API v2 - Local Development
+
+Lightweight dev stack for building applications against the sda-download v2 API.
+
+## Quick Start
+
+```bash
+# Build images first (only needed once, or after code changes)
+make build-all
+
+# Start all services
+make dev-download-v2-up
+
+# Get a token
+TOKEN=$(curl -s http://localhost:8000/tokens | jq -r '.[0]')
+
+# List datasets
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets
+
+# List files in dataset
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets/EGAD00000000001/files
+```
+
+## Services
+
+| Service  | Port  | Description                          |
+|----------|-------|--------------------------------------|
+| download | 8085  | Download API v2                      |
+| mockauth | 8000  | Mock OIDC (JWKS, userinfo, /tokens)  |
+| postgres | 15432 | PostgreSQL with SDA schema           |
+| minio    | 19000 | S3 storage (console at 19001)        |
+| reencrypt| 50051 | gRPC re-encryption for file downloads|
+
+## Getting Tokens
+
+```bash
+# Get dev token (JSON array with one entry)
+curl http://localhost:8000/tokens
+
+# Token for integration_test@example.org (has access to all test datasets)
+TOKEN=$(curl -s http://localhost:8000/tokens | jq -r '.[0]')
+```
+
+## API Endpoints
+
+Full documentation: [sda/cmd/download/download.md](../../sda/cmd/download/download.md)
+
+```bash
+# Health check
+curl http://localhost:8085/health/ready
+
+# List datasets
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets
+
+# Dataset details
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets/EGAD00000000001
+
+# List files in dataset
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets/EGAD00000000001/files
+
+# File metadata
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/files/EGAF00000000001
+
+# DRS object resolution
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/objects/EGAD00000000001/test-file.c4gh
+
+# Get the c4gh public key from the running stack
+docker cp $(docker ps -qf label=com.docker.compose.project=download-v2-dev -f label=com.docker.compose.service=reencrypt | head -1):/shared/c4gh.pub.pem /tmp/dev-c4gh.pub.pem
+C4GH_KEY=$(base64 -w0 /tmp/dev-c4gh.pub.pem)
+
+# Download a file (requires c4gh public key)
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "X-C4GH-Public-Key: $C4GH_KEY" \
+     http://localhost:8085/files/EGAF00000000001 -o file.c4gh
+
+# Download content only (stable ETag, supports Range requests)
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "X-C4GH-Public-Key: $C4GH_KEY" \
+     http://localhost:8085/files/EGAF00000000001/content -o content.c4gh
+```
+
+## Test Data
+
+The stack is pre-seeded with:
+
+- **Dataset**: `EGAD00000000001` ("Test Dataset")
+- **File**: `EGAF00000000001` (`test-file.c4gh`, 1000 bytes archived, 500 bytes decrypted)
+- **User**: `integration_test@example.org` (file owner)
+
+## Using with sda-auth
+
+A JWT from `sda-auth` works with this download service as long as the public key
+matches. Configure the download service with `JWT_PUBKEY_PATH` or `JWT_PUBKEY_URL`
+pointing to sda-auth's public key.
+
+## Interactive Demo
+
+Run the sprint review demo script to see all endpoints in action:
+
+```bash
+./dev-tools/download-v2-dev/demo.sh        # all 7 steps
+./dev-tools/download-v2-dev/demo.sh 6      # single step (e.g. file download)
+```
+
+## Limitations
+
+- **Authorization is bypassed.** The config sets `jwt.allow-all-data: true` so any valid
+  JWT can access all datasets. This simplifies getting started but means permission
+  denied paths (ownership model, visa grants) are not exercised locally. When building
+  auth flows against sda-auth, be aware that access control will behave differently in
+  real deployments.
+
+## Cleanup
+
+```bash
+make dev-download-v2-down
+```

--- a/dev-tools/download-v2-dev/compose.yml
+++ b/dev-tools/download-v2-dev/compose.yml
@@ -9,6 +9,8 @@
 #   TOKEN=$(curl -s http://localhost:8000/tokens | jq -r '.[0]')
 #   curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets
 
+name: download-v2-dev
+
 services:
   postgres:
     build:

--- a/dev-tools/download-v2-dev/compose.yml
+++ b/dev-tools/download-v2-dev/compose.yml
@@ -135,7 +135,7 @@ services:
         condition: service_healthy
     environment:
       - PGPASSWORD=rootpasswd
-    image: python:3.11-slim-bookworm
+    image: python:3.14-slim-trixie
     volumes:
       - shared:/shared
 
@@ -161,7 +161,7 @@ services:
         condition: service_healthy
     environment:
       - PGPASSWORD=rootpasswd
-    image: python:3.11-slim-bookworm
+    image: python:3.14-slim-trixie
     volumes:
       - ./seed.sh:/seed.sh:ro
       - shared:/shared
@@ -175,7 +175,7 @@ services:
         pip install --upgrade pip > /dev/null
         pip install aiohttp Authlib joserfc > /dev/null
         python -u /mockoidc.py
-    image: python:3.10-slim
+    image: python:3.14-slim-trixie
     volumes:
       - ./mockoidc.py:/mockoidc.py
     ports:

--- a/dev-tools/download-v2-dev/compose.yml
+++ b/dev-tools/download-v2-dev/compose.yml
@@ -1,0 +1,228 @@
+# Lightweight dev stack for the sda-download v2 API.
+#
+# Starts the minimum services needed for local webapp development:
+# postgres, minio, mockoidc, reencrypt, and the download service.
+# Database is pre-seeded with a test dataset and file.
+#
+# Usage:
+#   docker compose up -d
+#   TOKEN=$(curl -s http://localhost:8000/tokens | jq -r '.[0]')
+#   curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets
+
+services:
+  postgres:
+    build:
+      context: ../../postgresql
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER:-dev}-postgres
+    environment:
+      - POSTGRES_PASSWORD=rootpasswd
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 2s
+      retries: 6
+    ports:
+      - "15432:5432"
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    networks:
+      default:
+        aliases:
+          - s3
+    environment:
+      - MINIO_ROOT_USER=access
+      - MINIO_ROOT_PASSWORD=secretKey
+      - MINIO_SERVER_URL=http://127.0.0.1:9000
+    healthcheck:
+      test: ["CMD", "curl", "-fkq", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 2s
+      retries: 6
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    volumes:
+      - minio_data:/data
+
+  # Generates JWT keys, c4gh keys, and a dev token
+  credentials:
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        set -e
+        apt-get -o DPkg::Lock::Timeout=60 update > /dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y postgresql-client > /dev/null
+        pip install --upgrade pip > /dev/null
+        pip install joserfc crypt4gh > /dev/null
+
+        # Create database role for download service
+        psql -U postgres -h postgres -d sda -c "ALTER ROLE download LOGIN PASSWORD 'download';" || true
+        psql -U postgres -h postgres -d sda -c "GRANT base TO download;" || true
+
+        # Create RSA key pair for JWT signing
+        # Uses the same hardcoded key as mockoidc.py so tokens are interchangeable
+        mkdir -p /shared/keys/pub
+        if [ ! -f "/shared/keys/jwt.key" ]; then
+            cat > /shared/keys/jwt.key << 'PRIVKEY'
+        -----BEGIN PRIVATE KEY-----
+        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDhuZjxPmOGUIW1
+        LhxzKfxkN+1aTbvI5w+AptqT33X+bWuzfjvhEodiNz0bBfQgJJpQ3TZ8J1IZpM2F
+        Tnzox+FGxKPe5T9Mgngzd4N6eByWVPXoNMk7IdmBXMdPZBFSyjMW4ba1MELCpiKV
+        05de4J5opRDwmHmyMqYJxBk78e3iiYYixVk+j1Ku+yFl4d2R29y2+O9PlZegJloe
+        8FGnKIGZApS/8t9iyCkXg8WbjSPzgYCTQKxn/E4lcGdTrAt/McKrWmAuppcr+rpP
+        +BInm3l5Zu/QiRSZcMb5O460ojP9eKnaUlDpGZv9CY5j4x4lq8vjU2kK77YXBO8I
+        2oxse5a5AgMBAAECggEABbwSX6anHqVzECxQurhJWj51gELTT4JXSXxztygJNmKP
+        RushGFHBMMSYf9RB5IMpjH5iQPs6wb4HHqjk0YEqfwLF6wbF+eqipSQXKghdKZCV
+        AsY8io0MmpXB1omDSygp7h3j52yHdayE2muav+VTAPOYn5QwG0/gGgVqYrR9x7CM
+        iTuyOIuGNO4Wlly4/5RhLtSo0pal9AgBvX4crtVEwN8tPgqPVo9w71bSROt9EVNI
+        3cZiFFrrapYiifckIGiPGQYQUd5ej9Mq/77Fa0fv0pk0ONQV8HwstQ5HY2WwJWsn
+        mccF9plVTzem7N/vo+T+hFRPUO9TZUao91mMV8iV5QKBgQD1nZbQW3NHdol0fXA8
+        nw5JRkTLZx1zcZ5l36WVPkwCjJOyXQ2vWHm4lz7F81Rr8dQnMKLWMDKjrBT9Dbfs
+        xYK2bYxENS1W/n+0jOIaX/792DY9tfX7vvHU9yGSdoJE5os6DGCHYInOD0xnRmnl
+        3vS7gKv8miDwDzFsbjtDg6WfSwKBgQDrRLkmmfZCMcmLA02YSrErAlUseuyad7lY
+        HEJApXKfn262iHELlQa2zOBZpJGXIcHsNf1XGpMeU5pH+ILKE4Y5qbclq+AzFCcZ
+        nBFUfDeawmWdV5FJqNDd1L8Mb8aE+6q0Y5rNb3RL7A2ypH2ZeYKSGpHz3C7Rn5KW
+        voWAXRWriwKBgQCH4bxK3x0ivxiCgtcyIojDzwVGRnDLqmMIVzeDHqjsjBs2BTcJ
+        9/e3QK1w1BKzeWF2oPilaJrLY+tkqE9FxWtwQ6DjJ0xDIZ9DIuH/13X5t8EiWOWS
+        devSdzpyje+58JW78pcArk7u2hXZ2OHDU5qvlRsRL6/jP3SHWWCeFFnviwKBgGov
+        M02r0YygwfEfBYeFtp7Nx7lypZU2Eg4levWIdsp6f9KclEEA+u3IXD25XAiVMNw2
+        pegJU3stioWPMSCZXUxrQAEdqOwE3XzehqfWBJaxxIEWQ7m2Gsb0PWIUlMnyeGJA
+        Tl8IPboCiVAmk5WQVREyMsuYhf0Qg23MAZ8k5CHvAoGBAJm55NQZVKAEDGd4a21q
+        TDcRddtPwwL2oP3qa0gbGk4YFRUCrX99hIejOTvQW1xf6vGxTd7E1QizvFse4yRz
+        ZRKyXIc7DCcdzOnpMrSd1+aXwZtRHLSw0EDS6PWeJZdjJYHxl2YpAmMdURdcGTrH
+        b6b/6vhU90+xL14CX7Awofp/
+        -----END PRIVATE KEY-----
+        PRIVKEY
+            cat > /shared/keys/pub/jwt.pub << 'PUBKEY'
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4bmY8T5jhlCFtS4ccyn8
+        ZDftWk27yOcPgKbak991/m1rs3474RKHYjc9GwX0ICSaUN02fCdSGaTNhU586Mfh
+        RsSj3uU/TIJ4M3eDengcllT16DTJOyHZgVzHT2QRUsozFuG2tTBCwqYildOXXuCe
+        aKUQ8Jh5sjKmCcQZO/Ht4omGIsVZPo9SrvshZeHdkdvctvjvT5WXoCZaHvBRpyiB
+        mQKUv/LfYsgpF4PFm40j84GAk0CsZ/xOJXBnU6wLfzHCq1pgLqaXK/q6T/gSJ5t5
+        eWbv0IkUmXDG+TuOtKIz/Xip2lJQ6Rmb/QmOY+MeJavL41NpCu+2FwTvCNqMbHuW
+        uQIDAQAB
+        -----END PUBLIC KEY-----
+        PUBKEY
+            chmod 644 /shared/keys/pub/jwt.pub /shared/keys/jwt.key
+        fi
+
+        # Create trusted issuers for visa validation
+        cat > "/shared/trusted-issuers.json" <<'ISSUERS'
+        [
+          {
+            "iss": "https://demo.example",
+            "jku": "http://mockauth:8000/jwks"
+          }
+        ]
+        ISSUERS
+
+        # Generate c4gh key pair (used by reencrypt and seed)
+        if [ ! -f "/shared/c4gh.pub.pem" ]; then
+            printf 'c4ghpass\nc4ghpass\n' | crypt4gh-keygen --sk /shared/c4gh.sec.pem --pk /shared/c4gh.pub.pem
+            chmod 644 /shared/c4gh.sec.pem /shared/c4gh.pub.pem
+        fi
+
+        echo "Credentials ready"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - PGPASSWORD=rootpasswd
+    image: python:3.11-slim-bookworm
+    volumes:
+      - shared:/shared
+
+  # Create a real Crypt4GH test file, upload to MinIO, seed database
+  seed:
+    command:
+      - /bin/sh
+      - -c
+      - |
+        apt-get -o DPkg::Lock::Timeout=60 update > /dev/null
+        apt-get -o DPkg::Lock::Timeout=60 install -y curl postgresql-client > /dev/null
+        pip install --upgrade pip > /dev/null
+        pip install crypt4gh > /dev/null
+        curl -sL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
+        chmod +x /usr/local/bin/mc
+        sh /seed.sh
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    environment:
+      - PGPASSWORD=rootpasswd
+    image: python:3.11-slim-bookworm
+    volumes:
+      - ./seed.sh:/seed.sh:ro
+      - shared:/shared
+
+  # Mock OIDC server with /tokens endpoint for easy token retrieval
+  mockauth:
+    command:
+      - /bin/sh
+      - -c
+      - |
+        pip install --upgrade pip > /dev/null
+        pip install aiohttp Authlib joserfc > /dev/null
+        python -u /mockoidc.py
+    image: python:3.10-slim
+    volumes:
+      - ./mockoidc.py:/mockoidc.py
+    ports:
+      - "8000:8000"
+    restart: always
+
+  # gRPC re-encryption service (needed for file downloads)
+  reencrypt:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER:-dev}
+    command: [sda-reencrypt]
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+    ports:
+      - "50051:50051"
+    restart: always
+    volumes:
+      - ./reencrypt-config.yaml:/config.yaml
+      - shared:/shared
+
+  # Download service v2
+  download:
+    image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER:-dev}
+    command:
+      - sda-download
+      - "--config-file=/config.yaml"
+    depends_on:
+      credentials:
+        condition: service_completed_successfully
+      seed:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      reencrypt:
+        condition: service_started
+      mockauth:
+        condition: service_started
+    environment:
+      - CONFIG_FILE=/config.yaml
+    ports:
+      - "8085:8080"
+    restart: always
+    volumes:
+      - ./config.yaml:/config.yaml
+      - shared:/shared
+
+volumes:
+  minio_data:
+  postgres_data:
+  shared:

--- a/dev-tools/download-v2-dev/config.yaml
+++ b/dev-tools/download-v2-dev/config.yaml
@@ -1,0 +1,76 @@
+# Download service v2 - local development configuration
+
+api:
+  host: "0.0.0.0"
+  port: 8080
+
+service:
+  id: "neicnordic.sda.download"
+  org-name: "NBIS"
+  org-url: "https://nbis.se"
+
+db:
+  host: "postgres"
+  port: 5432
+  user: "postgres"
+  password: "rootpasswd"
+  database: "sda"
+  sslmode: "disable"
+
+grpc:
+  host: "reencrypt"
+  port: 50051
+  timeout: 30
+
+jwt:
+  pubkey-path: "/shared/keys/pub/"
+  allow-all-data: true
+
+permission:
+  model: "combined"
+
+auth:
+  allow-opaque: false
+
+visa:
+  enabled: true
+  source: "userinfo"
+  userinfo-url: "http://mockauth:8000/userinfo"
+  trusted-issuers-path: "/shared/trusted-issuers.json"
+  dataset-id-mode: "raw"
+  identity:
+    mode: "broker-bound"
+  validate-asserted: true
+  allow-insecure-jku: true
+  limits:
+    max-visas: 200
+    max-jwks-per-request: 10
+    max-visa-size: 16384
+  cache:
+    token-ttl: 3600
+    jwk-ttl: 300
+    validation-ttl: 120
+    userinfo-ttl: 60
+
+session:
+  expiration: 3600
+  secure: false
+  http-only: true
+  name: "sda_session"
+
+cache:
+  enabled: true
+  file-ttl: 300
+  permission-ttl: 120
+  dataset-ttl: 300
+
+storage:
+  backend: "archive"
+  archive:
+    s3:
+      - endpoint: "http://s3:9000"
+        access_key: "access"
+        secret_key: "secretKey"
+        region: "us-east-1"
+        bucket_prefix: "archive"
+        disable_https: true

--- a/dev-tools/download-v2-dev/demo.sh
+++ b/dev-tools/download-v2-dev/demo.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Sprint Review Demo Script — SDA Download API v2
+#
+# Starts the dev stack automatically if not already running.
+# Run from the repository root.
+#
+# Usage:
+#   ./dev-tools/download-v2-dev/demo.sh              # run all steps interactively
+#   ./dev-tools/download-v2-dev/demo.sh <step>        # run a single step (1-7)
+#   ./dev-tools/download-v2-dev/demo.sh --tmux        # tmux split with service logs
+#   ./dev-tools/download-v2-dev/demo.sh --tmux <step> # tmux + single step
+
+set -euo pipefail
+
+BASE="http://localhost:8085"
+AUTH="http://localhost:8000"
+BOLD='\033[1m'
+DIM='\033[2m'
+CYAN='\033[1;36m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+RESET='\033[0m'
+TOKEN=""
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+banner() {
+    echo ""
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "${BOLD}  $1${RESET}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+}
+
+narrate() {
+    echo -e "\n${DIM}# $1${RESET}"
+}
+
+run() {
+    local display_cmd="$1"
+    # Show the command with $TOKEN truncated for readability
+    if [[ -n "$TOKEN" ]]; then
+        local short_token="${TOKEN:0:20}..."
+        echo -e "${YELLOW}\$ ${display_cmd//$TOKEN/$short_token}${RESET}"
+    else
+        echo -e "${YELLOW}\$ $display_cmd${RESET}"
+    fi
+    eval "$1"
+    echo ""
+}
+
+pause() {
+    echo -e "${DIM}  [press Enter to continue]${RESET}"
+    read -r
+}
+
+# ── token setup ──────────────────────────────────────────────────────
+
+get_token() {
+    TOKEN=$(curl -sf "$AUTH/tokens" | jq -r '.[0]')
+    if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+        echo -e "${RED}ERROR: Could not get token from mockauth. Is docker compose running?${RESET}"
+        exit 1
+    fi
+    echo -e "${GREEN}Token acquired from mock OIDC.${RESET}"
+}
+
+# ── demo steps ───────────────────────────────────────────────────────
+
+step1() {
+    banner "1/7  Health Check"
+    narrate "Liveness — is the process up?"
+    run "curl -s $BASE/health/live | jq ."
+
+    narrate "Readiness — are all dependencies healthy? (DB, storage, gRPC)"
+    run "curl -s $BASE/health/ready | jq ."
+    pause
+}
+
+step2() {
+    banner "2/7  GA4GH Service Info"
+    narrate "Public endpoint, no auth required."
+    narrate "Follows the GA4GH service-info spec — ID and organization are configurable."
+    run "curl -s $BASE/service-info | jq ."
+    pause
+}
+
+step3() {
+    banner "3/7  Authentication & Dataset Listing"
+    narrate "Get a JWT from the mock OIDC provider, then list accessible datasets."
+    get_token
+    echo ""
+    run "curl -s -H \"Authorization: Bearer $TOKEN\" $BASE/datasets | jq ."
+    pause
+}
+
+step4() {
+    banner "4/7  Dataset Details & Files"
+    narrate "Drill into a dataset and list its files."
+    run "curl -s -H \"Authorization: Bearer $TOKEN\" $BASE/datasets/EGAD00000000001 | jq ."
+
+    narrate "Files in the dataset:"
+    run "curl -s -H \"Authorization: Bearer $TOKEN\" $BASE/datasets/EGAD00000000001/files | jq ."
+    pause
+}
+
+step5() {
+    banner "5/7  DRS Object Resolution (GA4GH DRS 1.5)"
+    narrate "Resolve dataset + file path → DRS object with download URL."
+    narrate "This is how htsget-rs and other GA4GH clients discover files."
+    run "curl -s -H \"Authorization: Bearer $TOKEN\" $BASE/objects/EGAD00000000001/test-file.c4gh | jq ."
+    pause
+}
+
+step6() {
+    banner "6/7  File Download (Crypt4GH)"
+    narrate "Three-tier download: combined, header-only, content-only."
+    narrate "Downloads require a Crypt4GH public key in the X-C4GH-Public-Key header."
+
+    # Get c4gh public key from the running stack
+    local c4gh_key=""
+    local container_id
+    container_id=$(docker ps -qf 'label=com.docker.compose.project=download-v2-dev' -f 'label=com.docker.compose.service=reencrypt' | head -1)
+    if [[ -n "$container_id" ]]; then
+        docker cp "$container_id:/shared/c4gh.pub.pem" /tmp/dev-c4gh.pub.pem 2>/dev/null
+        c4gh_key=$(base64 -w0 /tmp/dev-c4gh.pub.pem 2>/dev/null)
+    fi
+    if [[ -z "$c4gh_key" ]]; then
+        narrate "WARNING: Could not get c4gh key from container — download will fail with 400."
+        c4gh_key="missing"
+    fi
+
+    narrate "HEAD request — file size and ETag without downloading:"
+    run "curl -sI -H \"Authorization: Bearer $TOKEN\" -H \"X-C4GH-Public-Key: $c4gh_key\" $BASE/files/EGAF00000000001"
+
+    narrate "Combined download (re-encrypted header + data segments):"
+    run "curl -s -o /dev/null -w 'HTTP %{http_code}  Size: %{size_download} bytes\n' -H \"Authorization: Bearer $TOKEN\" -H \"X-C4GH-Public-Key: $c4gh_key\" $BASE/files/EGAF00000000001"
+
+    narrate "Content-only with Range request (first 512 bytes):"
+    run "curl -s -o /dev/null -w 'HTTP %{http_code}  Size: %{size_download} bytes\n' -H \"Authorization: Bearer $TOKEN\" -H \"X-C4GH-Public-Key: $c4gh_key\" -H 'Range: bytes=0-511' $BASE/files/EGAF00000000001/content"
+    pause
+}
+
+step7() {
+    banner "7/7  Error Handling (RFC 9457 Problem Details)"
+    narrate "No token → 401:"
+    run "curl -s $BASE/datasets | jq ."
+
+    narrate "Non-existent resource → 403 (prevents existence leakage):"
+    run "curl -s -H \"Authorization: Bearer $TOKEN\" $BASE/datasets/DOES_NOT_EXIST | jq ."
+    pause
+}
+
+# ── auto-start ──────────────────────────────────────────────────────
+
+ensure_running() {
+    if curl -sf "$BASE/health/live" > /dev/null 2>&1; then
+        return
+    fi
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+    echo -e "${YELLOW}Dev stack not running — starting with make dev-download-v2-up ...${RESET}"
+    make -C "$REPO_ROOT" dev-download-v2-up
+    echo "Waiting for download service ..."
+    for _ in $(seq 1 30); do
+        if curl -sf "$BASE/health/live" > /dev/null 2>&1; then
+            echo -e "${GREEN}Ready.${RESET}"
+            return
+        fi
+        sleep 2
+    done
+    echo "ERROR: download service did not become ready in time."
+    exit 1
+}
+
+# ── tmux mode ───────────────────────────────────────────────────────
+
+launch_tmux() {
+    local step="${1:-all}"
+    local script
+    script=$(readlink -f "$0")
+    local session="sda-demo"
+
+    if tmux has-session -t "$session" 2>/dev/null; then
+        tmux kill-session -t "$session"
+    fi
+
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+    # Start logs pane first so it catches all requests
+    tmux new-session -d -s "$session"
+    tmux send-keys -t "$session" "PR_NUMBER=\$(date +%F) docker compose -f $repo_root/dev-tools/download-v2-dev/compose.yml logs -f --tail 0 download mockauth" Enter
+
+    # Demo pane on the left
+    tmux split-window -h -b -t "$session"
+    tmux send-keys -t "$session" "sleep 2 && $script $step" Enter
+
+    tmux attach -t "$session"
+}
+
+# ── main ─────────────────────────────────────────────────────────────
+
+main() {
+    ensure_running
+    banner "SDA Download API v2 — Sprint Review Demo"
+    echo ""
+    echo -e "  Download API:  ${BOLD}$BASE${RESET}"
+    echo -e "  Mock OIDC:     ${BOLD}$AUTH${RESET}"
+    echo -e "  Test dataset:  ${BOLD}EGAD00000000001${RESET}"
+    echo -e "  Test file:     ${BOLD}EGAF00000000001${RESET}"
+    echo ""
+
+    if [[ ${1:-all} == "all" ]]; then
+        get_token
+        pause
+        step1; step2; step3; step4; step5; step6; step7
+        banner "Demo Complete!"
+    else
+        if [[ $1 -ge 3 ]]; then
+            get_token
+        fi
+        "step$1"
+    fi
+}
+
+# ── entrypoint ──────────────────────────────────────────────────────
+
+if [[ "${1:-}" == "--tmux" ]]; then
+    shift
+    launch_tmux "${1:-all}"
+else
+    main "${1:-all}"
+fi

--- a/dev-tools/download-v2-dev/mockoidc.py
+++ b/dev-tools/download-v2-dev/mockoidc.py
@@ -1,7 +1,10 @@
 """Mock OIDC server for download service local development.
 
-Provides JWT/JWKS validation, userinfo with GA4GH visas, and a /tokens
-endpoint for easy token retrieval (matching the v1 developer experience).
+Provides OIDC discovery, JWKS metadata, userinfo with GA4GH visas, and a
+/tokens endpoint for easy token retrieval (matching the v1 developer
+experience). Tokens are generated for local dev; the /userinfo handler
+does not verify JWT signatures or claims — it only decodes the payload
+to extract the subject.
 
 Uses the same RSA key as make_download_credentials.sh so tokens are
 accepted by the download service.

--- a/dev-tools/download-v2-dev/mockoidc.py
+++ b/dev-tools/download-v2-dev/mockoidc.py
@@ -1,0 +1,198 @@
+"""Mock OIDC server for download service local development.
+
+Provides JWT/JWKS validation, userinfo with GA4GH visas, and a /tokens
+endpoint for easy token retrieval (matching the v1 developer experience).
+
+Uses the same RSA key as make_download_credentials.sh so tokens are
+accepted by the download service.
+"""
+
+from aiohttp import web
+from authlib.jose import jwt, RSAKey
+import json
+import base64
+import time
+
+# RSA private key - same as in make_download_credentials.sh
+PRIVATE_KEY_PEM = """-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDhuZjxPmOGUIW1
+LhxzKfxkN+1aTbvI5w+AptqT33X+bWuzfjvhEodiNz0bBfQgJJpQ3TZ8J1IZpM2F
+Tnzox+FGxKPe5T9Mgngzd4N6eByWVPXoNMk7IdmBXMdPZBFSyjMW4ba1MELCpiKV
+05de4J5opRDwmHmyMqYJxBk78e3iiYYixVk+j1Ku+yFl4d2R29y2+O9PlZegJloe
+8FGnKIGZApS/8t9iyCkXg8WbjSPzgYCTQKxn/E4lcGdTrAt/McKrWmAuppcr+rpP
++BInm3l5Zu/QiRSZcMb5O460ojP9eKnaUlDpGZv9CY5j4x4lq8vjU2kK77YXBO8I
+2oxse5a5AgMBAAECggEABbwSX6anHqVzECxQurhJWj51gELTT4JXSXxztygJNmKP
+RushGFHBMMSYf9RB5IMpjH5iQPs6wb4HHqjk0YEqfwLF6wbF+eqipSQXKghdKZCV
+AsY8io0MmpXB1omDSygp7h3j52yHdayE2muav+VTAPOYn5QwG0/gGgVqYrR9x7CM
+iTuyOIuGNO4Wlly4/5RhLtSo0pal9AgBvX4crtVEwN8tPgqPVo9w71bSROt9EVNI
+3cZiFFrrapYiifckIGiPGQYQUd5ej9Mq/77Fa0fv0pk0ONQV8HwstQ5HY2WwJWsn
+mccF9plVTzem7N/vo+T+hFRPUO9TZUao91mMV8iV5QKBgQD1nZbQW3NHdol0fXA8
+nw5JRkTLZx1zcZ5l36WVPkwCjJOyXQ2vWHm4lz7F81Rr8dQnMKLWMDKjrBT9Dbfs
+xYK2bYxENS1W/n+0jOIaX/792DY9tfX7vvHU9yGSdoJE5os6DGCHYInOD0xnRmnl
+3vS7gKv8miDwDzFsbjtDg6WfSwKBgQDrRLkmmfZCMcmLA02YSrErAlUseuyad7lY
+HEJApXKfn262iHELlQa2zOBZpJGXIcHsNf1XGpMeU5pH+ILKE4Y5qbclq+AzFCcZ
+nBFUfDeawmWdV5FJqNDd1L8Mb8aE+6q0Y5rNb3RL7A2ypH2ZeYKSGpHz3C7Rn5KW
+voWAXRWriwKBgQCH4bxK3x0ivxiCgtcyIojDzwVGRnDLqmMIVzeDHqjsjBs2BTcJ
+9/e3QK1w1BKzeWF2oPilaJrLY+tkqE9FxWtwQ6DjJ0xDIZ9DIuH/13X5t8EiWOWS
+devSdzpyje+58JW78pcArk7u2hXZ2OHDU5qvlRsRL6/jP3SHWWCeFFnviwKBgGov
+M02r0YygwfEfBYeFtp7Nx7lypZU2Eg4levWIdsp6f9KclEEA+u3IXD25XAiVMNw2
+pegJU3stioWPMSCZXUxrQAEdqOwE3XzehqfWBJaxxIEWQ7m2Gsb0PWIUlMnyeGJA
+Tl8IPboCiVAmk5WQVREyMsuYhf0Qg23MAZ8k5CHvAoGBAJm55NQZVKAEDGd4a21q
+TDcRddtPwwL2oP3qa0gbGk4YFRUCrX99hIejOTvQW1xf6vGxTd7E1QizvFse4yRz
+ZRKyXIc7DCcdzOnpMrSd1+aXwZtRHLSw0EDS6PWeJZdjJYHxl2YpAmMdURdcGTrH
+b6b/6vhU90+xL14CX7Awofp/
+-----END PRIVATE KEY-----"""
+
+# Load RSA key
+KEY = RSAKey.import_key(PRIVATE_KEY_PEM)
+PUBLIC_JWK = KEY.as_dict(is_private=False)
+PUBLIC_JWK["kid"] = "rsa1"
+PUBLIC_JWK["use"] = "sig"
+PUBLIC_JWK["alg"] = "RS256"
+PRIVATE_JWK = dict(KEY)
+
+
+def generate_token(sub: str) -> str:
+    """Generate a signed JWT for a user."""
+    header = {
+        "alg": "RS256",
+        "typ": "JWT",
+        "kid": "rsa1",
+    }
+    now = int(time.time())
+    payload = {
+        "iss": "http://mockauth:8000",
+        "sub": sub,
+        "aud": "XC56EL11xx",
+        "iat": now,
+        "exp": now + 86400,  # 24 hours
+        "jti": f"dev-token-{sub}",
+    }
+    return jwt.encode(header, payload, PRIVATE_JWK).decode("utf-8")
+
+
+def generate_visa(dataset: str, sub: str) -> str:
+    """Generate a signed visa JWT for a dataset."""
+    header = {
+        "alg": "RS256",
+        "typ": "JWT",
+        "kid": "rsa1",
+        "jku": "http://mockauth:8000/jwks",
+    }
+    payload = {
+        "iss": "https://demo.example",
+        "sub": sub,
+        "ga4gh_visa_v1": {
+            "type": "ControlledAccessGrants",
+            "value": dataset,
+            "source": "https://doi.example/no_org",
+            "by": "self",
+            "asserted": 1568699331,
+        },
+        "iat": 1571144438,
+        "exp": 9999999999,
+        "jti": f"visa-{dataset}",
+    }
+    return jwt.encode(header, payload, PRIVATE_JWK).decode("utf-8")
+
+
+# Pre-generate visas for test datasets
+VISAS = {}
+
+
+def get_visas_for_user(sub: str) -> list:
+    """Get visas for a user, generating them if needed."""
+    if sub not in VISAS:
+        VISAS[sub] = [
+            generate_visa("EGAD00000000001", sub),
+        ]
+    return VISAS[sub]
+
+
+async def well_known(request: web.Request) -> web.Response:
+    """Return OIDC discovery document."""
+    print("[mockoidc] GET /.well-known/openid-configuration")
+    config = {
+        "issuer": "http://mockauth:8000",
+        "authorization_endpoint": "http://mockauth:8000/authorize",
+        "token_endpoint": "http://mockauth:8000/token",
+        "userinfo_endpoint": "http://mockauth:8000/userinfo",
+        "jwks_uri": "http://mockauth:8000/jwks",
+        "response_types_supported": ["code", "token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "scopes_supported": ["openid", "ga4gh_passport_v1"],
+        "claims_supported": ["sub", "iss", "aud", "exp", "iat", "ga4gh_passport_v1"],
+    }
+    return web.json_response(config)
+
+
+async def jwks(request: web.Request) -> web.Response:
+    """Return JSON Web Key Set."""
+    print("[mockoidc] GET /jwks")
+    return web.json_response({"keys": [PUBLIC_JWK]})
+
+
+async def tokens(request: web.Request) -> web.Response:
+    """Serve pre-generated tokens for development.
+
+    Returns a JSON array with one token for integration_test@example.org
+    which has access to all seeded test datasets.
+    """
+    print("[mockoidc] GET /tokens — generating dev token")
+    data = [
+        generate_token("integration_test@example.org"),
+    ]
+    return web.json_response(data)
+
+
+async def userinfo(request: web.Request) -> web.Response:
+    """Return user info with GA4GH visas."""
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return web.json_response(
+            {"error": "invalid_token", "error_description": "Missing bearer token"},
+            status=401,
+        )
+
+    print("[mockoidc] GET /userinfo")
+    token = auth_header.split(" ")[1]
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError("Not a JWT")
+
+        payload_b64 = parts[1].replace("-", "+").replace("_", "/")
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+
+        payload = json.loads(base64.b64decode(payload_b64))
+        sub = payload.get("sub", "unknown@example.org")
+    except Exception:
+        sub = token
+
+    visas = get_visas_for_user(sub)
+    response = {
+        "sub": sub,
+        "ga4gh_passport_v1": visas,
+    }
+    return web.json_response(response)
+
+
+def init() -> web.Application:
+    """Initialize the web application."""
+    app = web.Application()
+    app.router.add_get("/.well-known/openid-configuration", well_known)
+    app.router.add_get("/jwks", jwks)
+    app.router.add_get("/tokens", tokens)
+    app.router.add_get("/userinfo", userinfo)
+    return app
+
+
+if __name__ == "__main__":
+    print("[mockoidc] Starting mock OIDC server on port 8000")
+    print("[mockoidc] GET /tokens  - fetch dev tokens")
+    print("[mockoidc] GET /jwks    - JSON Web Key Set")
+    print("[mockoidc] GET /userinfo - user info with visas")
+    web.run_app(init(), port=8000)

--- a/dev-tools/download-v2-dev/reencrypt-config.yaml
+++ b/dev-tools/download-v2-dev/reencrypt-config.yaml
@@ -1,0 +1,10 @@
+log:
+  format: "json"
+  level: "debug"
+
+c4gh:
+  filePath: /shared/c4gh.sec.pem
+  passphrase: "c4ghpass"
+  privateKeys:
+  - filePath: /shared/c4gh.sec.pem
+    passphrase: "c4ghpass"

--- a/dev-tools/download-v2-dev/seed.sh
+++ b/dev-tools/download-v2-dev/seed.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Seed script for download v2 dev compose.
+# Creates a real Crypt4GH encrypted test file, uploads data segments to MinIO,
+# and inserts matching metadata (header, checksums, sizes) into the database.
+# Idempotent: safe to re-run against existing volumes.
+set -e
+
+echo "=== Seeding test data ==="
+
+# Create deterministic plaintext test data (1 KB)
+python3 -c "import hashlib; open('/tmp/plaintext.bin','wb').write(hashlib.sha256(b'sda-download-v2-dev-test-data').digest() * 32)"
+
+# Encrypt with crypt4gh using the server's public key
+crypt4gh encrypt --recipient_pk /shared/c4gh.pub.pem < /tmp/plaintext.bin > /tmp/encrypted.c4gh
+
+# Split: extract header and data segments, compute checksums
+python3 << 'PYEOF'
+import struct, hashlib
+
+with open("/tmp/encrypted.c4gh", "rb") as f:
+    data = f.read()
+
+# Parse c4gh header
+magic = data[:8]
+assert magic == b"crypt4gh", f"Bad magic: {magic}"
+packet_count = struct.unpack("<I", data[12:16])[0]
+
+offset = 16
+for _ in range(packet_count):
+    pkt_len = struct.unpack("<I", data[offset:offset+4])[0]
+    offset += pkt_len
+
+header = data[:offset]
+body = data[offset:]
+
+with open("/tmp/header.bin", "wb") as f:
+    f.write(header)
+with open("/tmp/body.bin", "wb") as f:
+    f.write(body)
+
+plaintext = open("/tmp/plaintext.bin", "rb").read()
+
+with open("/tmp/seed_metadata.env", "w") as f:
+    f.write(f"HEADER_HEX={header.hex()}\n")
+    f.write(f"ARCHIVE_SIZE={len(body)}\n")
+    f.write(f"DECRYPTED_SIZE={len(plaintext)}\n")
+    f.write(f"ARCHIVE_CHECKSUM={hashlib.sha256(body).hexdigest()}\n")
+    f.write(f"DECRYPTED_CHECKSUM={hashlib.sha256(plaintext).hexdigest()}\n")
+
+print(f"Header: {len(header)} bytes, Body: {len(body)} bytes")
+PYEOF
+
+# Upload data segments to MinIO (overwrites if exists)
+mc alias set myminio http://s3:9000 access secretKey --quiet
+mc mb myminio/archive --ignore-existing --quiet
+mc pipe myminio/archive/test-file.c4gh < /tmp/body.bin
+echo "Uploaded to MinIO: archive/test-file.c4gh"
+
+# Load computed metadata
+. /tmp/seed_metadata.env
+
+# Seed database (upserts so reruns are safe with persistent volumes)
+pg_isready -h postgres -p 5432 -U postgres
+
+psql -h postgres -U postgres -d sda << EOSQL
+INSERT INTO sda.files (
+  id, stable_id, submission_user, submission_file_path,
+  archive_file_path, archive_location, archive_file_size, decrypted_file_size,
+  header, encryption_method
+) VALUES (
+  'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  'EGAF00000000001',
+  'integration_test@example.org',
+  'test-file.c4gh',
+  'test-file.c4gh',
+  'http://s3:9000/archive',
+  $ARCHIVE_SIZE,
+  $DECRYPTED_SIZE,
+  '$HEADER_HEX',
+  'CRYPT4GH'
+) ON CONFLICT (id) DO UPDATE SET
+  archive_file_size = EXCLUDED.archive_file_size,
+  decrypted_file_size = EXCLUDED.decrypted_file_size,
+  header = EXCLUDED.header;
+
+INSERT INTO sda.datasets (stable_id, title)
+  VALUES ('EGAD00000000001', 'Test Dataset')
+  ON CONFLICT (stable_id) DO NOTHING;
+
+INSERT INTO sda.file_dataset (file_id, dataset_id)
+  SELECT 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'::uuid, d.id
+  FROM sda.datasets d
+  WHERE d.stable_id = 'EGAD00000000001'
+  ON CONFLICT DO NOTHING;
+
+DELETE FROM sda.checksums WHERE file_id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+INSERT INTO sda.checksums (file_id, checksum, type, source) VALUES
+  ('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '$ARCHIVE_CHECKSUM', 'SHA256', 'ARCHIVED'),
+  ('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '$DECRYPTED_CHECKSUM', 'SHA256', 'UNENCRYPTED');
+EOSQL
+
+echo "=== Seed complete ==="

--- a/dev-tools/download-v2-dev/seed.sh
+++ b/dev-tools/download-v2-dev/seed.sh
@@ -57,6 +57,7 @@ mc pipe myminio/archive/test-file.c4gh < /tmp/body.bin
 echo "Uploaded to MinIO: archive/test-file.c4gh"
 
 # Load computed metadata
+# shellcheck source=/dev/null
 . /tmp/seed_metadata.env
 
 # Seed database (upserts so reruns are safe with persistent volumes)


### PR DESCRIPTION
## Summary

- Adds a minimal Docker Compose stack (`dev-tools/download-v2-dev/`) for webapp development against the download v2 API
- Replaces the need for `make sda-s3-up` + full pipeline — just `make dev-download-v2-up` and go
- Includes a mock OIDC server with `GET /tokens` endpoint matching the v1 developer experience
- Seeds a real Crypt4GH encrypted test file so all three download tiers work (combined, header, content)
- Adds an interactive demo script with `--tmux` support for live service logs

### Services (5 running containers)

| Service | Port | Description |
|---------|------|-------------|
| download | 8085 | Download API v2 |
| mockauth | 8000 | Mock OIDC (JWKS, userinfo, /tokens) |
| postgres | 15432 | PostgreSQL with SDA schema |
| minio | 19000 | S3 storage (console at 19001) |
| reencrypt | 50051 | gRPC re-encryption |

### Quick start

```bash
make dev-download-v2-up
TOKEN=$(curl -s http://localhost:8000/tokens | jq -r '.[0]')
curl -H "Authorization: Bearer $TOKEN" http://localhost:8085/datasets
```

### Known limitations

- Authorization is bypassed (`jwt.allow-all-data: true`) — all authenticated users see all datasets
- See `dev-tools/download-v2-dev/README.md` for full details

Refs: #2353

## Test plan

- [ ] `make dev-download-v2-up` starts all services from a clean checkout
- [ ] `curl http://localhost:8000/tokens` returns a valid JWT
- [ ] All v2 endpoints respond: `/datasets`, `/files`, `/objects`, `/health`, `/service-info`
- [ ] File download works with `X-C4GH-Public-Key` header (HTTP 200 combined, 206 Range)
- [ ] `make dev-download-v2-down` tears down cleanly
- [ ] `./dev-tools/download-v2-dev/demo.sh --tmux` runs all 7 steps without errors