### PR TITLE
feat(s3inbox): use postgres instead of in memory cache for fileIds

### DIFF
--- a/.github/integration/tests/sda/01_install_dependencies.sh
+++ b/.github/integration/tests/sda/01_install_dependencies.sh
@@ -2,7 +2,7 @@
 set -e
 
 # install tools if missing
-for t in curl expect jq openssh-client postgresql-client xxd; do
+for t in curl expect jq openssh-client postgresql-client xxd awscli; do
     if [ ! "$(command -v $t)" ]; then
         if [ "$(id -u)" != 0 ]; then
             echo "$t is missing, unable to install it"

--- a/.github/integration/tests/sda/10_upload_test.sh
+++ b/.github/integration/tests/sda/10_upload_test.sh
@@ -67,8 +67,8 @@ if [ "$num_rows" -ne 5 ]; then
 fi
 
 num_log_rows=$(psql -U postgres -h postgres -d sda -At -c "SELECT COUNT(*) from sda.file_event_log;")
-if [ "$num_log_rows" -ne 12 ]; then
-    echo "database queries for file_event_logs failed, expected 12 got $num_log_rows"
+if [ "$num_log_rows" -ne 11 ]; then
+    echo "database queries for file_event_logs failed, expected 11 got $num_log_rows"
     exit 1
 fi
 

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -14,8 +14,8 @@ if ! [[ "$list_all_buckets" =~ "Forbidden" ]]; then
 fi
 
 # test disallowed characters
