### PR TITLE
docs(adr): propose ADR-0005 introduce RFCs as upstream exploration phase

### DIFF
--- a/docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md
+++ b/docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md
@@ -1,0 +1,167 @@
+---
+status: proposed
+date: "2026-04-20"
+decision-makers:
+  - "@neicnordic/sensitive-data-development-collaboration"
+consulted: []
+informed: []
+---
+
+# Introduce RFCs as an Upstream Exploration Phase for ADRs
+
+## Context and Problem Statement
+
+The decision log in `docs/decisions/` is intended to record what the system is
+committed to. In practice, some proposals open an ADR PR long before the team
+can honestly write *"Chosen option: X, because Y"*. The discussion lingers, the
+PR stays open, and the decision log ends up mixing committed decisions with
+speculative futures. This weakens its value as a trustworthy record of what the
+system actually does and intends to do.
+
+A concrete example: at the time of writing, two ADR PRs
+([#2263 ADR-0001][pr-2263], [#2320 ADR-0004][pr-2320]) have been open for
+extended periods without convergence. Their implementation horizon is unclear.
+They belong to a different conversation than decisions we are ready to commit
+to.
+
+We need a place for exploration that does not add noise to the decision log.
+
+## Decision Drivers
+
+* **Decision log trustworthiness** — entries in `docs/decisions/` should reflect
+  actual commitments, not hopes.
+* **Patience for open questions** — exploration needs a venue more patient
+  than a PR that is expected to merge.
+* **Low ceremony** — any new process must be lightweight or it will be ignored.
+* **Ease of promotion** — turning a mature exploration into a decision record
+  should be a near-trivial edit, so the separation does not penalise good
+  work.
+* **No semantic drift** — the existing status vocabulary
+  (`proposed` → `accepted` \| `rejected` \| `deprecated` \| `superseded`) is
+  working and should not be redefined.
+
+## Considered Options
+
+1. **Keep everything in `docs/decisions/`** — do nothing; accept that some ADRs
+   will linger in `proposed`.
+2. **Parking-lot tag on ADRs** — add a label or front-matter flag (e.g.
+   `horizon: distant`) to distinguish speculative ADRs from imminent ones.
+3. **Introduce `docs/rfcs/` as an upstream exploration phase** — RFCs live
+   outside the decision log, are promoted to ADRs when the team can commit.
+
+## Decision Outcome
+
+Chosen option: **option 3, introduce `docs/rfcs/` as an upstream exploration
+phase**. It matches the separation that Rust, Python, Kubernetes, and Go
+already use between *"should we?"* and *"we did, because"*. Exploration gets
+its own venue, and the existing ADR status vocabulary stays as it is.
+
+### Consequences
+
+* **Good**: The decision log reflects real commitments only; `proposed` keeps
+  its current meaning of *"under discussion in a PR, expected to merge"*.
+* **Good**: Exploration has a patient venue. An RFC can live in the repository
+  indefinitely without cluttering the decision log.
+* **Good**: Promotion is a light edit — copy the relevant content into a new
+  ADR file, fill in `## Decision Outcome`, and freeze the RFC. The RFC template
+  is a strict subset of MADR, so nothing has to be restructured on the way
+  across.
+* **Good**: The RFC file stays in `docs/rfcs/` after promotion. The exploration
+  remains a git artifact in its own right, instead of living only in a GitHub
+  PR thread.
+* **Neutral**: Contributors must learn the difference between an RFC and an
+  ADR. The README files and the promotion rule make this explicit.
+* **Bad**: An extra directory in `docs/` to explain. Mitigated by clear README
+  text and a shared template.
+* **Bad**: Risk that RFCs become a *dumping ground* that nobody promotes.
+  Three things push back on that: an explicit promotion trigger (*"when you
+  can write 'Chosen option: X, because Y' with a straight face"*), the
+  expectation that ADR PRs opened from a mature RFC merge quickly, and a
+  pass over the RFC index at each bi-weekly NeIC SDA-Devs meet-up — every
+  open RFC either gets touched, withdrawn, or annotated with a reason it is
+  still open.
+
+### Confirmation
+
+Confirmation is delivered in two steps:
+
+1. The merge of this PR creates `docs/rfcs/` with its README and template, and
+   adds the promotion rule to `docs/decisions/README.md`.
+2. Two follow-up PRs close the currently open ADR PRs
+   ([#2263][pr-2263], [#2320][pr-2320]) and re-open their content as RFCs.
+   Successful completion of those follow-ups confirms that the flow works in
+   practice.
+
+## Pros and Cons of the Options
+
+### Option 1 — Keep everything in `docs/decisions/`
+
+* Good, because there is zero process change.
+* Bad, because the decision log continues to mix commitments with speculation.
+* Bad, because there is no signal for *"we are exploring this, do not expect a
+  commitment yet"*.
+
+### Option 2 — Parking-lot tag on ADRs
+
+* Good, because it is a one-line change to existing ADRs.
+* Bad, because it overloads the decision log with documents that are not
+  decisions.
+* Bad, because it introduces a second orthogonal lifecycle (horizon) on top of
+  the existing status lifecycle, which is more semantic surface area than
+  option 3.
+
+### Option 3 — Introduce `docs/rfcs/` as an upstream exploration phase
+
+* Good, because it matches the separation used by Rust
+  ([rust-lang/rfcs][rust-rfcs]), Python ([PEP 1][pep-1]), Kubernetes
+  ([KEP process][kep]), and Go ([golang/proposal][go-proposal]).
+* Good, because the RFC template is a subset of MADR, so promotion is
+  near-trivial.
+* Good, because it leaves the existing ADR status lifecycle untouched.
+* Neutral, because it introduces one new directory.
+* Bad, because it requires a small amount of new documentation (two READMEs
+  and a template).
+
+## More Information
+
+### Conventions Established by This ADR
+
+| Convention | Detail |
+| --- | --- |
+| Directory | `docs/rfcs/` |
+| File naming | `NNNN-title-with-dashes.md` — same as ADRs, numbering independent |
+| RFC numbering | Starts at 0001; numbers are never reused |
+| RFC status lifecycle | `exploring` → `ready-for-decision` → `promoted` \| `withdrawn` |
+| RFC template | `docs/rfcs/template.md` (MADR 4.0.0 minus `## Decision Outcome` and `### Confirmation`, plus `## Open Questions`) |
+| Promotion trigger | The team can honestly write *"Chosen option: X, because Y"* |
+| Promotion mechanics | Create a new ADR file under the next free ADR number from [`docs/decisions/template.md`](template.md), pulling across the relevant content from the RFC. In the RFC: flip `status` to `promoted`, set `promoted-to` to the ADR filename(s), freeze the body. Promotion is only complete once the index in [this README](README.md#index) and the RFC index are both updated. |
+| One RFC, multiple ADRs | Supported: `promoted-to` accepts a list of ADR filenames. |
+| Reserved ADR numbers | `0001` and `0004` are reserved by open ADR PRs ([#2263][pr-2263], [#2320][pr-2320]). The next free ADR number is `0005` (this ADR); the number after is `0006`. |
+| RFC lifetime | Unlimited. An RFC living for a long time without promotion is not a defect. Stale RFCs are surfaced at the bi-weekly NeIC SDA-Devs meet-up. |
+| Post-promotion edits | A `promoted` or `withdrawn` RFC is frozen — only metadata and index rows change. Revisions to a decision live in the ADR. |
+| ADR lifecycle unchanged | The ADR status lifecycle (`proposed` → `accepted` \| `rejected` \| `deprecated` \| `superseded`) is **not** modified by this ADR. ADR statuses only apply to files in `docs/decisions/`. |
+
+### Relationship to other ADRs
+
+This ADR adds to [ADR-0000][adr-0000]; it does not replace it. ADR-0000
+established ADRs; this one adds an exploration phase upstream of them.
+
+### References
+
+* [MADR 4.0.0 template][madr] — the ADR template this project uses.
+* [Rust RFC process][rust-rfcs] — canonical single-document RFC flow.
+* [Python PEP 1][pep-1] — PEP status lifecycle and exploration conventions.
+* [Kubernetes KEP process][kep] — provisional vs implementable states.
+* [Go proposal template][go-proposal] — proposal-to-design-doc flow.
+* [Candost Dagdeviren, *ADRs and RFCs*][candost] — an accepted RFC may spawn
+  one or more ADRs.
+
+[pr-2263]: https://github.com/neicnordic/sensitive-data-archive/pull/2263
+[pr-2320]: https://github.com/neicnordic/sensitive-data-archive/pull/2320
+[adr-0000]: 0000-use-markdown-architectural-decision-records.md
+[madr]: https://github.com/adr/madr/blob/4.0.0/template/adr-template.md
+[rust-rfcs]: https://github.com/rust-lang/rfcs/blob/master/0000-template.md
+[pep-1]: https://peps.python.org/pep-0001/
+[kep]: https://github.com/kubernetes/enhancements/tree/master/keps/NNNN-kep-template
+[go-proposal]: https://github.com/golang/proposal/blob/master/design/TEMPLATE.md
+[candost]: https://candost.blog/adrs-rfcs-differences-when-which/

--- a/docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md
+++ b/docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md
@@ -87,10 +87,13 @@ Confirmation is delivered in two steps:
 
 1. The merge of this PR creates `docs/rfcs/` with its README and template, and
    adds the promotion rule to `docs/decisions/README.md`.
-2. Two follow-up PRs close the currently open ADR PRs
-   ([#2263][pr-2263], [#2320][pr-2320]) and re-open their content as RFCs.
-   Successful completion of those follow-ups confirms that the flow works in
-   practice.
+2. The two currently open ADR PRs ([#2263][pr-2263], [#2320][pr-2320]) are
+   converted in place to RFC PRs: the files move from `docs/decisions/` to
+   `docs/rfcs/`, the front matter and body are reshaped to the RFC template,
+   and the PRs are relabelled `rfc`. The existing PR discussion threads are
+   preserved — they are exactly the kind of exploration an RFC should
+   capture. Successful completion of those conversions confirms the flow
+   works in practice.
 
 ## Pros and Cons of the Options
 
@@ -136,7 +139,7 @@ Confirmation is delivered in two steps:
 | Promotion trigger | The team can honestly write *"Chosen option: X, because Y"* |
 | Promotion mechanics | Create a new ADR file under the next free ADR number from [`docs/decisions/template.md`](template.md), pulling across the relevant content from the RFC. In the RFC: flip `status` to `promoted`, set `promoted-to` to the ADR filename(s), freeze the body. Promotion is only complete once the index in [this README](README.md#index) and the RFC index are both updated. |
 | One RFC, multiple ADRs | Supported: `promoted-to` accepts a list of ADR filenames. |
-| Reserved ADR numbers | `0001` and `0004` are reserved by open ADR PRs ([#2263][pr-2263], [#2320][pr-2320]). The next free ADR number is `0005` (this ADR); the number after is `0006`. |
+| Retired ADR numbers | `0001` and `0004` were proposed in open PRs ([#2263][pr-2263], [#2320][pr-2320]) but will not be accepted as ADRs; their content is converted to RFCs under this ADR's flow. In line with the *"numbers are never reused"* rule from [ADR-0000][adr-0000], those ADR numbers stay retired. |
 | RFC lifetime | Unlimited. An RFC living for a long time without promotion is not a defect. Stale RFCs are surfaced at the bi-weekly NeIC SDA-Devs meet-up. |
 | Post-promotion edits | A `promoted` or `withdrawn` RFC is frozen — only metadata and index rows change. Revisions to a decision live in the ADR. |
 | ADR lifecycle unchanged | The ADR status lifecycle (`proposed` → `accepted` \| `rejected` \| `deprecated` \| `superseded`) is **not** modified by this ADR. ADR statuses only apply to files in `docs/decisions/`. |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -36,6 +36,22 @@ already obvious from the code or commit message.
 Not every change needs a record — use your judgement. The pull request template
 includes a checkbox as a reminder.
 
+## RFCs — upstream exploration
+
+When the team recognises an architectural question but cannot yet commit to a
+specific answer, write an [RFC](../rfcs/) instead of an ADR. RFCs live in
+`docs/rfcs/` and reuse the MADR structure of this template, minus
+`## Decision Outcome` and `### Confirmation`, plus `## Open Questions`.
+
+An RFC is **promoted** to an ADR when the team can honestly write
+*"Chosen option: X, because Y"*. Promotion creates a new ADR file here under
+the next free ADR number; the original RFC file stays in `docs/rfcs/` as a
+frozen reference to the exploration. ADR statuses (`proposed`, `accepted`,
+etc.) only apply to files in this directory.
+
+See [ADR-0005](0005-introduce-rfcs-as-upstream-exploration-phase.md) for the
+rationale and the full promotion procedure.
+
 ## How to create a decision record
 
 1. Copy the template:
@@ -95,6 +111,12 @@ superseded-by: "0005-use-new-approach.md"
 | [0000](0000-use-markdown-architectural-decision-records.md) | Use Markdown Architectural Decision Records | accepted |
 | [0002](0002-merge-dependabot-package-managers.md) | Merge Dependabot package managers | accepted |
 | [0003](0003-shared-state-strategy-for-s3inbox-and-caching.md) | Replace s3inbox In-Memory File ID Cache with Database Lookups | proposed |
+| [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md) | Introduce RFCs as an upstream exploration phase for ADRs | proposed |
+
+Numbers `0001` and `0004` are reserved by open ADR PRs
+([#2263](https://github.com/neicnordic/sensitive-data-archive/pull/2263),
+[#2320](https://github.com/neicnordic/sensitive-data-archive/pull/2320)). The
+next free ADR number for a new decision is `0006`.
 
 ## More information
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -113,10 +113,14 @@ superseded-by: "0005-use-new-approach.md"
 | [0003](0003-shared-state-strategy-for-s3inbox-and-caching.md) | Replace s3inbox In-Memory File ID Cache with Database Lookups | proposed |
 | [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md) | Introduce RFCs as an upstream exploration phase for ADRs | proposed |
 
-Numbers `0001` and `0004` are reserved by open ADR PRs
-([#2263](https://github.com/neicnordic/sensitive-data-archive/pull/2263),
-[#2320](https://github.com/neicnordic/sensitive-data-archive/pull/2320)). The
-next free ADR number for a new decision is `0006`.
+Numbers `0001` and `0004` were proposed in PRs
+[#2263](https://github.com/neicnordic/sensitive-data-archive/pull/2263) and
+[#2320](https://github.com/neicnordic/sensitive-data-archive/pull/2320) but
+are being converted to RFCs per
+[ADR-0005](0005-introduce-rfcs-as-upstream-exploration-phase.md). Per the
+*"numbers are never reused"* rule from
+[ADR-0000](0000-use-markdown-architectural-decision-records.md), those ADR
+numbers stay retired.
 
 ## More information
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,136 @@
+# Requests for Comments (RFCs)
+
+This directory is an **upstream exploration phase** for architectural work.
+It is not a decision log. For the decision log, see
+[`docs/decisions/`](../decisions/).
+
+An RFC is the right place to put a question the team is actively exploring but
+cannot yet resolve with *"Chosen option: X, because Y"*. When an RFC matures
+to that point, it is **promoted** to an ADR. The RFC file stays in this
+directory as a frozen reference to the exploration; the ADR is a new file in
+`docs/decisions/`.
+
+For the full rationale, see
+[ADR-0005](../decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md).
+
+## When to write an RFC
+
+Write an RFC when all of the following are true:
+
+* The team recognises a question that will benefit from written discussion.
+* You can describe the problem, but **cannot yet commit** to one option.
+* The discussion will plausibly take longer than a typical ADR PR — days or
+  weeks, not hours.
+
+Skip the RFC and open an ADR directly when the team has already converged and
+you can write *"Chosen option: X, because Y"* in the initial PR.
+
+## How to write an RFC
+
+1. Copy the template:
+
+   ```sh
+   cp docs/rfcs/template.md docs/rfcs/NNNN-title-with-dashes.md
+   ```
+
+   Use the next available RFC number, zero-padded to four digits. RFC and ADR
+   numbering are independent.
+
+2. Fill in the sections. The `## Open Questions` section is the heart of an
+   RFC — not a placeholder, it is the deliverable.
+
+3. Set `status: exploring` in the front matter.
+
+4. Open a pull request and label it `rfc`.
+
+5. The RFC is merged in its current state so the exploration can be versioned.
+   It does **not** have to reach a conclusion before merging. `exploring` is a
+   valid end state for a long time.
+
+## Status lifecycle
+
+| Status | Meaning |
+| --- | --- |
+| `exploring` | Under active exploration. Open questions are expected. |
+| `ready-for-decision` | The team believes an ADR can now be written from this RFC. |
+| `promoted` | One or more ADRs have been created from this RFC. The RFC body is frozen; `promoted-to` lists the resulting ADR filenames. |
+| `withdrawn` | No longer pursued. Kept in place for history. |
+
+RFC numbers are never reused. Once an RFC has any status other than `exploring`,
+its body should not be edited further — only `status`, `date`, `promoted-to`,
+and index entries change.
+
+## Promotion — RFC → ADR
+
+An RFC is ready to be promoted when the team can honestly write
+*"Chosen option: X, because Y"*. When that is true:
+
+1. Create the ADR file at `docs/decisions/NNNN-title-with-dashes.md` using the
+   next free ADR number (see the [ADR index](../decisions/README.md#index) —
+   some numbers may already be reserved by open ADR PRs). Start from
+   [`docs/decisions/template.md`](../decisions/template.md). Pull over the
+   Context, Considered Options, and the chosen option; drop the Open Questions
+   that the decision resolves.
+2. Add `## Decision Outcome` with *"Chosen option: X, because Y"*, and
+   `### Confirmation` if applicable.
+3. In the original RFC file: flip `status` from `exploring` or
+   `ready-for-decision` to `promoted`, set `promoted-to` to the ADR filename
+   (or a list of filenames, if the RFC yielded more than one decision), and
+   update the `date`.
+4. **Do not edit the RFC body after promotion.** The RFC is a frozen artifact
+   of the exploration that preceded the decision. If the ADR later needs
+   revision, revise the ADR, not the RFC.
+5. Update both indices:
+   * the RFC row in [this README's index](#index) — mark as `promoted`, link
+     to the ADR;
+   * the ADR row in [`docs/decisions/README.md`](../decisions/README.md#index).
+
+Promotion is complete only when both index updates have been made.
+
+The ADR PR that follows promotion is expected to merge quickly. If it stalls,
+that is a signal that the exploration was not complete — consider reopening
+the question as a new RFC rather than leaving the ADR `proposed` indefinitely.
+
+### Edge cases
+
+**One RFC, several decisions.** If the exploration reveals more than one
+decision the team is ready to make, create one ADR per decision. The RFC's
+`promoted-to` field lists all the resulting ADR filenames. No need to split
+the RFC.
+
+**Reviving a `withdrawn` RFC.** Write a new RFC that links back to the
+withdrawn one in its `## More Information`. Do not reopen the withdrawn file;
+it is part of the historical record.
+
+## Lifetime
+
+An RFC can live in this directory indefinitely. That is not a defect. If a
+question is worth thinking about but not yet worth committing to, leaving the
+RFC in `exploring` is the correct state. Only change the status when something
+actually changes.
+
+To keep the folder from quietly rotting, the RFC index gets a pass at each
+bi-weekly NeIC SDA-Devs meet-up. Every `exploring` or `ready-for-decision`
+RFC is touched, withdrawn, or left with a short note explaining why it is
+still open. The review is a lightweight forcing function, not a deadline.
+
+## How this relates to ADRs
+
+| | `docs/rfcs/` | `docs/decisions/` |
+| --- | --- | --- |
+| Purpose | Exploration | Commitment |
+| Typical question | *"Should we?"* | *"We did, because."* |
+| Status vocabulary | `exploring`, `ready-for-decision`, `promoted`, `withdrawn` | `proposed`, `accepted`, `rejected`, `deprecated`, `superseded` |
+| Template | MADR 4.0.0 structure, minus `## Decision Outcome` and `### Confirmation`, plus `## Open Questions` | Full MADR 4.0.0 |
+| Expected PR lifetime | Indefinite | Short — merges when the discussion has already happened |
+
+ADR statuses only apply after a file lives in `docs/decisions/`. An RFC is not
+a `proposed` ADR; it is a separate artifact with its own lifecycle.
+
+## Index
+
+| # | RFC | Status | Promoted to |
+| --- | --- | --- | --- |
+
+*(empty at the time this folder is introduced; entries added as RFCs are
+written)*

--- a/docs/rfcs/template.md
+++ b/docs/rfcs/template.md
@@ -1,0 +1,104 @@
+---
+# RFC front matter. These are optional unless noted. Remove fields you do not need.
+status: exploring # exploring | ready-for-decision | promoted | withdrawn
+promoted-to: [] # one or more ADR filenames — set when status is `promoted`
+date: "YYYY-MM-DD" # when the RFC was last updated
+authors: [] # people actively shaping this RFC
+consulted: [] # subject-matter experts consulted (two-way communication)
+informed: [] # kept up to date on the discussion (one-way communication)
+---
+
+<!--
+Promotion checklist (when this RFC becomes an ADR):
+
+1. Create the ADR file at docs/decisions/NNNN-title-with-dashes.md using the
+   next free ADR number. Start from docs/decisions/template.md. Pull over the
+   Context, Considered Options, and the chosen option; drop the Open Questions
+   that are resolved by the decision.
+2. Fill in ## Decision Outcome with "Chosen option: X, because Y", and add
+   ### Confirmation if applicable.
+3. In this RFC file: flip status exploring | ready-for-decision -> promoted,
+   set promoted-to to the new ADR filename (or filenames, if the RFC yielded
+   more than one decision), and update the date.
+4. Do not edit the body of this RFC after promotion. The RFC is frozen as a
+   reference artifact for the exploration that led to the ADR.
+5. Promotion is complete only once both indices are updated: the RFC row in
+   docs/rfcs/README.md (status promoted, link to the new ADR) and the ADR row
+   in docs/decisions/README.md.
+
+See [ADR-0005](../decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md)
+for the full rationale.
+-->
+
+# {short title, representative of the question the RFC is exploring}
+
+## Context and Problem Statement
+
+{Describe the context and the problem in two to three sentences, or as a short
+story. Link to collaboration boards, issues, or prior discussions. Unlike an
+ADR, an RFC does not have to frame the problem as a question with an imminent
+answer — it is fine to describe a tension the team wants to explore.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {driver 1 — a force or concern the RFC should account for}
+* {driver 2}
+* …
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* …
+
+<!--
+Intentionally no `## Decision Outcome` section in RFCs. The whole point of an
+RFC is that the team is not yet ready to commit. Add this section at promotion
+time.
+-->
+
+## Open Questions
+
+{List what the team does not yet know or agree on. Unresolved items are not a
+gap in the RFC; they are the point of writing one. When the list is short
+enough that the team can honestly write "Chosen option: X, because Y", the
+RFC is ready for promotion.}
+
+* {open question 1}
+* {open question 2}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{Provide additional evidence or context. Link to related RFCs, ADRs, prior art
+from other projects, and any external discussion threads. If the RFC has a
+suspected eventual decision direction, note it here — but do not put a
+commitment in the `## Decision Outcome` section until promotion.}


### PR DESCRIPTION
## Summary

Adds `docs/rfcs/` as an upstream exploration phase for architectural questions
the team isn't yet ready to commit to. The existing ADR status vocabulary is
unchanged.

See `docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md` for
the rationale, and `docs/rfcs/README.md` for how to write one.

## Why now

The product owner (@viklund ) raised this at the last NeIC SDA-Devs sync: ADR PRs #2263
and #2320 have been open without converging, and their presence in the
decision log makes it harder to trust as a record of commitments. An upstream
exploration phase addresses that without redefining `proposed`.

## Follow-ups (separate PRs)

After this PR merges, the two open ADR PRs are converted in place to RFC PRs
— the existing discussion threads are the exploration we want to preserve,
so closing them would throw away the most useful artefact we have.

- Convert #2263 to RFC: move file to `docs/rfcs/0001-standardize-accessionid.md`,
  reshape to the RFC template, relabel PR as `rfc`.
- Convert #2320 to RFC: move file to `docs/rfcs/0002-separate-visa-authorization-service.md`,
  same reshape.

Per the *"numbers are never reused"* rule from ADR-0000, ADR numbers `0001`
and `0004` stay retired.

## Test plan

- [ ] Tables and links render correctly on GitHub.
- [ ] Inter-doc links resolve.
- [ ] Discussed at next NeIC SDA-Devs meet-up. On merge, ADR-0005 flips to `accepted`.