### PR TITLE
Feature/sda svc sda api multiple jwt origins

### DIFF
--- a/.github/integration/scripts/charts/values.yaml
+++ b/.github/integration/scripts/charts/values.yaml
@@ -90,10 +90,10 @@ global:
       configFile: "iss.json"
       iss:
         - iss: "http://oidc:8080"
-          jku: "http://oidc:8080/jwks"
+          jku: "http://oidc:8080/jwk"
   oidc:
     provider: "http://oidc:8080"
-    jwkPath: "/jwks"
+    jwkPath: "/jwk"
     id: DfCieZLuBU
     secret: DfCieZLuBU
   reencrypt:

--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 3.4.0
+version: 3.4.1
 appVersion: v3.1.37
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/templates/api-secrets.yaml
+++ b/charts/sda-svc/templates/api-secrets.yaml
@@ -78,10 +78,14 @@ stringData:
     schema:
       type: {{ default "federated" .Values.global.schemaType }}
     server:
+      {{- if not (or .Values.global.api.jwtPubKeyName .Values.global.oidc.provider) }}
+      {{- fail "Either global.api.jwtPubKeyName or global.oidc.provider must be configured" }}
+      {{- end }}
       {{- if .Values.global.api.jwtPubKeyName }}
       jwtpubkeypath: {{ include "jwtPath" . }}
-      {{- else }}
-      jwtpubkeyurl: "{{ required "A oidc provider is required" .Values.global.oidc.provider  | trimSuffix "/" }}/{{ .Values.global.oidc.jwkPath | trimPrefix "/" }}"
+      {{- end }}
+      {{- if .Values.global.oidc.provider }}
+      jwtpubkeyurl: "{{ .Values.global.oidc.provider | trimSuffix "/" }}/{{ required "A valid OIDC JWK path is required when global.oidc.provider is configured" .Values.global.oidc.jwkPath | trimPrefix "/" }}"
       {{- end }}
 ---
 {{- if not .Values.global.api.adminsFileSecret }}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2421


## Description

Update sda-api secret to accept both `Values.global.api.jwtPubKeyName` and `Values.global.oidc.provider`, or either, but not none