-disallowed_characters=$(s3cmd -c s3cfg -q put s3cfg s3://test_dummy.org/fai\| 2>&1)
-if ! [[ "$disallowed_characters" =~ "filepath contains disallowed characters" ]];then
+bad_request=$(s3cmd -c s3cfg -q put s3cfg s3://test_dummy.org/fai\| 2>&1)
+if ! [[ "$bad_request" =~ "Bad Request" ]];then
     echo "test with disallowed characters failed"
     exit 1
 fi
@@ -34,13 +34,13 @@ aws configure set aws_access_key_id dummy # Value dont matter as we authenticate
 aws configure set aws_secret_access_key dummy # Value dont matter as we authenticate with the aws_session_token
 aws configure set aws_session_token "$(grep 'access_token' s3cfg | cut -d "=" -f 2 | xargs)"
 
-listResponse=$(aws s3api list-objects --endpoint http://s3inbox:8000 --bucket test_dummy.org)
+listResponse=$(aws s3api list-objects --endpoint-url http://s3inbox:8000 --bucket test_dummy.org)
 if (( $(echo "$listResponse" | grep -c "test_dummy.org") == 0 )); then
   echo "found no files for users when listing towards s3inbox with ListObjects call"
   exit 1
 fi
 
-listV2Response=$(aws s3api list-objects-v2 --endpoint http://s3inbox:8000 --bucket test_dummy.org)
+listV2Response=$(aws s3api list-objects-v2 --endpoint-url http://s3inbox:8000 --bucket test_dummy.org)
 if (( $(echo "$listV2Response" | grep -c "test_dummy.org") == 0 )); then
   echo "found no files for users when listing towards s3inbox with ListObjectsV2 call"
   exit 1
@@ -49,13 +49,13 @@ fi
 
 aws configure set aws_session_token "$(cat token)"
 
-listResponse=$(aws s3api list-objects --endpoint http://s3inbox:8000 --bucket testu_lifescience-ri.eu)
+listResponse=$(aws s3api list-objects --endpoint-url http://s3inbox:8000 --bucket testu_lifescience-ri.eu)
 if ! (( $(echo "$listResponse" | grep -c "test_dummy.org") == 0 )); then
   echo "found other users files when listing towards s3inbox with ListObjects call"
   exit 1
 fi
 
-listV2Response=$(aws s3api list-objects-v2 --endpoint http://s3inbox:8000 --bucket testu_lifescience-ri.eu)
+listV2Response=$(aws s3api list-objects-v2 --endpoint-url http://s3inbox:8000 --bucket testu_lifescience-ri.eu)
 if ! (( $(echo "$listV2Response" | grep -c "test_dummy.org") == 0 )); then
   echo "found other users files when listing towards s3inbox with ListObjectsV2 call"
   exit 1

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -30,5 +30,36 @@ if ! [[ "$unathorized" =~ "Unauthorized" ]]; then
     exit 1
 fi
 
+aws configure set aws_access_key_id dummy # Value dont matter as we authenticate with the aws_session_token
+aws configure set aws_secret_access_key dummy # Value dont matter as we authenticate with the aws_session_token
+aws configure set aws_session_token "$(grep 'access_token' s3cfg | cut -d "=" -f 2 | xargs)"
+
+listResponse=$(aws s3api list-objects --endpoint http://s3inbox:8000 --bucket test_dummy.org)
+if (( $(echo "$listResponse" | grep -c "test_dummy.org") == 0 )); then
+  echo "found no files for users when listing towards s3inbox with ListObjects call"
+  exit 1
+fi
+
+listV2Response=$(aws s3api list-objects --endpoint http://s3inbox:8000 --bucket test_dummy.org)
+if (( $(echo "$listV2Response" | grep -c "test_dummy.org") == 0 )); then
+  echo "found no files for users when listing towards s3inbox with ListObjectsV2 call"
+  exit 1
+fi
+
+
+aws configure set aws_session_token "$(cat token)"
+
+listResponse=$(aws s3api list-objects --endpoint http://s3inbox:8000 --bucket testu_lifescience-ri.eu)
+if ! (( $(echo "$listResponse" | grep -c "test_dummy.org") == 0 )); then
+  echo "found other users files when listing towards s3inbox with ListObjects call"
+  exit 1
+fi
+
+listV2Response=$(aws s3api list-objects-v2 --endpoint http://s3inbox:8000 --bucket testu_lifescience-ri.eu)
+if ! (( $(echo "$listV2Response" | grep -c "test_dummy.org") == 0 )); then
+  echo "found other users files when listing towards s3inbox with ListObjectsV2 call"
+  exit 1
+fi
+
 
 echo "s3cmd error messages tested successfully"

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -8,7 +8,7 @@ cd shared || true
 
 # test that listing all buckets is not allowed
 list_all_buckets=$(s3cmd -c s3cfg -q ls 2>&1)
-if ! [[ "$list_all_buckets" =~ "not allowed response" ]]; then
+if ! [[ "$list_all_buckets" =~ "Forbidden" ]]; then
     echo "list buckets should fail"
     exit 1
 fi
@@ -25,7 +25,7 @@ cp s3cfg bads3cfg
 sed -i "s/access_token=.*/access_token=invalid/" bads3cfg
 
 unathorized=$(s3cmd -c bads3cfg -q ls s3://test_dummy.org/ 2>&1)
-if ! [[ "$unathorized" =~ "not authorized" ]]; then
+if ! [[ "$unathorized" =~ "Unauthorized" ]]; then
     echo "testing unathorized call failed"
     exit 1
 fi

--- a/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
+++ b/.github/integration/tests/sda/15_s3cmd-errorcodes_test.sh
@@ -40,7 +40,7 @@ if (( $(echo "$listResponse" | grep -c "test_dummy.org") == 0 )); then
   exit 1
 fi
 
-listV2Response=$(aws s3api list-objects --endpoint http://s3inbox:8000 --bucket test_dummy.org)
+listV2Response=$(aws s3api list-objects-v2 --endpoint http://s3inbox:8000 --bucket test_dummy.org)
 if (( $(echo "$listV2Response" | grep -c "test_dummy.org") == 0 )); then
   echo "found no files for users when listing towards s3inbox with ListObjectsV2 call"
   exit 1

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -96,7 +96,8 @@ func NewProxy(s3conf config.S3InboxConf, s3Client *s3.Client, auth userauth.Auth
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	token, err := p.auth.Authenticate(r)
 	if err != nil {
-		p.notAuthorized(w, err.Error())
+		log.Warnf("unauthorized user attempted: method: %s, path: %s, query: %s", r.Method, r.URL.Path, r.URL.RawQuery)
+		reportErrorToClient(http.StatusUnauthorized, "Unauthorized", w)
 
 		return
 	}
@@ -110,24 +111,15 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case PutObject, CreateMultiPartUpload, CompleteMultiPartUpload:
 		p.handleUpload(s3RequestType, w, r, token)
 	default:
-		p.notAllowedResponse(w, fmt.Sprintf("user: %s, attempted to do not allowed request: method: %s, path: %s, query: %s", token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery))
+		log.Warnf("user: %s, attempted to do not allowed request: method: %s, path: %s, query: %s", token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery)
+		reportErrorToClient(http.StatusForbidden, "Forbidden", w)
 	}
 }
 
 // Report 500 to the user, log the original error
-func (p *Proxy) internalServerError(w http.ResponseWriter, err string) {
-	log.Error(err)
+func (p *Proxy) internalServerError(w http.ResponseWriter, tokenSubject, httpMethod, path, query, err string) {
+	log.Errorf("user: %s, method: %s, path: %s, query: %s, encountered internal error: %s", tokenSubject, httpMethod, path, query, err)
 	reportErrorToClient(http.StatusInternalServerError, "Internal Error", w)
-}
-
-func (p *Proxy) notAllowedResponse(w http.ResponseWriter, err string) {
-	log.Warn(err)
-	reportErrorToClient(http.StatusForbidden, "Forbidden", w)
-}
-
-func (p *Proxy) notAuthorized(w http.ResponseWriter, err string) {
-	log.Warn(err)
-	reportErrorToClient(http.StatusUnauthorized, "Unauthorized", w)
 }
 
 // prepareForwardPathAndQuery prepares the new path and query to be used for the s3 request to be user specific when
@@ -201,13 +193,13 @@ func (p *Proxy) forwardRequest(s3RequestType S3RequestType, w http.ResponseWrite
 
 	s3Response, err := p.forwardRequestToBackend(r)
 	if err != nil {
-		p.internalServerError(w, fmt.Sprintf("forwarding error: %v", err))
+		p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("forwarding error: %v", err))
 
 		return
 	}
 
 	if err := p.forwardResponseToClient(s3Response, w); err != nil {
-		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
+		p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
 
 	_ = s3Response.Body.Close()
@@ -235,7 +227,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 
 	fileID, err := p.database.GetFileIDInInbox(r.Context(), username, filePath)
 	if err != nil {
-		p.internalServerError(w, fmt.Sprintf("failed to check/get existing file id from database: %v", err))
+		p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("failed to check/get existing file id from database: %v", err))
 
 		return
 	}
@@ -244,7 +236,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	if fileID == "" {
 		fileID, err = p.database.RegisterFile(nil, p.s3Conf.Endpoint+"/"+p.s3Conf.Bucket, filePath, username)
 		if err != nil {
-			p.internalServerError(w, fmt.Sprintf("failed to register file in database: %v", err))
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("failed to register file in database: %v", err))
 
 			return
 		}
@@ -256,7 +248,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	if s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload {
 		isReupload, err = p.checkFileExists(r.Context(), s3FilePath)
 		if err != nil {
-			p.internalServerError(w, err.Error())
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, err.Error())
 
 			return
 		}
@@ -264,7 +256,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 
 	s3Response, err := p.forwardRequestToBackend(r)
 	if err != nil {
-		p.internalServerError(w, fmt.Sprintf("forwarding error: %v", err))
+		p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("forwarding error: %v", err))
 
 		return
 	}
@@ -277,31 +269,31 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	if s3Response.StatusCode == 200 && (s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload) {
 		message, err := p.CreateMessageFromRequest(r.Context(), token.Subject(), s3FilePath)
 		if err != nil {
-			p.internalServerError(w, err.Error())
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, err.Error())
 
 			return
 		}
 		jsonMessage, err := json.Marshal(message)
 		if err != nil {
-			p.internalServerError(w, fmt.Sprintf("failed to marshal rabbitmq message to json: %v", err))
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("failed to marshal rabbitmq message to json: %v", err))
 
 			return
 		}
 
 		if err = p.checkAndSendMessage(fileID, jsonMessage); err != nil {
-			p.internalServerError(w, fmt.Sprintf("broker error: %v", err))
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("broker error: %v", err))
 
 			return
 		}
 
 		if err := p.storeObjectSizeInDB(r.Context(), s3FilePath, fileID); err != nil {
-			p.internalServerError(w, fmt.Sprintf("storeObjectSizeInDB failed because: %v", err))
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("storeObjectSizeInDB failed because: %v", err))
 
 			return
 		}
 
 		if err := p.database.UpdateFileEventLog(fileID, "uploaded", "inbox", "{}", string(jsonMessage)); err != nil {
-			p.internalServerError(w, fmt.Sprintf("could not connect to db: %v", err))
+			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("could not connect to db: %v", err))
 
 			return
 		}
@@ -309,7 +301,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 		if isReupload {
 			log.Infof("user: %s, reuploaded file: %s, with id: %s", username, filePath, fileID)
 			if err := p.sendMessageOnOverwrite(username, fileID, s3FilePath); err != nil {
-				p.internalServerError(w, err.Error())
+				p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, err.Error())
 
 				return
 			}
@@ -319,7 +311,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	}
 
 	if err := p.forwardResponseToClient(s3Response, w); err != nil {
-		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
+		p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
 }
 

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -157,6 +157,8 @@ func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPa
 
 	var newPath, newQuery string
 	switch s3RequestType {
+	case GetBucketLocation:
+		newPath = "/" + p.s3Conf.Bucket
 	case ListObjects, ListObjectsV2, ListMultiPartUploads:
 		newPath = "/" + p.s3Conf.Bucket
 

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -28,10 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type uniqueFileID struct {
-	username, filePath string
-}
-
 // Proxy represents the toplevel object in this application
 type Proxy struct {
 	s3Conf    config.S3InboxConf
@@ -40,7 +36,6 @@ type Proxy struct {
 	messenger *broker.AMQPBroker
 	database  *database.SDAdb
 	client    *http.Client
-	fileIDs   map[uniqueFileID]string
 }
 
 // The Event struct
@@ -70,15 +65,16 @@ type ErrorResponse struct {
 
 // The different types of requests
 const (
-	MakeBucket S3RequestType = iota
-	RemoveBucket
-	List
-	Put
-	Get
-	Delete
-	AbortMultipart
-	Policy
-	Other
+	Unsupported S3RequestType = iota
+	ListObjectsV2
+	ListObjects
+	PutObject
+	UploadPart
+	CreateMultiPartUpload
+	CompleteMultiPartUpload
+	ListMultiPartUpload
+	AbortMultiPartUpload
+	GetBucketLocation
 )
 
 // NewProxy creates a new S3Proxy. This implements the ServerHTTP interface.
@@ -93,208 +89,205 @@ func NewProxy(s3conf config.S3InboxConf, s3Client *s3.Client, auth userauth.Auth
 		messenger: messenger,
 		database:  db,
 		client:    client,
-		fileIDs:   make(map[uniqueFileID]string),
 	}
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	token, err := p.auth.Authenticate(r)
 	if err != nil {
-		log.Debugln("Request not authenticated")
-		p.notAuthorized(w, r)
+		p.notAuthorized(w, err.Error())
 
 		return
 	}
 
-	switch t := p.detectRequestType(r); t {
-	case MakeBucket, RemoveBucket, Delete, Policy, Get:
-		// Not allowed
-		log.Debug("not allowed known")
-		p.notAllowedResponse(w, r)
-	case Put, List, Other, AbortMultipart:
-		// Allowed
-		log.Debug("allowed known")
-		p.allowedResponse(w, r, token)
+	s3RequestType := detectS3RequestType(r)
+	switch s3RequestType {
+	// These actions we just forward to the s3 backend after ensuring that requests have been made user specific by
+	// prepareForwardPathAndQuery
+	case ListObjects, ListObjectsV2, GetBucketLocation, UploadPart, ListMultiPartUpload, AbortMultiPartUpload:
+		p.forwardRequest(s3RequestType, w, r, token)
+	case PutObject, CreateMultiPartUpload, CompleteMultiPartUpload:
+		p.handleUpload(s3RequestType, w, r, token)
 	default:
-		log.Debugf("Unexpected request (%v) not allowed", r)
-		p.notAllowedResponse(w, r)
+		p.notAllowedResponse(w, fmt.Sprintf("user: %s, attempted to do not allowed request: method: %s, path: %s, query: %s", token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery))
 	}
 }
 
 // Report 500 to the user, log the original error
-func (p *Proxy) internalServerError(w http.ResponseWriter, r *http.Request, err string) {
+func (p *Proxy) internalServerError(w http.ResponseWriter, err string) {
 	log.Error(err)
-	msg := fmt.Sprintf("Internal server error for request (%v)", r)
-	reportError(http.StatusInternalServerError, msg, w)
+	reportError(http.StatusInternalServerError, "Internal Error", w)
 }
 
-func (p *Proxy) notAllowedResponse(w http.ResponseWriter, _ *http.Request) {
-	reportError(http.StatusForbidden, "not allowed response", w)
+func (p *Proxy) notAllowedResponse(w http.ResponseWriter, err string) {
+	log.Warn(err)
+	reportError(http.StatusForbidden, "Forbidden", w)
 }
 
-func (p *Proxy) notAuthorized(w http.ResponseWriter, _ *http.Request) {
-	reportError(http.StatusUnauthorized, "not authorized", w)
+func (p *Proxy) notAuthorized(w http.ResponseWriter, err string) {
+	log.Warn(err)
+	reportError(http.StatusUnauthorized, "Unauthorized", w)
 }
 
-func (p *Proxy) allowedResponse(w http.ResponseWriter, r *http.Request, token jwt.Token) {
-	log.Debug("prepend")
-	// Check whether token username and filepath match
-	str, err := url.ParseRequestURI(r.URL.Path)
-	if err != nil || str.Path == "" {
-		reportError(http.StatusBadRequest, err.Error(), w)
+// prepareForwardPathAndQuery prepares the new path and query to be used for the s3 request to be user specific when
+// reaching the s3 backend
+func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPath, originQuery, tokenSubject string) (string, string, error) {
+	str, err := url.ParseRequestURI(originPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	if str.Path == "" {
+		return "", "", fmt.Errorf("invalid path: %s", originPath)
 	}
 
 	path := strings.Split(str.Path, "/")
-	if strings.Contains(token.Subject(), "@") {
-		if strings.ReplaceAll(token.Subject(), "@", "_") != path[1] {
-			reportError(http.StatusBadRequest, fmt.Sprintf("token supplied username: %s, but URL had: %s", token.Subject(), path[1]), w)
-
-			return
-		}
-	} else if token.Subject() != path[1] {
-		reportError(http.StatusBadRequest, fmt.Sprintf("token supplied username: %s, but URL had: %s", token.Subject(), path[1]), w)
-
-		return
+	if strings.Contains(tokenSubject, "@") {
+		tokenSubject = strings.ReplaceAll(tokenSubject, "@", "_")
 	}
-	err = p.prependBucketToHostPath(r)
+
+	userNameInPath := path[1]
+	if tokenSubject != userNameInPath {
+		return "", "", fmt.Errorf("token supplied username: %s, but URL had: %s", tokenSubject, path[1])
+	}
+
+	var newPath, newQuery string
+	switch s3RequestType {
+	case ListObjects, ListObjectsV2:
+		newPath = "/" + p.s3Conf.Bucket
+		if strings.Contains(originQuery, "prefix") {
+			params := strings.Split(originQuery, "prefix=")
+			if !strings.HasPrefix(params[1], tokenSubject) {
+				newQuery = params[0] + "prefix=" + tokenSubject + "%2F" + params[1]
+			}
+		} else {
+			newQuery = originQuery + "&prefix=" + tokenSubject + "%2F"
+		}
+	default:
+		newPath = "/" + p.s3Conf.Bucket + originPath
+		newQuery = originQuery
+	}
+
+	return newPath, newQuery, nil
+}
+
+// forwardRequest forwards the request to the s3 backend after making request user specific, then forwards response to client
+func (p *Proxy) forwardRequest(s3RequestType S3RequestType, w http.ResponseWriter, r *http.Request, token jwt.Token) {
+	var err error
+	r.URL.Path, r.URL.RawQuery, err = p.prepareForwardPathAndQuery(s3RequestType, r.URL.Path, r.URL.RawQuery, token.Subject())
 	if err != nil {
 		reportError(http.StatusBadRequest, err.Error(), w)
-	}
-
-	username := token.Subject()
-	rawFilepath := strings.Replace(r.URL.Path, "/"+p.s3Conf.Bucket+"/", "", 1)
-	anonymizedFilepath := helper.AnonymizeFilepath(rawFilepath, username)
-
-	filePath, err := formatUploadFilePath(anonymizedFilepath)
-	if err != nil {
-		reportError(http.StatusNotAcceptable, err.Error(), w)
 
 		return
 	}
 
-	fileIdentifier := uniqueFileID{
-		username: username,
-		filePath: filePath,
-	}
-
-	location := p.s3Conf.Endpoint + "/" + p.s3Conf.Bucket
-	// if this is an upload request
-	if p.detectRequestType(r) == Put && p.fileIDs[fileIdentifier] == "" {
-		// register file in database
-		log.Debugf("registering file %v in the database with location: %s", r.URL.Path, location)
-		p.fileIDs[fileIdentifier], err = p.database.RegisterFile(nil, location, filePath, username)
-		log.Debugf("fileId: %v", p.fileIDs[fileIdentifier])
-		if err != nil {
-			p.internalServerError(w, r, fmt.Sprintf("failed to register file in database: %v", err))
-
-			return
-		}
-
-		// check if the file already exists, in that case send an overwrite message,
-		// so that the FEGA portal is informed that a new version of the file exists.
-		err = p.sendMessageOnOverwrite(r, p.fileIDs[fileIdentifier], rawFilepath, token)
-		if err != nil {
-			p.internalServerError(w, r, err.Error())
-
-			return
-		}
-	}
-
-	log.Debug("Forwarding to backend")
-	s3response, err := p.forwardToBackend(r)
+	s3response, err := p.forwardRequestToBackend(r)
 	if err != nil {
-		p.internalServerError(w, r, fmt.Sprintf("forwarding error: %v", err))
+		p.internalServerError(w, fmt.Sprintf("forwarding error: %v", err))
+
+		return
+	}
+
+	if err := p.forwardResponseToClient(s3response, w); err != nil {
+		p.internalServerError(w, fmt.Sprintf("failed to forward reponse to client: %v", err))
+	}
+}
+func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter, r *http.Request, token jwt.Token) {
+	username := token.Subject()
+
+	var err error
+	r.URL.Path, r.URL.RawQuery, err = p.prepareForwardPathAndQuery(s3RequestType, r.URL.Path, r.URL.RawQuery, username)
+	if err != nil {
+		reportError(http.StatusBadRequest, err.Error(), w)
+
+		return
+	}
+
+	s3FilePath := strings.Replace(r.URL.Path, "/"+p.s3Conf.Bucket+"/", "", 1)
+	filePath, err := formatUploadFilePath(helper.AnonymizeFilepath(s3FilePath, username))
+	if err != nil {
+		reportError(http.StatusBadRequest, err.Error(), w)
+
+		return
+	}
+
+	fileID, err := p.database.GetFileIDInInbox(r.Context(), username, filePath)
+	if err != nil {
+		p.internalServerError(w, fmt.Sprintf("failed to check/get existing file id from database: %v", err))
+
+		return
+	}
+
+	// if this is an upload request
+	if fileID == "" {
+		fileID, err = p.database.RegisterFile(nil, p.s3Conf.Endpoint+"/"+p.s3Conf.Bucket, filePath, username)
+		if err != nil {
+			p.internalServerError(w, fmt.Sprintf("failed to register file in database: %v", err))
+
+			return
+		}
+	}
+
+	// check if the file already exists when an upload completes, in that case send an overwrite message,
+	// so that the FEGA portal is informed that a new version
+	if s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload {
+		if err := p.sendMessageOnOverwrite(r.Context(), username, fileID, s3FilePath, filePath); err != nil {
+			p.internalServerError(w, err.Error())
+
+			return
+		}
+	}
+
+	s3Response, err := p.forwardRequestToBackend(r)
+	if err != nil {
+		p.internalServerError(w, fmt.Sprintf("forwarding error: %v", err))
 
 		return
 	}
 
 	// Send message to upstream and set file as uploaded in the database
 	// nolint: nestif // We need a nested if statement for checking whether fileId is persisted during possible reconnections
-	if p.uploadFinishedSuccessfully(r, s3response) {
-		log.Debug("create message")
-		message, err := p.CreateMessageFromRequest(r, token, anonymizedFilepath)
+	if s3Response.StatusCode == 200 && (s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload) {
+		message, err := p.CreateMessageFromRequest(r.Context(), token.Subject(), s3FilePath)
 		if err != nil {
-			p.internalServerError(w, r, err.Error())
+			p.internalServerError(w, err.Error())
 
 			return
 		}
 		jsonMessage, err := json.Marshal(message)
 		if err != nil {
-			p.internalServerError(w, r, fmt.Sprintf("failed to marshal rabbitmq message to json: %v", err))
+			p.internalServerError(w, fmt.Sprintf("failed to marshal rabbitmq message to json: %v", err))
 
 			return
 		}
 
-		err = p.checkAndSendMessage(p.fileIDs[fileIdentifier], jsonMessage, r)
-		if err != nil {
-			p.internalServerError(w, r, fmt.Sprintf("broker error: %v", err))
+		if err = p.checkAndSendMessage(fileID, jsonMessage); err != nil {
+			p.internalServerError(w, fmt.Sprintf("broker error: %v", err))
 
 			return
 		}
 
-		// The following block is for treating the case when the client loses connection to the server and then it reconnects to a
-		// different instance of s3inbox. For more details see #1358.
-		if p.fileIDs[fileIdentifier] == "" {
-			p.fileIDs[fileIdentifier], err = p.database.GetFileIDByUserPathAndStatus(username, filePath, "registered")
-			if err != nil {
-				p.internalServerError(w, r, fmt.Sprintf("failed to retrieve fileID from database: %v", err))
-
-				return
-			}
-
-			log.Debugf("resuming work on file with fileId: %v", p.fileIDs[fileIdentifier])
-		}
-
-		if err := p.storeObjectSizeInDB(r.Context(), rawFilepath, p.fileIDs[fileIdentifier]); err != nil {
-			log.Errorf("storeObjectSizeInDB failed because: %s", err.Error())
-			p.internalServerError(w, r, "storeObjectSizeInDB failed")
+		if err := p.storeObjectSizeInDB(r.Context(), s3FilePath, fileID); err != nil {
+			p.internalServerError(w, fmt.Sprintf("storeObjectSizeInDB failed because: %v", err))
 
 			return
 		}
 
-		log.Debugf("marking file %v as 'uploaded' in database", p.fileIDs[fileIdentifier])
-		err = p.database.UpdateFileEventLog(p.fileIDs[fileIdentifier], "uploaded", "inbox", "{}", string(jsonMessage))
-		if err != nil {
-			p.internalServerError(w, r, fmt.Sprintf("could not connect to db: %v", err))
+		if err := p.database.UpdateFileEventLog(fileID, "uploaded", "inbox", "{}", string(jsonMessage)); err != nil {
+			p.internalServerError(w, fmt.Sprintf("could not connect to db: %v", err))
 
 			return
 		}
-
-		delete(p.fileIDs, fileIdentifier)
+		log.Infof("user: %s, uploaded file: %s, with id: %s", username, filePath, fileID)
 	}
 
-	// Writing non-200 to the response before the headers propagate the error
-	// to the s3cmd client.
-	// Writing 200 here breaks uploads though, and writing non-200 codes after
-	// the headers results in the error message always being
-	// "MD5 Sums don't match!".
-	if s3response.StatusCode < 200 || s3response.StatusCode > 299 {
-		w.WriteHeader(s3response.StatusCode)
+	if err := p.forwardResponseToClient(s3Response, w); err != nil {
+		p.internalServerError(w, fmt.Sprintf("failed to forward reponse to client: %v", err))
 	}
-
-	// Redirect answer
-	log.Debug("redirect answer")
-	for header, values := range s3response.Header {
-		for _, value := range values {
-			w.Header().Add(header, value)
-		}
-	}
-
-	_, err = io.Copy(w, s3response.Body)
-	if err != nil {
-		p.internalServerError(w, r, fmt.Sprintf("redirect error: %v", err))
-
-		return
-	}
-
-	// Read any remaining data in the connection and
-	// Close so connection can be reused.
-	_, _ = io.ReadAll(s3response.Body)
-	_ = s3response.Body.Close()
 }
 
 // Renew the connection to MQ if necessary, then send message
-func (p *Proxy) checkAndSendMessage(fileID string, jsonMessage []byte, r *http.Request) error {
+func (p *Proxy) checkAndSendMessage(fileID string, jsonMessage []byte) error {
 	var err error
 	if p.messenger == nil {
 		return errors.New("messenger is down")
@@ -315,7 +308,6 @@ func (p *Proxy) checkAndSendMessage(fileID string, jsonMessage []byte, r *http.R
 		}
 	}
 
-	log.Debugf("Sending message with id %s", fileID)
 	if err := p.messenger.SendMessage(fileID, p.messenger.Conf.Exchange, p.messenger.Conf.RoutingKey, jsonMessage); err != nil {
 		return fmt.Errorf("error when sending message to broker: %v", err)
 	}
@@ -323,115 +315,51 @@ func (p *Proxy) checkAndSendMessage(fileID string, jsonMessage []byte, r *http.R
 	return nil
 }
 
-func (p *Proxy) uploadFinishedSuccessfully(req *http.Request, response *http.Response) bool {
-	if response.StatusCode != 200 {
-		return false
-	}
-
-	switch req.Method {
-	case http.MethodPut:
-		if !strings.Contains(req.URL.String(), "partNumber") {
-			return true
-		}
-
-		return false
-	case http.MethodPost:
-		if strings.Contains(req.URL.String(), "uploadId") {
-			return true
-		}
-
-		return false
-	default:
-
-		return false
-	}
-}
-
-func (p *Proxy) forwardToBackend(r *http.Request) (*http.Response, error) {
+func (p *Proxy) forwardRequestToBackend(r *http.Request) (*http.Response, error) {
 	p.resignHeader(r)
-
 	// Redirect request
-	nr, err := http.NewRequest(r.Method, p.s3Conf.Endpoint+r.URL.String(), r.Body) // #nosec G704 -- endpoint and port controlled by configuration, TODO verify if r.URL needs to be sanitized
+	nr, err := http.NewRequest(r.Method, p.s3Conf.Endpoint+r.URL.String(), r.Body) // #nosec G704 -- endpoint and port controlled by configuration
 	if err != nil {
-		log.Debug("error when redirecting the request")
-		log.Debug(err)
-
 		return nil, err
 	}
 	nr.Header = r.Header
 	contentLength, _ := strconv.ParseInt(r.Header.Get("content-length"), 10, 64)
 	nr.ContentLength = contentLength
 
-	return p.client.Do(nr) // #nosec G704 -- endpoint and port controlled by configuration, TODO verify if r.URL needs to be sanitized
+	return p.client.Do(nr) // #nosec G704 -- endpoint and port controlled by configuration
 }
-
-// Add bucket to host path
-func (p *Proxy) prependBucketToHostPath(r *http.Request) error {
-	bucket := p.s3Conf.Bucket
-
-	// Extract username for request's url path
-	str, err := url.ParseRequestURI(r.URL.Path)
-	if err != nil || str.Path == "" {
-		return fmt.Errorf("failed to get path from query (%v)", r.URL.Path)
+func (p *Proxy) forwardResponseToClient(s3response *http.Response, w http.ResponseWriter) error {
+	// Writing non-200 to the response before the headers propagate the error
+	// to the s3cmd client.
+	// Writing 200 here breaks uploads though, and writing non-200 codes after
+	// the headers results in the error message always being
+	// "MD5 Sums don't match!".
+	if s3response.StatusCode < 200 || s3response.StatusCode > 299 {
+		w.WriteHeader(s3response.StatusCode)
 	}
-	path := strings.Split(str.Path, "/")
-	username := path[1]
 
-	log.Debugf("incoming path: %s", r.URL.Path)
-	log.Debugf("incoming raw: %s", r.URL.RawQuery)
-
-	// Restructure request to query the users folder instead of the general bucket
-	switch r.Method {
-	case http.MethodGet:
-		switch {
-		case strings.Contains(r.URL.String(), "?uploadId"):
-			// resume multipart upload
-			r.URL.Path = "/" + bucket + r.URL.Path
-		case strings.Contains(r.URL.String(), "?uploads"):
-			// list multipart upload
-			r.URL.Path = "/" + bucket
-			r.URL.RawQuery = "uploads&prefix=" + username + "%2F"
-		case strings.Contains(r.URL.String(), "?delimiter"):
-			r.URL.Path = "/" + bucket + "/"
-			if strings.Contains(r.URL.RawQuery, "&prefix") {
-				params := strings.Split(r.URL.RawQuery, "&prefix=")
-				r.URL.RawQuery = params[0] + "&prefix=" + username + "%2F" + params[1]
-			} else {
-				r.URL.RawQuery = r.URL.RawQuery + "&prefix=" + username + "%2F"
-			}
-			log.Debug("new Raw Query: ", r.URL.RawQuery)
-		case strings.Contains(r.URL.String(), "?location") || strings.Contains(r.URL.String(), "&prefix"):
-			r.URL.Path = "/" + bucket + "/"
-			log.Debug("new Path: ", r.URL.Path)
-		default:
-			r.URL.Path = "/" + bucket + "/"
+	for header, values := range s3response.Header {
+		for _, value := range values {
+			w.Header().Add(header, value)
 		}
-	case http.MethodPost:
-		r.URL.Path = "/" + bucket + r.URL.Path
-		log.Debug("new Path: ", r.URL.Path)
-	case http.MethodPut:
-		r.URL.Path = "/" + bucket + r.URL.Path
-		log.Info("new PUT Path: ", r.URL.Path)
-	case http.MethodDelete:
-		if strings.Contains(r.URL.String(), "?uploadId") {
-			// abort multipart upload
-			r.URL.Path = "/" + bucket + r.URL.Path
-		}
-	default:
-		log.Errorf("unknown request: %s", r.Method)
-
-		return errors.New("unknown request method")
 	}
-	log.Infof("User: %v, Request type %v, Path: %v", username, r.Method, r.URL.Path)
+
+	if _, err := io.Copy(w, s3response.Body); err != nil {
+		return err
+	}
+
+	// Read any remaining data in the connection and
+	// Close so connection can be reused.
+	_, _ = io.ReadAll(s3response.Body)
+	_ = s3response.Body.Close()
 
 	return nil
 }
 
 // Function for signing the headers of the s3 requests
-// Used for for creating a signature for with the default
+// Used for creating a signature for with the default
 // credentials of the s3 service and the user's signature (authentication)
 func (p *Proxy) resignHeader(r *http.Request) *http.Request {
-	log.Debugf("Generating resigning header for %s", p.s3Conf.Endpoint)
 	r.Header.Del("X-Amz-Security-Token")
 	r.Header.Del("X-Forwarded-Port")
 	r.Header.Del("X-Forwarded-Proto")
@@ -449,94 +377,109 @@ func (p *Proxy) resignHeader(r *http.Request) *http.Request {
 	return signer.SignV4(*r, p.s3Conf.AccessKey, p.s3Conf.SecretKey, "", p.s3Conf.Region)
 }
 
-// Not necessarily a function on the struct since it does not use any of the
-// members.
-func (p *Proxy) detectRequestType(r *http.Request) S3RequestType {
-	switch r.Method {
-	case http.MethodGet:
-		switch {
-		case strings.HasSuffix(r.URL.String(), "/"):
-			log.Debug("detect Get")
+// detectS3RequestType detects which s3 actions is being taken based upon the http method, path and query
+// Allowed actions:
+//
+// * GetBucketLocation == GET /${bucket}?location
+// For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
+//
+// * ListObjectsV2 == GET /${bucket}?list-type=2
+// For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+// For ListObjectsV2 we enforce that the prefix query argument starts with the token.Subject() such that a user can
+// only see files within a directory named by the token subject
+//
+// * ListObjects == GET /${bucket}
+// For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html
+// Checked by makings sure there are nu query params that indicate other actions
+// Checks that any of the following are not present in the query:
+// "acl", "policy", "cors", "lifecycle", "versioning", "logging", "tagging", "encryption", "website", "notification",
+//
+//	"replication", "analytics", "metrics", "inventory", "ownershipControls", "publicAccessBlock", "object-lock"
+//
+// * PutObject == PUT /${bucket}/${object}
+// For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+// partNumber and uploadId query arguments not present
+// We ensure x-amz-copy-source is not present to now allow CopyObject
+//
+// * UploadPart == PUT /${bucket}/${object}
+// For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+// partNumber and uploadId query arguments present
+//
+// * CreateMultiPartUpload == POST /${bucket}/${object}?uploads
+// For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+//
+// * CompleteMultiPartUpload == POST /${bucket}/${object}?uploads
+// For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+//
+// * AbortMultiPartUpload == DELETE /${bucket}/${object}?uploads
+// For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+//
+// * ListMultiPartUpload == Get /${bucket}/${object}?uploadId
+// For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+func detectS3RequestType(r *http.Request) S3RequestType {
+	query := r.URL.Query()
 
-			return Get
-		case strings.Contains(r.URL.String(), "?acl"):
-			log.Debug("detect Policy")
+	pathParts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	isBucketPath := len(pathParts) == 1 && pathParts[0] != ""
+	isObjectPath := len(pathParts) > 1 && pathParts[0] != "" && pathParts[1] != ""
 
-			return Policy
-		default:
-			log.Debug("detect List")
-
-			return List
-		}
-	case http.MethodDelete:
-		switch {
-		case strings.HasSuffix(r.URL.String(), "/"):
-			log.Debug("detect RemoveBucket")
-
-			return RemoveBucket
-		case strings.Contains(r.URL.String(), "uploadId"):
-			log.Debug("detect AbortMultipart")
-
-			return AbortMultipart
-		default:
-			// Do we allow deletion of files?
-			log.Debug("detect Delete")
-
-			return Delete
-		}
-	case http.MethodPut:
-		switch {
-		case strings.HasSuffix(r.URL.String(), "/"):
-			log.Debug("detect MakeBucket")
-
-			return MakeBucket
-		case strings.Contains(r.URL.String(), "?policy"):
-			log.Debug("detect Policy")
-
-			return Policy
-		default:
-			// Should decide if we will handle copy here or through authentication
-			log.Debug("detect Put")
-
-			return Put
-		}
+	switch {
+	// ListObjectsV2
+	case r.Method == http.MethodGet && isBucketPath && query.Get("list-type") == "2":
+		return ListObjectsV2
+	case r.Method == http.MethodGet && isObjectPath && query.Has("uploadId"):
+		return ListMultiPartUpload
+	case r.Method == http.MethodGet && isBucketPath && query.Has("location"):
+		return GetBucketLocation
+	case r.Method == http.MethodGet && isBucketPath && !query.Has("acl") && !query.Has("policy") &&
+		!query.Has("cors") && !query.Has("lifecycle") && !query.Has("versioning") &&
+		!query.Has("location") && !query.Has("logging") && !query.Has("tagging") &&
+		!query.Has("encryption") && !query.Has("website") && !query.Has("notification") &&
+		!query.Has("replication") && !query.Has("analytics") && !query.Has("metrics") &&
+		!query.Has("inventory") && !query.Has("ownershipControls") && !query.Has("publicAccessBlock") &&
+		!query.Has("object-lock"):
+		return ListObjects
+	case r.Method == http.MethodPut && isObjectPath && !query.Has("partNumber") && !query.Has("uploadId") && r.Header.Get("x-amz-copy-source") == "":
+		return PutObject
+	case r.Method == http.MethodPut && isObjectPath && query.Has("partNumber") && query.Has("uploadId") && r.Header.Get("x-amz-copy-source") == "":
+		return UploadPart
+	case r.Method == http.MethodPost && isObjectPath && query.Has("uploads"):
+		return CreateMultiPartUpload
+	case r.Method == http.MethodPost && isObjectPath && query.Has("uploadId"):
+		return CompleteMultiPartUpload
+	case r.Method == http.MethodDelete && isObjectPath && query.Has("uploadId"):
+		return AbortMultiPartUpload
 	default:
-		log.Debug("detect Other")
-
-		return Other
+		return Unsupported
 	}
 }
 
 // CreateMessageFromRequest is a function that can take a http request and
 // figure out the correct rabbitmq message to send from it.
-func (p *Proxy) CreateMessageFromRequest(r *http.Request, claims jwt.Token, anonymizedFilepath string) (Event, error) {
+func (p *Proxy) CreateMessageFromRequest(ctx context.Context, username, s3FilePath string) (Event, error) {
 	event := Event{}
 	checksum := Checksum{}
 	var err error
 
-	checksum.Value, event.Filesize, err = p.requestInfo(r.Context(), r.URL.Path)
+	checksum.Value, event.Filesize, err = p.requestInfo(ctx, s3FilePath)
 	if err != nil {
 		return event, fmt.Errorf("could not get checksum information: %s", err)
 	}
 
 	// Case for simple upload
 	event.Operation = "upload"
-	event.Filepath = anonymizedFilepath
+	event.Filepath = s3FilePath
 
-	event.Username = claims.Subject()
+	event.Username = username
 	checksum.Type = "md5"
 	event.Checksum = []any{checksum}
-	privateClaims := claims.PrivateClaims()
-	log.Info("user ", event.Username, " with pilot ", privateClaims["pilot"], " uploaded file ", event.Filepath, " with checksum ", checksum.Value, " at ", time.Now())
 
 	return event, nil
 }
 
 // RequestInfo is a function that makes a request to the S3 and collects
 // the etag and size information for the uploaded document
-func (p *Proxy) requestInfo(ctx context.Context, fullPath string) (string, int64, error) {
-	filePath := strings.Replace(fullPath, "/"+p.s3Conf.Bucket+"/", "", 1)
-
+func (p *Proxy) requestInfo(ctx context.Context, filePath string) (string, int64, error) {
 	input := &s3.HeadObjectInput{
 		Bucket: aws.String(p.s3Conf.Bucket),
 		Key:    aws.String(filePath),
@@ -544,8 +487,6 @@ func (p *Proxy) requestInfo(ctx context.Context, fullPath string) (string, int64
 
 	result, err := p.s3Client.HeadObject(ctx, input)
 	if err != nil {
-		log.Debug(err.Error())
-
 		return "", 0, err
 	}
 
@@ -558,48 +499,43 @@ func (p *Proxy) requestInfo(ctx context.Context, fullPath string) (string, int64
 
 // checkFileExists makes a request to the S3 to check whether the file already
 // is uploaded. Returns a bool indicating whether the file was found.
-func (p *Proxy) checkFileExists(ctx context.Context, fullPath string) (bool, error) {
-	filePath := strings.Replace(fullPath, "/"+p.s3Conf.Bucket+"/", "", 1)
-
+func (p *Proxy) checkFileExists(ctx context.Context, s3FilePath string) (bool, error) {
 	result, err := p.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(p.s3Conf.Bucket),
-		Key:    aws.String(filePath),
+		Key:    aws.String(s3FilePath),
 	})
 
 	if err != nil && strings.Contains(err.Error(), "StatusCode: 404") {
-		log.Debugf("s3 could not find file %s: %s", fullPath, err.Error())
-
 		return false, nil
 	}
 
 	return result != nil, err
 }
 
-func (p *Proxy) sendMessageOnOverwrite(r *http.Request, fileID, rawFilepath string, token jwt.Token) error {
-	exist, err := p.checkFileExists(r.Context(), r.URL.Path)
+func (p *Proxy) sendMessageOnOverwrite(ctx context.Context, username, fileID, s3FilePath, filepath string) error {
+	exist, err := p.checkFileExists(ctx, s3FilePath)
 	if err != nil {
 		return err
 	}
-	if exist {
-		username := token.Subject()
-		msg := schema.InboxRemove{
-			User:      username,
-			FilePath:  rawFilepath,
-			Operation: "remove",
-		}
+	if !exist {
+		return nil
+	}
 
-		privateClaims := token.PrivateClaims()
-		log.Info("user ", msg.User, " with pilot ", privateClaims["pilot"], " will overwrite file ", msg.FilePath, " at ", time.Now())
+	log.Infof("user: %s, reuploaded file: %s, with id: %s", username, filepath, fileID)
+	msg := schema.InboxRemove{
+		User:      username,
+		FilePath:  s3FilePath,
+		Operation: "remove",
+	}
 
-		jsonMessage, err := json.Marshal(msg)
-		if err != nil {
-			return err
-		}
+	jsonMessage, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
 
-		err = p.checkAndSendMessage(fileID, jsonMessage, r)
-		if err != nil {
-			return err
-		}
+	err = p.checkAndSendMessage(fileID, jsonMessage)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -651,10 +587,10 @@ func reportError(errorCode int, message string, w http.ResponseWriter) {
 	}
 }
 
-func (p *Proxy) storeObjectSizeInDB(ctx context.Context, path, fileID string) error {
+func (p *Proxy) storeObjectSizeInDB(ctx context.Context, s3FilePath, fileID string) error {
 	o, err := p.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(p.s3Conf.Bucket),
-		Key:    aws.String(path),
+		Key:    aws.String(s3FilePath),
 	})
 	if err != nil {
 		return err

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -155,14 +155,24 @@ func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPa
 	switch s3RequestType {
 	case ListObjects, ListObjectsV2:
 		newPath = "/" + p.s3Conf.Bucket
-		if strings.Contains(originQuery, "prefix") {
-			params := strings.Split(originQuery, "prefix=")
-			if !strings.HasPrefix(params[1], tokenSubject) {
-				newQuery = params[0] + "prefix=" + tokenSubject + "%2F" + params[1]
-			}
-		} else {
-			newQuery = originQuery + "&prefix=" + tokenSubject + "%2F"
+
+		queryValues, err := url.ParseQuery(originQuery)
+		if err != nil {
+			return "", "", err
 		}
+		requiredPrefix := tokenSubject + "/"
+		existingPrefix := queryValues.Get("prefix")
+		switch {
+		case existingPrefix == "":
+			queryValues.Set("prefix", requiredPrefix)
+		case existingPrefix == tokenSubject:
+			queryValues.Set("prefix", requiredPrefix)
+		case strings.HasPrefix(existingPrefix, requiredPrefix):
+			queryValues.Set("prefix", existingPrefix)
+		default:
+			queryValues.Set("prefix", requiredPrefix+existingPrefix)
+		}
+		newQuery = queryValues.Encode()
 	default:
 		newPath = "/" + p.s3Conf.Bucket + originPath
 		newQuery = originQuery
@@ -329,6 +339,12 @@ func (p *Proxy) forwardRequestToBackend(r *http.Request) (*http.Response, error)
 	return p.client.Do(nr) // #nosec G704 -- endpoint and port controlled by configuration
 }
 func (p *Proxy) forwardResponseToClient(s3response *http.Response, w http.ResponseWriter) error {
+	for header, values := range s3response.Header {
+		for _, value := range values {
+			w.Header().Add(header, value)
+		}
+	}
+
 	// Writing non-200 to the response before the headers propagate the error
 	// to the s3cmd client.
 	// Writing 200 here breaks uploads though, and writing non-200 codes after
@@ -336,12 +352,6 @@ func (p *Proxy) forwardResponseToClient(s3response *http.Response, w http.Respon
 	// "MD5 Sums don't match!".
 	if s3response.StatusCode < 200 || s3response.StatusCode > 299 {
 		w.WriteHeader(s3response.StatusCode)
-	}
-
-	for header, values := range s3response.Header {
-		for _, value := range values {
-			w.Header().Add(header, value)
-		}
 	}
 
 	if _, err := io.Copy(w, s3response.Body); err != nil {
@@ -408,10 +418,10 @@ func (p *Proxy) resignHeader(r *http.Request) *http.Request {
 // * CreateMultiPartUpload == POST /${bucket}/${object}?uploads
 // For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
 //
-// * CompleteMultiPartUpload == POST /${bucket}/${object}?uploads
+// * CompleteMultiPartUpload == POST /${bucket}/${object}?uploadId
 // For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
 //
-// * AbortMultiPartUpload == DELETE /${bucket}/${object}?uploads
+// * AbortMultiPartUpload == DELETE /${bucket}/${object}?uploadId
 // For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
 //
 // * ListMultiPartUpload == Get /${bucket}/${object}?uploadId

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -159,6 +159,7 @@ func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPa
 	switch s3RequestType {
 	case GetBucketLocation:
 		newPath = "/" + p.s3Conf.Bucket
+		newQuery = originQuery
 	case ListObjects, ListObjectsV2, ListMultiPartUploads:
 		newPath = "/" + p.s3Conf.Bucket
 

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -142,11 +142,14 @@ func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPa
 		return "", "", fmt.Errorf("invalid path: %s", originPath)
 	}
 
-	path := strings.Split(str.Path, "/")
 	if strings.Contains(tokenSubject, "@") {
 		tokenSubject = strings.ReplaceAll(tokenSubject, "@", "_")
 	}
 
+	path := strings.Split(str.Path, "/")
+	if len(path) < 2 || path[1] == "" {
+		return "", "", fmt.Errorf("invalid path: %s", originPath)
+	}
 	userNameInPath := path[1]
 	if tokenSubject != userNameInPath {
 		return "", "", fmt.Errorf("token supplied username: %s, but URL had: %s", tokenSubject, path[1])

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -153,7 +153,7 @@ func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPa
 
 	var newPath, newQuery string
 	switch s3RequestType {
-	case ListObjects, ListObjectsV2:
+	case ListObjects, ListObjectsV2, ListMultiPartUpload:
 		newPath = "/" + p.s3Conf.Bucket
 
 		queryValues, err := url.ParseQuery(originQuery)
@@ -199,7 +199,7 @@ func (p *Proxy) forwardRequest(s3RequestType S3RequestType, w http.ResponseWrite
 	}
 
 	if err := p.forwardResponseToClient(s3response, w); err != nil {
-		p.internalServerError(w, fmt.Sprintf("failed to forward reponse to client: %v", err))
+		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
 }
 func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter, r *http.Request, token jwt.Token) {
@@ -292,7 +292,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	}
 
 	if err := p.forwardResponseToClient(s3Response, w); err != nil {
-		p.internalServerError(w, fmt.Sprintf("failed to forward reponse to client: %v", err))
+		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
 }
 
@@ -354,14 +354,15 @@ func (p *Proxy) forwardResponseToClient(s3response *http.Response, w http.Respon
 		w.WriteHeader(s3response.StatusCode)
 	}
 
+	defer func() {
+		// Read any remaining data in the connection and
+		// Close so connection can be reused.
+		_, _ = io.ReadAll(s3response.Body)
+		_ = s3response.Body.Close()
+	}()
 	if _, err := io.Copy(w, s3response.Body); err != nil {
 		return err
 	}
-
-	// Read any remaining data in the connection and
-	// Close so connection can be reused.
-	_, _ = io.ReadAll(s3response.Body)
-	_ = s3response.Body.Close()
 
 	return nil
 }
@@ -424,7 +425,7 @@ func (p *Proxy) resignHeader(r *http.Request) *http.Request {
 // * AbortMultiPartUpload == DELETE /${bucket}/${object}?uploadId
 // For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
 //
-// * ListMultiPartUpload == Get /${bucket}/${object}?uploadId
+// * ListMultiPartUpload == Get /${bucket}/${object}?uploads
 // For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
 func detectS3RequestType(r *http.Request) S3RequestType {
 	query := r.URL.Query()
@@ -437,7 +438,7 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 	// ListObjectsV2
 	case r.Method == http.MethodGet && isBucketPath && query.Get("list-type") == "2":
 		return ListObjectsV2
-	case r.Method == http.MethodGet && isObjectPath && query.Has("uploadId"):
+	case r.Method == http.MethodGet && isObjectPath && query.Has("uploads"):
 		return ListMultiPartUpload
 	case r.Method == http.MethodGet && isBucketPath && query.Has("location"):
 		return GetBucketLocation
@@ -447,7 +448,7 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 		!query.Has("encryption") && !query.Has("website") && !query.Has("notification") &&
 		!query.Has("replication") && !query.Has("analytics") && !query.Has("metrics") &&
 		!query.Has("inventory") && !query.Has("ownershipControls") && !query.Has("publicAccessBlock") &&
-		!query.Has("object-lock"):
+		!query.Has("object-lock") && !query.Has("uploads"):
 		return ListObjects
 	case r.Method == http.MethodPut && isObjectPath && !query.Has("partNumber") && !query.Has("uploadId") && r.Header.Get("x-amz-copy-source") == "":
 		return PutObject

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -246,10 +246,12 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 		}
 	}
 
-	// check if the file already exists when an upload completes, in that case send an overwrite message,
+	isReupload := false
+	// check if the file already exists when an upload completes, in that case send an overwrite message when the s3 has responded with 200,
 	// so that the FEGA portal is informed that a new version
 	if s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload {
-		if err := p.sendMessageOnOverwrite(r.Context(), username, fileID, s3FilePath, filePath); err != nil {
+		isReupload, err = p.checkFileExists(r.Context(), s3FilePath)
+		if err != nil {
 			p.internalServerError(w, err.Error())
 
 			return
@@ -262,6 +264,9 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 
 		return
 	}
+	defer func() {
+		_ = s3Response.Body.Close()
+	}()
 
 	// Send message to upstream and set file as uploaded in the database
 	// nolint: nestif // We need a nested if statement for checking whether fileId is persisted during possible reconnections
@@ -296,14 +301,22 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 
 			return
 		}
-		log.Infof("user: %s, uploaded file: %s, with id: %s", username, filePath, fileID)
+
+		if isReupload {
+			log.Infof("user: %s, reuploaded file: %s, with id: %s", username, filePath, fileID)
+			if err := p.sendMessageOnOverwrite(username, fileID, s3FilePath); err != nil {
+				p.internalServerError(w, err.Error())
+
+				return
+			}
+		} else {
+			log.Infof("user: %s, uploaded file: %s, with id: %s", username, filePath, fileID)
+		}
 	}
 
 	if err := p.forwardResponseToClient(s3Response, w); err != nil {
 		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
-
-	_ = s3Response.Body.Close()
 }
 
 // Renew the connection to MQ if necessary, then send message
@@ -535,16 +548,7 @@ func (p *Proxy) checkFileExists(ctx context.Context, s3FilePath string) (bool, e
 	return result != nil, err
 }
 
-func (p *Proxy) sendMessageOnOverwrite(ctx context.Context, username, fileID, s3FilePath, filepath string) error {
-	exist, err := p.checkFileExists(ctx, s3FilePath)
-	if err != nil {
-		return err
-	}
-	if !exist {
-		return nil
-	}
-
-	log.Infof("user: %s, reuploaded file: %s, with id: %s", username, filepath, fileID)
+func (p *Proxy) sendMessageOnOverwrite(username, fileID, s3FilePath string) error {
 	msg := schema.InboxRemove{
 		User:      username,
 		FilePath:  s3FilePath,

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -72,7 +72,8 @@ const (
 	UploadPart
 	CreateMultiPartUpload
 	CompleteMultiPartUpload
-	ListMultiPartUpload
+	ListMultiPartUploads
+	ListParts
 	AbortMultiPartUpload
 	GetBucketLocation
 )
@@ -104,7 +105,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch s3RequestType {
 	// These actions we just forward to the s3 backend after ensuring that requests have been made user specific by
 	// prepareForwardPathAndQuery
-	case ListObjects, ListObjectsV2, GetBucketLocation, UploadPart, ListMultiPartUpload, AbortMultiPartUpload:
+	case ListObjects, ListObjectsV2, GetBucketLocation, UploadPart, ListMultiPartUploads, AbortMultiPartUpload, ListParts:
 		p.forwardRequest(s3RequestType, w, r, token)
 	case PutObject, CreateMultiPartUpload, CompleteMultiPartUpload:
 		p.handleUpload(s3RequestType, w, r, token)
@@ -153,7 +154,7 @@ func (p *Proxy) prepareForwardPathAndQuery(s3RequestType S3RequestType, originPa
 
 	var newPath, newQuery string
 	switch s3RequestType {
-	case ListObjects, ListObjectsV2, ListMultiPartUpload:
+	case ListObjects, ListObjectsV2, ListMultiPartUploads:
 		newPath = "/" + p.s3Conf.Bucket
 
 		queryValues, err := url.ParseQuery(originQuery)
@@ -401,7 +402,7 @@ func (p *Proxy) resignHeader(r *http.Request) *http.Request {
 //
 // * ListObjects == GET /${bucket}
 // For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html
-// Checked by makings sure there are nu query params that indicate other actions
+// Checked by making sure there are no query params that indicate other actions
 // Checks that any of the following are not present in the query:
 // "acl", "policy", "cors", "lifecycle", "versioning", "logging", "tagging", "encryption", "website", "notification",
 //
@@ -410,7 +411,7 @@ func (p *Proxy) resignHeader(r *http.Request) *http.Request {
 // * PutObject == PUT /${bucket}/${object}
 // For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 // partNumber and uploadId query arguments not present
-// We ensure x-amz-copy-source is not present to now allow CopyObject
+// We ensure x-amz-copy-source is not present to not allow CopyObject
 //
 // * UploadPart == PUT /${bucket}/${object}
 // For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
@@ -425,8 +426,11 @@ func (p *Proxy) resignHeader(r *http.Request) *http.Request {
 // * AbortMultiPartUpload == DELETE /${bucket}/${object}?uploadId
 // For aws docs see:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
 //
-// * ListMultiPartUpload == Get /${bucket}/${object}?uploads
+// * ListParts == Get /${bucket}/${object}?uploadId
 // For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html
+//
+// * ListMultiPartUploads == Get /${bucket}?uploads
+// For aws docs see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
 func detectS3RequestType(r *http.Request) S3RequestType {
 	query := r.URL.Query()
 
@@ -438,8 +442,10 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 	// ListObjectsV2
 	case r.Method == http.MethodGet && isBucketPath && query.Get("list-type") == "2":
 		return ListObjectsV2
-	case r.Method == http.MethodGet && isObjectPath && query.Has("uploads"):
-		return ListMultiPartUpload
+	case r.Method == http.MethodGet && isBucketPath && query.Has("uploads"):
+		return ListMultiPartUploads
+	case r.Method == http.MethodGet && isObjectPath && query.Has("uploadId"):
+		return ListParts
 	case r.Method == http.MethodGet && isBucketPath && query.Has("location"):
 		return GetBucketLocation
 	case r.Method == http.MethodGet && isBucketPath && !query.Has("acl") && !query.Has("policy") &&
@@ -448,7 +454,7 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 		!query.Has("encryption") && !query.Has("website") && !query.Has("notification") &&
 		!query.Has("replication") && !query.Has("analytics") && !query.Has("metrics") &&
 		!query.Has("inventory") && !query.Has("ownershipControls") && !query.Has("publicAccessBlock") &&
-		!query.Has("object-lock") && !query.Has("uploads"):
+		!query.Has("object-lock") && !query.Has("uploads") && !query.Has("uploadId"):
 		return ListObjects
 	case r.Method == http.MethodPut && isObjectPath && !query.Has("partNumber") && !query.Has("uploadId") && r.Header.Get("x-amz-copy-source") == "":
 		return PutObject

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -117,17 +117,17 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Report 500 to the user, log the original error
 func (p *Proxy) internalServerError(w http.ResponseWriter, err string) {
 	log.Error(err)
-	reportError(http.StatusInternalServerError, "Internal Error", w)
+	reportErrorToClient(http.StatusInternalServerError, "Internal Error", w)
 }
 
 func (p *Proxy) notAllowedResponse(w http.ResponseWriter, err string) {
 	log.Warn(err)
-	reportError(http.StatusForbidden, "Forbidden", w)
+	reportErrorToClient(http.StatusForbidden, "Forbidden", w)
 }
 
 func (p *Proxy) notAuthorized(w http.ResponseWriter, err string) {
 	log.Warn(err)
-	reportError(http.StatusUnauthorized, "Unauthorized", w)
+	reportErrorToClient(http.StatusUnauthorized, "Unauthorized", w)
 }
 
 // prepareForwardPathAndQuery prepares the new path and query to be used for the s3 request to be user specific when
@@ -193,7 +193,8 @@ func (p *Proxy) forwardRequest(s3RequestType S3RequestType, w http.ResponseWrite
 	var err error
 	r.URL.Path, r.URL.RawQuery, err = p.prepareForwardPathAndQuery(s3RequestType, r.URL.Path, r.URL.RawQuery, token.Subject())
 	if err != nil {
-		reportError(http.StatusBadRequest, err.Error(), w)
+		log.Warnf("bad request from user %s: %v", token.Subject(), err)
+		reportErrorToClient(http.StatusBadRequest, "Bad Request", w)
 
 		return
 	}
@@ -217,7 +218,8 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	var err error
 	r.URL.Path, r.URL.RawQuery, err = p.prepareForwardPathAndQuery(s3RequestType, r.URL.Path, r.URL.RawQuery, username)
 	if err != nil {
-		reportError(http.StatusBadRequest, err.Error(), w)
+		log.Warnf("bad request from user %s: %v", token.Subject(), err)
+		reportErrorToClient(http.StatusBadRequest, "Bad Request", w)
 
 		return
 	}
@@ -225,7 +227,8 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	s3FilePath := strings.Replace(r.URL.Path, "/"+p.s3Conf.Bucket+"/", "", 1)
 	filePath, err := formatUploadFilePath(helper.AnonymizeFilepath(s3FilePath, username))
 	if err != nil {
-		reportError(http.StatusBadRequest, err.Error(), w)
+		log.Warnf("bad request from user %s: %v", token.Subject(), err)
+		reportErrorToClient(http.StatusBadRequest, "Bad Request", w)
 
 		return
 	}
@@ -595,7 +598,7 @@ func formatUploadFilePath(filePath string) (string, error) {
 }
 
 // Write the error and its status code to the response
-func reportError(errorCode int, message string, w http.ResponseWriter) {
+func reportErrorToClient(errorCode int, message string, w http.ResponseWriter) {
 	errorResponse := ErrorResponse{
 		Code:    http.StatusText(errorCode),
 		Message: message,

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -192,16 +192,18 @@ func (p *Proxy) forwardRequest(s3RequestType S3RequestType, w http.ResponseWrite
 		return
 	}
 
-	s3response, err := p.forwardRequestToBackend(r)
+	s3Response, err := p.forwardRequestToBackend(r)
 	if err != nil {
 		p.internalServerError(w, fmt.Sprintf("forwarding error: %v", err))
 
 		return
 	}
 
-	if err := p.forwardResponseToClient(s3response, w); err != nil {
+	if err := p.forwardResponseToClient(s3Response, w); err != nil {
 		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
+
+	_ = s3Response.Body.Close()
 }
 func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter, r *http.Request, token jwt.Token) {
 	username := token.Subject()
@@ -295,6 +297,8 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	if err := p.forwardResponseToClient(s3Response, w); err != nil {
 		p.internalServerError(w, fmt.Sprintf("failed to forward response to client: %v", err))
 	}
+
+	_ = s3Response.Body.Close()
 }
 
 // Renew the connection to MQ if necessary, then send message
@@ -339,8 +343,8 @@ func (p *Proxy) forwardRequestToBackend(r *http.Request) (*http.Response, error)
 
 	return p.client.Do(nr) // #nosec G704 -- endpoint and port controlled by configuration
 }
-func (p *Proxy) forwardResponseToClient(s3response *http.Response, w http.ResponseWriter) error {
-	for header, values := range s3response.Header {
+func (p *Proxy) forwardResponseToClient(s3Response *http.Response, w http.ResponseWriter) error {
+	for header, values := range s3Response.Header {
 		for _, value := range values {
 			w.Header().Add(header, value)
 		}
@@ -351,19 +355,16 @@ func (p *Proxy) forwardResponseToClient(s3response *http.Response, w http.Respon
 	// Writing 200 here breaks uploads though, and writing non-200 codes after
 	// the headers results in the error message always being
 	// "MD5 Sums don't match!".
-	if s3response.StatusCode < 200 || s3response.StatusCode > 299 {
-		w.WriteHeader(s3response.StatusCode)
+	if s3Response.StatusCode < 200 || s3Response.StatusCode > 299 {
+		w.WriteHeader(s3Response.StatusCode)
 	}
 
-	defer func() {
-		// Read any remaining data in the connection and
-		// Close so connection can be reused.
-		_, _ = io.ReadAll(s3response.Body)
-		_ = s3response.Body.Close()
-	}()
-	if _, err := io.Copy(w, s3response.Body); err != nil {
+	if _, err := io.Copy(w, s3Response.Body); err != nil {
 		return err
 	}
+
+	// Read any remaining data in the connection
+	_, _ = io.ReadAll(s3Response.Body)
 
 	return nil
 }

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -593,7 +593,6 @@ func formatUploadFilePath(filePath string) (string, error) {
 
 // Write the error and its status code to the response
 func reportError(errorCode int, message string, w http.ResponseWriter) {
-	log.Error(message)
 	errorResponse := ErrorResponse{
 		Code:    http.StatusText(errorCode),
 		Message: message,

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -267,7 +267,7 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 	// Send message to upstream and set file as uploaded in the database when upload is complete(PutObject / CompleteMultipartUpload)
 	// nolint: nestif
 	if s3Response.StatusCode == 200 && (s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload) {
-		message, err := p.CreateMessageFromRequest(r.Context(), token.Subject(), s3FilePath)
+		message, checksum, err := p.CreateMessageFromRequest(r.Context(), token.Subject(), s3FilePath)
 		if err != nil {
 			p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, err.Error())
 
@@ -299,14 +299,14 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 		}
 
 		if isReupload {
-			log.Infof("user: %s, reuploaded file: %s, with id: %s", username, filePath, fileID)
+			log.Infof("user: %s, reuploaded file: %s, with id: %s, checksum: %s", username, filePath, fileID, checksum)
 			if err := p.sendMessageOnOverwrite(username, fileID, s3FilePath); err != nil {
 				p.internalServerError(w, token.Subject(), r.Method, r.URL.Path, r.URL.RawQuery, err.Error())
 
 				return
 			}
 		} else {
-			log.Infof("user: %s, uploaded file: %s, with id: %s", username, filePath, fileID)
+			log.Infof("user: %s, uploaded file: %s, with id: %s, checksum: %s", username, filePath, fileID, checksum)
 		}
 	}
 
@@ -490,14 +490,14 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 
 // CreateMessageFromRequest is a function that can take a http request and
 // figure out the correct rabbitmq message to send from it.
-func (p *Proxy) CreateMessageFromRequest(ctx context.Context, username, s3FilePath string) (Event, error) {
+func (p *Proxy) CreateMessageFromRequest(ctx context.Context, username, s3FilePath string) (Event, string, error) {
 	event := Event{}
 	checksum := Checksum{}
 	var err error
 
 	checksum.Value, event.Filesize, err = p.requestInfo(ctx, s3FilePath)
 	if err != nil {
-		return event, fmt.Errorf("could not get checksum information: %s", err)
+		return event, "", fmt.Errorf("could not get checksum information: %s", err)
 	}
 
 	// Case for simple upload
@@ -508,7 +508,7 @@ func (p *Proxy) CreateMessageFromRequest(ctx context.Context, username, s3FilePa
 	checksum.Type = "md5"
 	event.Checksum = []any{checksum}
 
-	return event, nil
+	return event, checksum.Value, nil
 }
 
 // RequestInfo is a function that makes a request to the S3 and collects

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -458,6 +458,14 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 	isObjectPath := len(pathParts) > 1 && pathParts[0] != "" && pathParts[1] != ""
 
 	switch {
+	// Unsupported actions
+	case query.Has("acl") || query.Has("policy") ||
+		query.Has("cors") || query.Has("lifecycle") || query.Has("versioning") ||
+		query.Has("logging") || query.Has("tagging") || query.Has("encryption") ||
+		query.Has("website") || query.Has("notification") || query.Has("replication") ||
+		query.Has("analytics") || query.Has("metrics") || query.Has("inventory") ||
+		query.Has("ownershipControls") || query.Has("publicAccessBlock") || query.Has("object-lock"):
+		return Unsupported
 	// ListObjectsV2
 	case r.Method == http.MethodGet && isBucketPath && query.Get("list-type") == "2":
 		return ListObjectsV2
@@ -467,13 +475,7 @@ func detectS3RequestType(r *http.Request) S3RequestType {
 		return ListParts
 	case r.Method == http.MethodGet && isBucketPath && query.Has("location"):
 		return GetBucketLocation
-	case r.Method == http.MethodGet && isBucketPath && !query.Has("acl") && !query.Has("policy") &&
-		!query.Has("cors") && !query.Has("lifecycle") && !query.Has("versioning") &&
-		!query.Has("location") && !query.Has("logging") && !query.Has("tagging") &&
-		!query.Has("encryption") && !query.Has("website") && !query.Has("notification") &&
-		!query.Has("replication") && !query.Has("analytics") && !query.Has("metrics") &&
-		!query.Has("inventory") && !query.Has("ownershipControls") && !query.Has("publicAccessBlock") &&
-		!query.Has("object-lock") && !query.Has("uploads") && !query.Has("uploadId"):
+	case r.Method == http.MethodGet && isBucketPath:
 		return ListObjects
 	case r.Method == http.MethodPut && isObjectPath && !query.Has("partNumber") && !query.Has("uploadId") && r.Header.Get("x-amz-copy-source") == "":
 		return PutObject

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -264,8 +264,8 @@ func (p *Proxy) handleUpload(s3RequestType S3RequestType, w http.ResponseWriter,
 		_ = s3Response.Body.Close()
 	}()
 
-	// Send message to upstream and set file as uploaded in the database
-	// nolint: nestif // We need a nested if statement for checking whether fileId is persisted during possible reconnections
+	// Send message to upstream and set file as uploaded in the database when upload is complete(PutObject / CompleteMultipartUpload)
+	// nolint: nestif
 	if s3Response.StatusCode == 200 && (s3RequestType == PutObject || s3RequestType == CompleteMultiPartUpload) {
 		message, err := p.CreateMessageFromRequest(r.Context(), token.Subject(), s3FilePath)
 		if err != nil {

--- a/sda/cmd/s3inbox/proxy.go
+++ b/sda/cmd/s3inbox/proxy.go
@@ -619,5 +619,9 @@ func (p *Proxy) storeObjectSizeInDB(ctx context.Context, s3FilePath, fileID stri
 		return err
 	}
 
+	if o.ContentLength == nil {
+		return errors.New("s3 content length not available")
+	}
+
 	return p.database.SetSubmissionFileSize(fileID, *o.ContentLength)
 }

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -134,6 +134,9 @@ func (s *ProxyTests) SetupTest() {
 	if err != nil {
 		s.T().FailNow()
 	}
+	if err := s.token.Set("sub", "dummy"); err != nil {
+		s.T().FailNow()
+	}
 
 	s3cfg, err := s3config.LoadDefaultConfig(context.TODO(), s3config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(s.s3Conf.AccessKey, s.s3Conf.SecretKey, "")))
 	if err != nil {
@@ -268,14 +271,6 @@ func (s *ProxyTests) TestServeHTTP_disallowed() {
 	assert.Equal(s.T(), 403, w.Result().StatusCode)
 	assert.Equal(s.T(), false, s.fakeServer.PingedAndRestore())
 
-	// Normal get is dissallowed
-	w = httptest.NewRecorder()
-	r.Method = "GET"
-	r.URL, _ = url.Parse("/asdf/")
-	proxy.ServeHTTP(w, r)
-	assert.Equal(s.T(), 403, w.Result().StatusCode)
-	assert.Equal(s.T(), false, s.fakeServer.PingedAndRestore())
-
 	// Put policy is disallowed
 	w = httptest.NewRecorder()
 	r.Method = "PUT"
@@ -317,8 +312,8 @@ func (s *ProxyTests) TestServeHTTPS3Unresponsive() {
 
 	// Just try to list the files
 	r.Method = "GET"
-	r.URL, _ = url.Parse("/dummy/asdf")
-	proxy.allowedResponse(w, r, s.token)
+	r.URL, _ = url.Parse("/dummy")
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 500, w.Result().StatusCode) // nolint:bodyclose
 }
 
@@ -336,7 +331,7 @@ func (s *ProxyTests) TestServeHTTP_MQConnectionClosed() {
 	w := httptest.NewRecorder()
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/db-test-file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\"", "Content-Length": "5"}
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode) // nolint:bodyclose
 	assert.False(s.T(), proxy.messenger.Connection.IsClosed())
 }
@@ -355,7 +350,7 @@ func (s *ProxyTests) TestServeHTTP_MQChannelClosed() {
 	w := httptest.NewRecorder()
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/db-test-file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\"", "Content-Length": "5"}
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode) // nolint:bodyclose
 	assert.False(s.T(), proxy.messenger.Channel.IsClosed())
 }
@@ -375,7 +370,7 @@ func (s *ProxyTests) TestServeHTTP_MQ_Unavailable() {
 	w := httptest.NewRecorder()
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/db-test-file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\"", "Content-Length": "5"}
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 500, w.Result().StatusCode) // nolint:bodyclose
 }
 
@@ -387,10 +382,10 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	proxy := NewProxy(s.s3Fakeconf, s.s3ClientToFake, helper.NewAlwaysAllow(), messenger, db, new(tls.Config))
 
 	// List files works
-	r, err := http.NewRequest("GET", "/dummy/file", nil)
+	r, err := http.NewRequest("GET", "/dummy", nil)
 	assert.NoError(s.T(), err)
 	w := httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 	assert.Equal(s.T(), false, s.fakeServer.PingedAndRestore()) // Testing the pinged interface
@@ -401,15 +396,15 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	assert.NoError(s.T(), err)
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\";", "Content-Length": "5"}
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
 	// Put with partnumber sends no message
 	w = httptest.NewRecorder()
 	r.Method = "PUT"
-	r.URL, _ = url.Parse("/dummy/file?partNumber=5")
-	proxy.allowedResponse(w, r, s.token)
+	r.URL, _ = url.Parse("/dummy/file?partNumber=5&uploadId=1")
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
@@ -417,15 +412,7 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	r.Method = "POST"
 	r.URL, _ = url.Parse("/dummy/file?uploadId=5")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
-	assert.Equal(s.T(), 200, w.Result().StatusCode)
-	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
-
-	// Post without uploadId sends no message
-	r.Method = "POST"
-	r.URL, _ = url.Parse("/dummy/file")
-	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
@@ -433,7 +420,7 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	r.Method = "DELETE"
 	r.URL, _ = url.Parse("/dummy/asdf?uploadId=123")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
@@ -441,33 +428,33 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	// that trigger different code paths in the code.
 	// Delimiter alone
 	r.Method = "GET"
-	r.URL, _ = url.Parse("/dummy/file?delimiter=puppe")
+	r.URL, _ = url.Parse("/dummy?delimiter=puppe")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
 	// Show multiparts uploads
 	r.Method = "GET"
-	r.URL, _ = url.Parse("/dummy/file?uploads")
+	r.URL, _ = url.Parse("/dummy/file?uploadId=1")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
 	// Delimiter alone together with prefix
 	r.Method = "GET"
-	r.URL, _ = url.Parse("/dummy/file?delimiter=puppe&prefix=asdf")
+	r.URL, _ = url.Parse("/dummy?delimiter=puppe&prefix=asdf")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
 	// Location parameter
 	r.Method = "GET"
-	r.URL, _ = url.Parse("/dummy/file?location=fnuffe")
+	r.URL, _ = url.Parse("/dummy?location=fnuffe")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 200, w.Result().StatusCode)
 	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 
@@ -476,8 +463,8 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	r.Method = "PUT"
 	r.URL, _ = url.Parse("/dummy/fi|le")
 	w = httptest.NewRecorder()
-	proxy.allowedResponse(w, r, s.token)
-	assert.Equal(s.T(), 406, w.Result().StatusCode)
+	proxy.ServeHTTP(w, r)
+	assert.Equal(s.T(), 400, w.Result().StatusCode)
 	assert.Equal(s.T(), false, s.fakeServer.PingedAndRestore())
 }
 
@@ -496,7 +483,7 @@ func (s *ProxyTests) TestMessageFormatting() {
 	proxy := NewProxy(s.s3Fakeconf, s.s3ClientToFake, &helper.AlwaysDeny{}, s.messenger, s.database, new(tls.Config))
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/user/new_file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/user/new_file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>1234</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\"", "Content-Length": "1234"}
-	msg, err := proxy.CreateMessageFromRequest(r, claims, "new_file.txt")
+	msg, err := proxy.CreateMessageFromRequest(r.Context(), claims.Subject(), "new_file.txt")
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), Event{}, msg)
 
@@ -512,7 +499,7 @@ func (s *ProxyTests) TestMessageFormatting() {
 
 	// Test single shot upload
 	r.Method = "PUT"
-	msg, err = proxy.CreateMessageFromRequest(r, jwt.New(), "new_file.txt")
+	msg, err = proxy.CreateMessageFromRequest(r.Context(), claims.Subject(), "new_file.txt")
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), Event{}, msg)
 	assert.Equal(s.T(), "upload", msg.Operation)
@@ -537,7 +524,7 @@ func (s *ProxyTests) TestDatabaseConnection() {
 	w := httptest.NewRecorder()
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/elixirid/db-test-file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/elixirid/file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>5</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\"", "Content-Length": "5"}
-	proxy.allowedResponse(w, r, s.token)
+	proxy.ServeHTTP(w, r)
 	res := w.Result()
 	defer res.Body.Close()
 	assert.Equal(s.T(), 200, res.StatusCode)

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -169,6 +170,51 @@ func (s *ProxyTests) SetupTest() {
 func (s *ProxyTests) TearDownTest() {
 	s.fakeServer.Close()
 	s.database.Close()
+}
+
+// TestServeHTTP_concurrent_put_noRace verifies that after the in-memory
+// fileIDs map was replaced with Postgres-backed lookups (#2382), concurrent
+// PUT requests no longer trigger the "fatal error: concurrent map writes"
+// crash from #2295. The same-shaped test fails on main under -race with
+// warnings on proxy.go:182/185/195 and the fatal error. Here it should pass.
+func (s *ProxyTests) TestServeHTTP_concurrent_put_noRace() {
+	db, err := database.NewSDAdb(s.DBConf)
+	if !assert.NoError(s.T(), err) {
+		return
+	}
+	defer db.Close()
+
+	const workers = 50
+	const rounds = 20
+
+	db.DB.SetMaxOpenConns(workers)
+	db.DB.SetMaxIdleConns(workers)
+
+	proxy := NewProxy(s.s3Conf, s.s3Client, helper.NewAlwaysAllow(), nil, db, new(tls.Config))
+	proxy.s3Conf.Endpoint = ":" // force forwardRequestToBackend to fail fast
+
+	for round := 0; round < rounds; round++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(workers)
+
+		for i := 0; i < workers; i++ {
+			n := round*workers + i
+			go func(n int) {
+				defer wg.Done()
+				req := httptest.NewRequest(
+					http.MethodPut,
+					fmt.Sprintf("/dummy/race-%04d.c4gh", n),
+					http.NoBody,
+				)
+				rec := httptest.NewRecorder()
+				<-start
+				proxy.ServeHTTP(rec, req)
+			}(n)
+		}
+		close(start)
+		wg.Wait()
+	}
 }
 
 type FakeServer struct {

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -466,6 +466,22 @@ func (s *ProxyTests) TestServeHTTP_allowed() {
 	proxy.ServeHTTP(w, r)
 	assert.Equal(s.T(), 400, w.Result().StatusCode)
 	assert.Equal(s.T(), false, s.fakeServer.PingedAndRestore())
+
+	// Get with list-type=2
+	w = httptest.NewRecorder()
+	r.Method = "GET"
+	r.URL, _ = url.Parse("/dummy?list-type=2")
+	proxy.ServeHTTP(w, r)
+	assert.Equal(s.T(), 200, w.Result().StatusCode)
+	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
+
+	// Get with uploads
+	w = httptest.NewRecorder()
+	r.Method = "GET"
+	r.URL, _ = url.Parse("/dummy?uploads")
+	proxy.ServeHTTP(w, r)
+	assert.Equal(s.T(), 200, w.Result().StatusCode)
+	assert.Equal(s.T(), true, s.fakeServer.PingedAndRestore())
 }
 
 func (s *ProxyTests) TestMessageFormatting() {

--- a/sda/cmd/s3inbox/proxy_test.go
+++ b/sda/cmd/s3inbox/proxy_test.go
@@ -499,7 +499,7 @@ func (s *ProxyTests) TestMessageFormatting() {
 	proxy := NewProxy(s.s3Fakeconf, s.s3ClientToFake, &helper.AlwaysDeny{}, s.messenger, s.database, new(tls.Config))
 	s.fakeServer.resp = "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>test</Name><Prefix>/user/new_file.txt</Prefix><KeyCount>1</KeyCount><MaxKeys>2</MaxKeys><Delimiter></Delimiter><IsTruncated>false</IsTruncated><Contents><Key>/user/new_file.txt</Key><LastModified>2020-03-10T13:20:15.000Z</LastModified><ETag>&#34;0a44282bd39178db9680f24813c41aec-1&#34;</ETag><Size>1234</Size><Owner><ID></ID><DisplayName></DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"
 	s.fakeServer.headHeaders = map[string]string{"ETag": "\"0a44282bd39178db9680f24813c41aec-1\"", "Content-Length": "1234"}
-	msg, err := proxy.CreateMessageFromRequest(r.Context(), claims.Subject(), "new_file.txt")
+	msg, checksumValue, err := proxy.CreateMessageFromRequest(r.Context(), claims.Subject(), "new_file.txt")
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), Event{}, msg)
 
@@ -512,10 +512,11 @@ func (s *ProxyTests) TestMessageFormatting() {
 	_ = json.Unmarshal(c, &checksum)
 	assert.Equal(s.T(), "md5", checksum.Type)
 	assert.Equal(s.T(), "0a44282bd39178db9680f24813c41aec-1", checksum.Value)
+	assert.Equal(s.T(), "0a44282bd39178db9680f24813c41aec-1", checksumValue)
 
 	// Test single shot upload
 	r.Method = "PUT"
-	msg, err = proxy.CreateMessageFromRequest(r.Context(), claims.Subject(), "new_file.txt")
+	msg, _, err = proxy.CreateMessageFromRequest(r.Context(), claims.Subject(), "new_file.txt")
 	assert.Nil(s.T(), err)
 	assert.IsType(s.T(), Event{}, msg)
 	assert.Equal(s.T(), "upload", msg.Operation)

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -119,7 +119,7 @@ WHERE id_and_event.event = $3;`
 }
 
 // GetFileIDInInbox gets the file id of a file which last known event is either 'registered', 'uploaded', or 'disabled'
-// as that means that ingestion has not been triggered and users is allowed continue uploading or reupload the file to the inbox
+// as that means that ingestion has not been triggered and users are allowed continue uploading or reupload the file to the inbox
 // if no row is found does not return sql.ErrNoRows, just empty string in id return field
 func (dbs *SDAdb) GetFileIDInInbox(ctx context.Context, submissionUser, filePath string) (string, error) {
 	dbs.checkAndReconnectIfNeeded()
@@ -143,6 +143,7 @@ WHERE id_and_event.event IN ('registered', 'uploaded', 'disabled');`
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil
 		}
+
 		return "", err
 	}
 

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -118,6 +118,37 @@ WHERE id_and_event.event = $3;`
 	return fileID, nil
 }
 
+// GetFileIDInInbox gets the file id of a file which last known event is either 'registered', 'uploaded', or 'disabled'
+// as that means that ingestion has not been triggered and users is allowed continue uploading or reupload the file to the inbox
+// if no row is found does not return sql.ErrNoRows, just empty string in id return field
+func (dbs *SDAdb) GetFileIDInInbox(ctx context.Context, submissionUser, filePath string) (string, error) {
+	dbs.checkAndReconnectIfNeeded()
+	db := dbs.DB
+
+	const getFileID = `
+SELECT id_and_event.id
+FROM (
+    SELECT DISTINCT ON (f.id) f.id, fel.event FROM sda.files AS f
+        LEFT JOIN sda.file_event_log AS fel ON fel.file_id = f.id
+    WHERE f.submission_user = $1
+      AND f.submission_file_path = $2
+      AND f.stable_id IS NULL
+    ORDER BY f.id, fel.started_at DESC LIMIT 1
+    ) AS id_and_event
+WHERE id_and_event.event IN ('registered', 'uploaded', 'disabled');`
+
+	var fileID string
+
+	if err := db.QueryRowContext(ctx, getFileID, submissionUser, filePath).Scan(&fileID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	return fileID, nil
+}
+
 // CheckStableIDOwnedByUser checks if the file a stableID links to belongs to the user
 // Returns true if a file is found by the stableID and user, false if not found
 func (dbs *SDAdb) CheckStableIDOwnedByUser(stableID, user string) (bool, error) {

--- a/sda/internal/database/db_functions.go
+++ b/sda/internal/database/db_functions.go
@@ -132,7 +132,7 @@ FROM (
         LEFT JOIN sda.file_event_log AS fel ON fel.file_id = f.id
     WHERE f.submission_user = $1
       AND f.submission_file_path = $2
-      AND f.stable_id IS NULL
+      AND f.archive_file_path = ''
     ORDER BY f.id, fel.started_at DESC LIMIT 1
     ) AS id_and_event
 WHERE id_and_event.event IN ('registered', 'uploaded', 'disabled');`

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -1916,6 +1916,18 @@ func (suite *DatabaseTests) TestGetFileIDInInbox() {
 	fileIDFromDB, err := db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), fileID, fileIDFromDB)
+
+	assert.NoError(suite.T(), db.SetArchived("/archive", FileInfo{fmt.Sprintf("%x", sha256.New()), 1000, fileID, fmt.Sprintf("%x", sha256.New()), -1, fmt.Sprintf("%x", sha256.New())}, fileID))
+
+	fileIDFromDB, err = db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "", fileIDFromDB)
+
+	assert.NoError(suite.T(), db.CancelFile(context.TODO(), fileID, "{}"))
+
+	fileIDFromDB, err = db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), fileID, fileIDFromDB)
 }
 
 func (suite *DatabaseTests) TestGetFileIDInInbox_NotFound() {

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -1913,7 +1913,7 @@ func (suite *DatabaseTests) TestGetFileIDInInbox() {
 	fileID, err := db.RegisterFile(nil, "/inbox", "TestGetFileIDInInbox.c4gh", "testuser")
 	assert.NoError(suite.T(), err, "failed to register file in database")
 
-	fileIdFromDB, err := db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
+	fileIDFromDB, err := db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), fileID, fileIdFromDB)
+	assert.Equal(suite.T(), fileID, fileIDFromDB)
 }

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -1904,3 +1904,16 @@ func (suite *DatabaseTests) TestSetBackedUp_FileID_Not_Exists() {
 	notExistingFileID := uuid.NewString()
 	assert.EqualError(suite.T(), db.SetBackedUp("/backup", notExistingFileID, notExistingFileID), sql.ErrNoRows.Error())
 }
+
+func (suite *DatabaseTests) TestGetFileIDInInbox() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got %v when creating new connection", err)
+	defer db.Close()
+
+	fileID, err := db.RegisterFile(nil, "/inbox", "TestGetFileIDInInbox.c4gh", "testuser")
+	assert.NoError(suite.T(), err, "failed to register file in database")
+
+	fileIdFromDB, err := db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), fileID, fileIdFromDB)
+}

--- a/sda/internal/database/db_functions_test.go
+++ b/sda/internal/database/db_functions_test.go
@@ -1917,3 +1917,13 @@ func (suite *DatabaseTests) TestGetFileIDInInbox() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), fileID, fileIDFromDB)
 }
+
+func (suite *DatabaseTests) TestGetFileIDInInbox_NotFound() {
+	db, err := NewSDAdb(suite.dbConf)
+	assert.NoError(suite.T(), err, "got %v when creating new connection", err)
+	defer db.Close()
+
+	fileIDFromDB, err := db.GetFileIDInInbox(context.TODO(), "testuser", "TestGetFileIDInInbox.c4gh")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "", fileIDFromDB)
+}

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -90,7 +90,11 @@ func NewAlwaysAllow() *AlwaysAllow {
 
 // Authenticate authenticates everyone.
 func (u *AlwaysAllow) Authenticate(_ *http.Request) (jwt.Token, error) {
-	return jwt.New(), nil
+	token := jwt.New()
+	if err := token.Set("sub", "dummy"); err != nil {
+		return nil, err
+	}
+	return token, nil
 }
 
 // AlwaysAllow is an Authenticator that always authenticates

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -98,7 +98,7 @@ func (u *AlwaysAllow) Authenticate(_ *http.Request) (jwt.Token, error) {
 	return token, nil
 }
 
-// AlwaysAllow is an Authenticator that always authenticates
+// AlwaysDeny is an Authenticator that always denies authentication
 type AlwaysDeny struct{}
 
 // Authenticate does not authenticate anyone.

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -94,6 +94,7 @@ func (u *AlwaysAllow) Authenticate(_ *http.Request) (jwt.Token, error) {
 	if err := token.Set("sub", "dummy"); err != nil {
 		return nil, err
 	}
+
 	return token, nil
 }
 


### PR DESCRIPTION
# Related issue(s) and PR(s)
This PR closes #2375.

# Description
- Add new DB func GetFileIDInInbox which returns the file id of a file if the latest file event deems it should exist in the inbox

- Also update dedection and mapping of s3 actions
  - Only explicitly allow GetBucketLocation, ListObjects, ListObjectsV2, PutObject, UploadPart, CreateMultiPartUpload, CompleteMultiPartUpload, AbortMultiPartUpload, ListMultiPartUpload, ListParts

- Remove unecessary logging which do not provide any useful information

- Update handling of s3 action to hopefully be more readable

- Reduce information exposed on errors, ie do not return errors, etc instead log them and return generic error message

- Update AlwaysAllow authenticator to set "dummy" as the subject on the token


[ADR-0003](https://github.com/neicnordic/sensitive-data-archive/pull/2319) states to specifically use GetFileIDByUserPathAndStatus, but instead new GetFileIDInInbox with different filter semantics was used to ensure that we find files based on all file event states that indicate that a file should be in the inbox.

# How to test
- Unit tests pass
- Integration tests pass
