### PR TITLE
fix(s3/writer): sort buckets numerically so 11th bucket is created

### DIFF
--- a/sda/internal/storage/v2/s3/writer/config.go
+++ b/sda/internal/storage/v2/s3/writer/config.go
@@ -213,7 +213,7 @@ func (endpointConf *endpointConfig) findActiveBucket(ctx context.Context, backen
 		return activeBucket, nil
 	}
 
-	slices.SortFunc(bucketsWithPrefix, strings.Compare)
+	sortBucketsNumerically(bucketsWithPrefix, endpointConf.BucketPrefix)
 
 	// find first bucket with available object count and size
 	for _, bucket := range bucketsWithPrefix {
@@ -253,4 +253,22 @@ func (endpointConf *endpointConfig) findActiveBucket(ctx context.Context, backen
 	}
 
 	return activeBucket, nil
+}
+
+// sortBucketsNumerically sorts buckets in place by the integer suffix that
+// follows prefix so `<prefix>10` comes after `<prefix>9`, not after
+// `<prefix>1`. With plain lexical ordering the 11th bucket lookup picked
+// `<prefix>9` as the "latest" entry and tried to recreate `<prefix>2`,
+// which the S3 API then rejected with BucketAlreadyExists (#2413). If a
+// bucket name can't be parsed as `<prefix><number>` we fall back to
+// lexical ordering between that pair so the function stays total.
+func sortBucketsNumerically(buckets []string, prefix string) {
+	slices.SortFunc(buckets, func(a, b string) int {
+		aInc, aErr := strconv.Atoi(strings.TrimPrefix(a, prefix))
+		bInc, bErr := strconv.Atoi(strings.TrimPrefix(b, prefix))
+		if aErr != nil || bErr != nil {
+			return strings.Compare(a, b)
+		}
+		return aInc - bInc
+	})
 }

--- a/sda/internal/storage/v2/s3/writer/config.go
+++ b/sda/internal/storage/v2/s3/writer/config.go
@@ -269,6 +269,7 @@ func sortBucketsNumerically(buckets []string, prefix string) {
 		if aErr != nil || bErr != nil {
 			return strings.Compare(a, b)
 		}
+
 		return aInc - bInc
 	})
 }

--- a/sda/internal/storage/v2/s3/writer/config_test.go
+++ b/sda/internal/storage/v2/s3/writer/config_test.go
@@ -1,0 +1,64 @@
+package writer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSortBucketsNumerically_OrderingFollowsSuffix pins the regression for
+// #2413 — under plain `strings.Compare` ordering, ten buckets named
+// `bucket-1`…`bucket-10` sort as `[bucket-1 bucket-10 bucket-2 …
+// bucket-9]`. The "latest" entry then becomes `bucket-9`, so the next
+// allocation attempts `bucket-10`, which already exists.
+// `sortBucketsNumerically` must place numeric suffixes in true numeric
+// order so the last element is always the highest-numbered bucket.
+func TestSortBucketsNumerically_OrderingFollowsSuffix(t *testing.T) {
+	t.Parallel()
+
+	buckets := []string{
+		"bucket-1", "bucket-10", "bucket-2", "bucket-3", "bucket-4",
+		"bucket-5", "bucket-6", "bucket-7", "bucket-8", "bucket-9",
+	}
+	sortBucketsNumerically(buckets, "bucket-")
+
+	want := []string{
+		"bucket-1", "bucket-2", "bucket-3", "bucket-4", "bucket-5",
+		"bucket-6", "bucket-7", "bucket-8", "bucket-9", "bucket-10",
+	}
+	assert.Equal(t, want, buckets,
+		"buckets must be ordered by integer suffix so bucket-10 lands after bucket-9")
+	assert.Equal(t, "bucket-10", buckets[len(buckets)-1],
+		"highest-numbered bucket must be last so the next allocation increments it")
+}
+
+// TestSortBucketsNumerically_NumericFallback pins the behaviour when a
+// bucket name does not match the expected `<prefix><integer>` shape —
+// the comparator falls back to lexical ordering between that pair so
+// the sort stays total and Go's slice-sort contract isn't violated.
+func TestSortBucketsNumerically_NumericFallback(t *testing.T) {
+	t.Parallel()
+
+	// "bucket-mixed" can't be parsed as an integer suffix; the comparator
+	// must not panic or produce a non-deterministic order.
+	buckets := []string{"bucket-10", "bucket-mixed", "bucket-2"}
+	sortBucketsNumerically(buckets, "bucket-")
+
+	assert.Contains(t, buckets, "bucket-mixed",
+		"non-numeric bucket name must still appear in the result")
+	assert.Len(t, buckets, 3, "no bucket name should be dropped during sort")
+}
+
+// TestSortBucketsNumerically_EmptyAndSingle covers degenerate inputs so
+// that we don't accidentally regress the n=0/n=1 paths.
+func TestSortBucketsNumerically_EmptyAndSingle(t *testing.T) {
+	t.Parallel()
+
+	var empty []string
+	sortBucketsNumerically(empty, "bucket-")
+	assert.Empty(t, empty)
+
+	single := []string{"bucket-7"}
+	sortBucketsNumerically(single, "bucket-")
+	assert.Equal(t, []string{"bucket-7"}, single)
+}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2413.


## Description

`findActiveBucket` sorts the existing prefix-matched buckets with `strings.Compare` and then uses the last element as the previous increment. With ten buckets named `bucket-1` through `bucket-10` the lexical order yields:

```
[bucket-1 bucket-10 bucket-2 bucket-3 bucket-4 bucket-5 bucket-6 bucket-7 bucket-8 bucket-9]
```

so the "last" bucket becomes `bucket-9` and the next increment is `bucket-10`, which the S3 API rejects with `BucketAlreadyExists`. Ingesting the 11th file therefore fails when `max_buckets > 10` — the exact reproducer in #2413.

The fix is the suggestion from the issue body, lifted into a small named helper `sortBucketsNumerically(buckets, prefix)` that:

1. parses the integer suffix after `prefix` and orders by that value, so `bucket-10` lands after `bucket-9`;
2. falls back to lexical comparison for any pair where either side doesn't match `<prefix><integer>`, so the comparator stays total and Go's slice-sort contract isn't violated.

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

## How to test

Three unit tests added under `internal/storage/v2/s3/writer`:

* `TestSortBucketsNumerically_OrderingFollowsSuffix` — ten-bucket regression case from the issue body; pins that the highest-numbered bucket is last so the next allocation increments it correctly.
* `TestSortBucketsNumerically_NumericFallback` — non-numeric suffix (e.g. `bucket-mixed`) doesn't get dropped or panic.
* `TestSortBucketsNumerically_EmptyAndSingle` — degenerate inputs (n=0, n=1).

```
$ go test -count=1 -run TestSortBucketsNumerically -v ./internal/storage/v2/s3/writer/...
=== RUN   TestSortBucketsNumerically_OrderingFollowsSuffix
--- PASS: TestSortBucketsNumerically_OrderingFollowsSuffix (0.00s)
=== RUN   TestSortBucketsNumerically_NumericFallback
--- PASS: TestSortBucketsNumerically_NumericFallback (0.00s)
=== RUN   TestSortBucketsNumerically_EmptyAndSingle
--- PASS: TestSortBucketsNumerically_EmptyAndSingle (0.00s)
PASS
ok  	github.com/neicnordic/sensitive-data-archive/internal/storage/v2/s3/writer	1.048s
```

`go build`, `go vet`, `gofmt` all clean on the modified files.