### PR TITLE
fix: real health probes for v2 download service (#2364, #2365)

### DIFF
--- a/.github/integration/scripts/make_download_credentials.sh
+++ b/.github/integration/scripts/make_download_credentials.sh
@@ -78,12 +78,16 @@ cat > "/shared/trusted-issuers.json" <<'EOF'
 ]
 EOF
 
-## create crypt4gh key
+## create crypt4gh keys
 if [ ! -f "/shared/c4gh.pub.pem" ]; then
     echo "downloading crypt4gh"
     latest_c4gh=$(curl --retry 100 -sL https://api.github.com/repos/neicnordic/crypt4gh/releases/latest | jq -r '.name')
     curl --retry 100 -sL "https://github.com/neicnordic/crypt4gh/releases/download/${latest_c4gh}/crypt4gh_linux_x86_64.tar.gz" | tar -xz -C /shared/
-    /shared/crypt4gh generate -n /shared/c4gh -p c4gh
+    # Generate all keys the shared reencrypt config references; passphrases
+    # must match sda/config.yaml.
+    /shared/crypt4gh generate -n /shared/c4gh -p c4ghpass
+    /shared/crypt4gh generate -n /shared/sync -p syncPass
+    /shared/crypt4gh generate -n /shared/rotatekey -p rotatekeyPass
 fi
 
 echo "download credentials setup complete"

--- a/sda/cmd/download/handlers/handlers_test.go
+++ b/sda/cmd/download/handlers/handlers_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,9 +12,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/neicnordic/sensitive-data-archive/cmd/download/middleware"
+	"github.com/neicnordic/sensitive-data-archive/cmd/download/reencrypt"
 	configv2 "github.com/neicnordic/sensitive-data-archive/internal/config/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var loadConfigOnce sync.Once
@@ -113,6 +119,135 @@ func TestHealthReady_Degraded(t *testing.T) {
 	assert.Equal(t, "ok", response.Services["database"])
 	assert.Contains(t, response.Services["storage"], "not configured")
 	assert.Contains(t, response.Services["grpc"], "not configured")
+}
+
+func TestHealthReady_StorageAndDBHealthy(t *testing.T) {
+	router := gin.New()
+	mockDB := &mockDatabase{}
+	mockStorage := &mockStorageReader{}
+	h, err := New(WithDatabase(mockDB), WithStorageReader(mockStorage))
+	require.NoError(t, err)
+	h.RegisterRoutes(router)
+
+	req, _ := http.NewRequest(http.MethodGet, "/health/ready", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	var response HealthStatus
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	// Still degraded because grpc is not configured
+	assert.Equal(t, "degraded", response.Status)
+	assert.Equal(t, "ok", response.Services["database"])
+	assert.Equal(t, "ok", response.Services["storage"])
+	assert.Contains(t, response.Services["grpc"], "not configured")
+}
+
+func TestHealthReady_StorageUnhealthy(t *testing.T) {
+	router := gin.New()
+	mockDB := &mockDatabase{}
+	mockStorage := &mockStorageReader{pingErr: fmt.Errorf("connection refused")}
+	h, err := New(WithDatabase(mockDB), WithStorageReader(mockStorage))
+	require.NoError(t, err)
+	h.RegisterRoutes(router)
+
+	req, _ := http.NewRequest(http.MethodGet, "/health/ready", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	var response HealthStatus
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "degraded", response.Status)
+	assert.Contains(t, response.Services["storage"], "connection refused")
+}
+
+// startHealthGRPCServer starts a gRPC server with a health service reporting
+// the given status. Returns the listening port and a stop function.
+func startHealthGRPCServer(t *testing.T, status healthgrpc.HealthCheckResponse_ServingStatus) (int, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", status)
+	healthgrpc.RegisterHealthServer(srv, healthSrv)
+
+	go func() { _ = srv.Serve(lis) }()
+
+	return lis.Addr().(*net.TCPAddr).Port, srv.Stop
+}
+
+func TestHealthReady_AllHealthy(t *testing.T) {
+	port, stopServer := startHealthGRPCServer(t, healthgrpc.HealthCheckResponse_SERVING)
+	defer stopServer()
+
+	reencryptClient := reencrypt.NewClient("localhost", port)
+	defer reencryptClient.Close()
+
+	router := gin.New()
+	h, err := New(
+		WithDatabase(&mockDatabase{}),
+		WithStorageReader(&mockStorageReader{}),
+		WithReencryptClient(reencryptClient),
+	)
+	require.NoError(t, err)
+	h.RegisterRoutes(router)
+
+	req, _ := http.NewRequest(http.MethodGet, "/health/ready", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response HealthStatus
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", response.Status)
+	assert.Equal(t, "ok", response.Services["database"])
+	assert.Equal(t, "ok", response.Services["storage"])
+	assert.Equal(t, "ok", response.Services["grpc"])
+}
+
+func TestHealthReady_GrpcUnhealthy(t *testing.T) {
+	port, stopServer := startHealthGRPCServer(t, healthgrpc.HealthCheckResponse_NOT_SERVING)
+	defer stopServer()
+
+	reencryptClient := reencrypt.NewClient("localhost", port)
+	defer reencryptClient.Close()
+
+	router := gin.New()
+	h, err := New(
+		WithDatabase(&mockDatabase{}),
+		WithStorageReader(&mockStorageReader{}),
+		WithReencryptClient(reencryptClient),
+	)
+	require.NoError(t, err)
+	h.RegisterRoutes(router)
+
+	req, _ := http.NewRequest(http.MethodGet, "/health/ready", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	var response HealthStatus
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "degraded", response.Status)
+	assert.Equal(t, "ok", response.Services["database"])
+	assert.Equal(t, "ok", response.Services["storage"])
+	assert.Contains(t, response.Services["grpc"], "NOT_SERVING")
 }
 
 // Test that hasDatasetAccess helper works correctly

--- a/sda/cmd/download/handlers/handlers_test.go
+++ b/sda/cmd/download/handlers/handlers_test.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -149,7 +149,7 @@ func TestHealthReady_StorageAndDBHealthy(t *testing.T) {
 func TestHealthReady_StorageUnhealthy(t *testing.T) {
 	router := gin.New()
 	mockDB := &mockDatabase{}
-	mockStorage := &mockStorageReader{pingErr: fmt.Errorf("connection refused")}
+	mockStorage := &mockStorageReader{pingErr: errors.New("connection refused")}
 	h, err := New(WithDatabase(mockDB), WithStorageReader(mockStorage))
 	require.NoError(t, err)
 	h.RegisterRoutes(router)
@@ -165,7 +165,7 @@ func TestHealthReady_StorageUnhealthy(t *testing.T) {
 	err = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, "degraded", response.Status)
-	assert.Contains(t, response.Services["storage"], "connection refused")
+	assert.Equal(t, "error: backend unresponsive", response.Services["storage"])
 }
 
 // startHealthGRPCServer starts a gRPC server with a health service reporting
@@ -247,7 +247,7 @@ func TestHealthReady_GrpcUnhealthy(t *testing.T) {
 	assert.Equal(t, "degraded", response.Status)
 	assert.Equal(t, "ok", response.Services["database"])
 	assert.Equal(t, "ok", response.Services["storage"])
-	assert.Contains(t, response.Services["grpc"], "NOT_SERVING")
+	assert.Equal(t, "error: backend unresponsive", response.Services["grpc"])
 }
 
 // Test that hasDatasetAccess helper works correctly

--- a/sda/cmd/download/handlers/health.go
+++ b/sda/cmd/download/handlers/health.go
@@ -28,7 +28,7 @@ func (h *Handlers) HealthReady(c *gin.Context) {
 	if h.db != nil {
 		if err := h.db.Ping(ctx); err != nil {
 			log.Warnf("health check: database ping failed: %v", err)
-			services["database"] = "error: " + err.Error()
+			services["database"] = "error: backend unresponsive"
 			allHealthy = false
 		} else {
 			services["database"] = "ok"
@@ -42,7 +42,7 @@ func (h *Handlers) HealthReady(c *gin.Context) {
 	if h.storageReader != nil {
 		if err := h.storageReader.Ping(ctx); err != nil {
 			log.Warnf("health check: storage ping failed: %v", err)
-			services["storage"] = "error: " + err.Error()
+			services["storage"] = "error: backend unresponsive"
 			allHealthy = false
 		} else {
 			services["storage"] = "ok"
@@ -56,7 +56,7 @@ func (h *Handlers) HealthReady(c *gin.Context) {
 	if h.reencryptClient != nil {
 		if err := h.reencryptClient.HealthCheck(ctx); err != nil {
 			log.Warnf("health check: grpc connection failed: %v", err)
-			services["grpc"] = "error: " + err.Error()
+			services["grpc"] = "error: backend unresponsive"
 			allHealthy = false
 		} else {
 			services["grpc"] = "ok"

--- a/sda/cmd/download/handlers/health.go
+++ b/sda/cmd/download/handlers/health.go
@@ -40,7 +40,13 @@ func (h *Handlers) HealthReady(c *gin.Context) {
 
 	// Check storage reader
 	if h.storageReader != nil {
-		services["storage"] = "ok"
+		if err := h.storageReader.Ping(ctx); err != nil {
+			log.Warnf("health check: storage ping failed: %v", err)
+			services["storage"] = "error: " + err.Error()
+			allHealthy = false
+		} else {
+			services["storage"] = "ok"
+		}
 	} else {
 		services["storage"] = "error: not configured"
 		allHealthy = false
@@ -48,7 +54,7 @@ func (h *Handlers) HealthReady(c *gin.Context) {
 
 	// Check gRPC reencrypt client
 	if h.reencryptClient != nil {
-		if err := h.reencryptClient.HealthCheck(); err != nil {
+		if err := h.reencryptClient.HealthCheck(ctx); err != nil {
 			log.Warnf("health check: grpc connection failed: %v", err)
 			services["grpc"] = "error: " + err.Error()
 			allHealthy = false

--- a/sda/cmd/download/handlers/mock_database_test.go
+++ b/sda/cmd/download/handlers/mock_database_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"github.com/neicnordic/sensitive-data-archive/cmd/download/audit"
@@ -121,4 +122,29 @@ func (m *mockDatabase) GetDatasetFilesPaginated(_ context.Context, _ string, _ d
 	}
 
 	return m.datasetFilesPaged, nil
+}
+
+// mockStorageReader is a mock implementation of storage.Reader for testing.
+type mockStorageReader struct {
+	pingErr error
+}
+
+func (m *mockStorageReader) NewFileReader(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *mockStorageReader) NewFileReadSeeker(_ context.Context, _, _ string) (io.ReadSeekCloser, error) {
+	return nil, nil
+}
+
+func (m *mockStorageReader) FindFile(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockStorageReader) GetFileSize(_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
+func (m *mockStorageReader) Ping(_ context.Context) error {
+	return m.pingErr
 }

--- a/sda/cmd/download/reencrypt/reencrypt.go
+++ b/sda/cmd/download/reencrypt/reencrypt.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // Client provides methods for re-encrypting crypt4gh headers.
@@ -193,12 +194,27 @@ func (c *Client) ReencryptHeaderWithEditList(ctx context.Context, oldHeader []by
 	return res.GetHeader(), nil
 }
 
-// HealthCheck validates that the gRPC client can be constructed with the
-// configured options. Note: grpc.NewClient does no I/O, so this does NOT
-// verify that the remote reencrypt service is reachable.
-// TODO: perform a real RPC (e.g. grpc health check) to verify reachability.
-func (c *Client) HealthCheck() error {
-	return c.connect()
+// HealthCheck verifies the remote reencrypt service is reachable and serving
+// using the standard gRPC health check protocol. The caller controls the
+// deadline via the provided context; no additional timeout is applied so
+// Kubernetes probe timeoutSeconds can bound the total duration.
+func (c *Client) HealthCheck(ctx context.Context) error {
+	if err := c.connect(); err != nil {
+		return err
+	}
+
+	client := healthgrpc.NewHealthClient(c.conn)
+
+	resp, err := client.Check(ctx, &healthgrpc.HealthCheckRequest{})
+	if err != nil {
+		return fmt.Errorf("grpc health check failed: %w", err)
+	}
+
+	if resp.GetStatus() != healthgrpc.HealthCheckResponse_SERVING {
+		return fmt.Errorf("reencrypt service status: %s", resp.GetStatus().String())
+	}
+
+	return nil
 }
 
 // Close closes the gRPC connection.

--- a/sda/cmd/download/reencrypt/reencrypt_test.go
+++ b/sda/cmd/download/reencrypt/reencrypt_test.go
@@ -1,10 +1,16 @@
 package reencrypt
 
 import (
+	"context"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func TestNewClient(t *testing.T) {
@@ -38,6 +44,65 @@ func TestClient_Close_WhenNotConnected(t *testing.T) {
 	// Should not error when closing without connecting
 	err := client.Close()
 	assert.NoError(t, err)
+}
+
+func TestHealthCheck_Serving(t *testing.T) {
+	// Start a gRPC server with health service
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", healthgrpc.HealthCheckResponse_SERVING)
+	healthgrpc.RegisterHealthServer(srv, healthSrv)
+
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	port := lis.Addr().(*net.TCPAddr).Port
+	client := NewClient("localhost", port)
+	defer client.Close()
+
+	err = client.HealthCheck(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestHealthCheck_NotServing(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", healthgrpc.HealthCheckResponse_NOT_SERVING)
+	healthgrpc.RegisterHealthServer(srv, healthSrv)
+
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	port := lis.Addr().(*net.TCPAddr).Port
+	client := NewClient("localhost", port)
+	defer client.Close()
+
+	err = client.HealthCheck(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NOT_SERVING")
+}
+
+func TestHealthCheck_ServerDown(t *testing.T) {
+	// Use a port with nothing listening
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	port := lis.Addr().(*net.TCPAddr).Port
+	lis.Close()
+
+	client := NewClient("localhost", port)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err = client.HealthCheck(ctx)
+	assert.Error(t, err)
 }
 
 // Note: Integration tests for ReencryptHeader would require a running gRPC server

--- a/sda/internal/storage/v2/posix/reader/reader.go
+++ b/sda/internal/storage/v2/posix/reader/reader.go
@@ -1,6 +1,7 @@
 package reader
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -36,4 +37,19 @@ func NewReader(backendName string) (*Reader, error) {
 	}
 
 	return backend, nil
+}
+
+// Ping verifies all configured POSIX paths are accessible directories.
+func (r *Reader) Ping(_ context.Context) error {
+	for _, e := range r.configuredEndpoints {
+		fileInfo, err := os.Stat(e.Path)
+		if err != nil {
+			return fmt.Errorf("failed to ping POSIX path: %s, due to: %v", e.Path, err)
+		}
+		if !fileInfo.IsDir() {
+			return fmt.Errorf("failed to ping POSIX path: %s is not a directory", e.Path)
+		}
+	}
+
+	return nil
 }

--- a/sda/internal/storage/v2/posix/reader/reader_test.go
+++ b/sda/internal/storage/v2/posix/reader/reader_test.go
@@ -139,6 +139,72 @@ func (ts *ReaderTestSuite) TestGetFileSize() {
 	ts.Equal(int64(len("file 6 content in dir2")), fileSize)
 }
 
+func (ts *ReaderTestSuite) TestPing() {
+	err := ts.reader.Ping(context.TODO())
+	ts.NoError(err)
+}
+
+func (ts *ReaderTestSuite) TestPing_PathGone() {
+	configDir := ts.T().TempDir()
+	vanishDir := ts.T().TempDir()
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(fmt.Sprintf(`
+storage:
+  ping_fail_test:
+    posix:
+    - path: %s
+`, vanishDir)), 0600); err != nil {
+		ts.FailNow(err.Error())
+	}
+
+	viper.SetConfigFile(filepath.Join(configDir, "config.yaml"))
+	ts.Require().NoError(viper.ReadInConfig())
+
+	reader, err := NewReader("ping_fail_test")
+	ts.Require().NoError(err)
+
+	// Remove the directory after creating the reader
+	ts.Require().NoError(os.Remove(vanishDir))
+
+	err = reader.Ping(context.TODO())
+	ts.Error(err)
+	ts.Contains(err.Error(), "failed to ping POSIX path")
+}
+
+func (ts *ReaderTestSuite) TestPing_PathIsFile() {
+	configDir := ts.T().TempDir()
+	dir := ts.T().TempDir()
+	filePath := filepath.Join(dir, "a_file")
+
+	if err := os.WriteFile(filePath, []byte("hello"), 0600); err != nil {
+		ts.FailNow(err.Error())
+	}
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(fmt.Sprintf(`
+storage:
+  ping_file_test:
+    posix:
+    - path: %s
+`, dir)), 0600); err != nil {
+		ts.FailNow(err.Error())
+	}
+
+	viper.SetConfigFile(filepath.Join(configDir, "config.yaml"))
+	ts.Require().NoError(viper.ReadInConfig())
+
+	reader, err := NewReader("ping_file_test")
+	ts.Require().NoError(err)
+
+	// Replace the directory with a file
+	ts.Require().NoError(os.RemoveAll(dir))
+	ts.Require().NoError(os.WriteFile(dir, []byte("now a file"), 0600))
+	defer os.Remove(dir)
+
+	err = reader.Ping(context.TODO())
+	ts.Error(err)
+	ts.Contains(err.Error(), "not a directory")
+}
+
 func (ts *ReaderTestSuite) TestFindFile() {
 	for _, test := range []struct {
 		testName         string

--- a/sda/internal/storage/v2/reader.go
+++ b/sda/internal/storage/v2/reader.go
@@ -21,6 +21,8 @@ type Reader interface {
 	FindFile(ctx context.Context, filePath string) (string, error)
 	// GetFileSize will return the size of the file specified by the file path and location
 	GetFileSize(ctx context.Context, location, filePath string) (int64, error)
+	// Ping verifies the storage backend is reachable
+	Ping(ctx context.Context) error
 }
 
 type reader struct {
@@ -87,6 +89,23 @@ func (r *reader) GetFileSize(ctx context.Context, location, filePath string) (in
 	}
 
 	return 0, storageerrors.ErrorNoValidReader
+}
+
+func (r *reader) Ping(ctx context.Context) error {
+	var errs []error
+
+	if r.s3Reader != nil {
+		if err := r.s3Reader.Ping(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if r.posixReader != nil {
+		if err := r.posixReader.Ping(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (r *reader) FindFile(ctx context.Context, filePath string) (string, error) {

--- a/sda/internal/storage/v2/s3/reader/reader.go
+++ b/sda/internal/storage/v2/s3/reader/reader.go
@@ -59,6 +59,22 @@ func (reader *Reader) getS3ClientForEndpoint(ctx context.Context, endpoint strin
 	return nil, nil, storageerrors.ErrorNoEndpointConfiguredForLocation
 }
 
+// Ping verifies all configured S3 endpoints are reachable by calling ListBuckets.
+func (reader *Reader) Ping(ctx context.Context) error {
+	for _, e := range reader.endpoints {
+		client, err := e.getS3Client(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to ping S3 endpoint: %s, due to: %v", e.Endpoint, err)
+		}
+
+		if _, err = client.ListBuckets(ctx, &s3.ListBucketsInput{}); err != nil {
+			return fmt.Errorf("failed to ping S3 endpoint: %s, due to: %v", e.Endpoint, err)
+		}
+	}
+
+	return nil
+}
+
 // parseLocation attempts to parse a location to a s3 endpoint, and a bucket
 // expected format of location is "${ENDPOINT}/${BUCKET}
 func parseLocation(location string) (string, string, error) {

--- a/sda/internal/storage/v2/s3/reader/reader_test.go
+++ b/sda/internal/storage/v2/s3/reader/reader_test.go
@@ -753,3 +753,48 @@ func (ts *ReaderTestSuite) TestNewFileReaderSeeker_InvalidLocation() {
 	_, err := ts.reader.NewFileReader(context.TODO(), "", "")
 	ts.EqualError(err, storageerrors.ErrorInvalidLocation.Error())
 }
+
+func (ts *ReaderTestSuite) TestPing() {
+	err := ts.reader.Ping(context.TODO())
+	ts.NoError(err)
+}
+
+func (ts *ReaderTestSuite) TestPing_EndpointDown() {
+	// Create a reader with a stopped server
+	configDir := ts.T().TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.RequestURI, "ListBuckets") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult><Buckets></Buckets></ListAllMyBucketsResult>`)
+
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(fmt.Sprintf(`
+storage:
+  ping_fail_test:
+    s3:
+    - endpoint: %s
+      access_key: ak
+      secret_key: sk
+      disable_https: true
+      region: us-east-1
+`, server.URL)), 0600); err != nil {
+		ts.FailNow(err.Error())
+	}
+
+	viper.SetConfigFile(filepath.Join(configDir, "config.yaml"))
+	ts.Require().NoError(viper.ReadInConfig())
+
+	reader, err := NewReader(context.TODO(), "ping_fail_test")
+	ts.Require().NoError(err)
+
+	// Stop the server, then ping should fail
+	server.Close()
+
+	err = reader.Ping(context.TODO())
+	ts.Error(err)
+	ts.Contains(err.Error(), "failed to ping S3 endpoint")
+}


### PR DESCRIPTION
## Summary

The `/health/ready` probe on the v2 download service reported "ok" for
storage and the reencrypt gRPC client based on nil-checks alone. Expired
S3 credentials or a dead reencrypt service would not trigger a
Kubernetes restart.

This PR closes both #2364 and #2365 by turning each dependency check
into a real round-trip.

- **Storage (#2364):** Added `Ping(ctx)` to the v2 `Reader` interface.
  S3 pings every configured endpoint with `ListBuckets` (matching the
  existing startup check). POSIX stats every path and re-verifies
  `IsDir`, mirroring the constructor's invariants. The wrapper
  delegates to both sub-readers and joins their errors.
- **Reencrypt (#2365):** Replaced the no-op `HealthCheck` (which only
  called `grpc.NewClient` and did no I/O) with a real
  `grpc_health_v1.Health/Check` RPC. The server side already registers
  the standard health service, so no server change is needed.
- **Context propagation:** `HealthCheck` now takes a `context.Context`
  and uses it directly without wrapping — the readiness handler's 5s
  deadline flows all the way through, matching how `db.Ping(ctx)` and
  `storageReader.Ping(ctx)` already work. This also follows the
  preference surfaced in #2343: let the caller (Kubernetes probe
  `timeoutSeconds`) bound health-check duration.

## Test plan

- [x] `go test -race ./internal/storage/v2/... ./cmd/download/...`
      passes (356 tests, 17 packages)
- [x] `go vet ./...` clean
- [x] New storage tests: S3 `Ping` OK + endpoint down, POSIX `Ping` OK
      + path gone + path is file
- [x] New reencrypt tests against a real `grpc_health_v1` server:
      SERVING, NOT_SERVING, server down
- [x] New handler tests using a real gRPC health server: all-healthy
      returns 200, reencrypt NOT_SERVING returns 503 with informative
      error
- [ ] Verify readiness probe behavior in a dev compose environment
- [ ] Confirm Kubernetes \`readinessProbe\` in the Helm chart still
      points to \`/health/ready\` after merge