### PR TITLE
fix(storage-v2): do not set ContentEncoding when writing to s3

### DIFF
--- a/sda/internal/storage/v2/s3/writer/write_file.go
+++ b/sda/internal/storage/v2/s3/writer/write_file.go
@@ -56,10 +56,9 @@ func (writer *Writer) WriteFile(ctx context.Context, filePath string, fileConten
 	})
 
 	_, err = uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
-		Body:            fileContent,
-		Bucket:          aws.String(activeBucket),
-		Key:             aws.String(filePath),
-		ContentEncoding: aws.String("application/octet-stream"),
+		Body:   fileContent,
+		Bucket: aws.String(activeBucket),
+		Key:    aws.String(filePath),
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to upload object: %s, bucket: %s, endpoint: %s, due to: %v", filePath, activeBucket, writer.activeEndpoint.Endpoint, err)


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #378.


## Description
Do not set ContentEncoding when writing to s3, as it leads to SignatureDoesNotMatch error when talking to ceph

## How to test
- Unit tests passes
- When deployed in staging, ingest can write to the archive
