### PR TITLE
feat(api): extend admin api add file_events

### DIFF
--- a/.github/integration/sda/rbac.json
+++ b/.github/integration/sda/rbac.json
@@ -26,6 +26,16 @@
           "action": "POST"
        },
        {
+          "role": "admin",
+          "path": "/file/events/:fileid",
+          "action": "GET"
+       },
+       {
+          "role": "admin",
+          "path": "/file/events/:fileid/:event",
+          "action": "POST"
+       },
+       {
           "role": "submission",
           "path": "/file/accession",
           "action": "POST"

--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -68,6 +68,7 @@ until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ |
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
         echo "::error::Time out while waiting for verify to complete"
+        docker logs ingest
         exit 1
     fi
     sleep 2

--- a/.github/integration/tests/sda/20_ingest-verify_test.sh
+++ b/.github/integration/tests/sda/20_ingest-verify_test.sh
@@ -68,7 +68,6 @@ until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/verified/ |
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
         echo "::error::Time out while waiting for verify to complete"
-        docker logs ingest
         exit 1
     fi
     sleep 2

--- a/postgresql/initdb.d/04_grants.sql
+++ b/postgresql/initdb.d/04_grants.sql
@@ -185,6 +185,7 @@ CREATE ROLE api;
 GRANT USAGE ON SCHEMA sda TO api;
 GRANT SELECT ON sda.files TO api;
 GRANT SELECT ON sda.file_dataset TO api;
+GRANT SELECT ON sda.file_events TO api;
 GRANT SELECT ON sda.checksums TO api;
 GRANT SELECT, INSERT ON sda.file_event_log TO api;
 GRANT SELECT ON sda.encryption_keys TO api;

--- a/sda-admin/README.md
+++ b/sda-admin/README.md
@@ -59,7 +59,23 @@ sda-admin file set-accession -filepath /path/to/file.c4gh -user test-user@exampl
 
 **By file ID:**
 ```sh
-sda-admin file set-accession -fileid <FILEUUID> -accession-id my-accession-id-1
+sda-admin file set-accession -fileid <FILE_UUID> -accession-id my-accession-id-1
+```
+
+## Get file events for a given file
+
+List all file events associated to a file:
+
+```sh
+sda-admin file get-events -file-id <FILE_UUID>
+```
+
+## Update latest file event for a given file
+
+Append a new file event to the file_event_log for a given file by specifying the fileID and the new event in the request payload
+
+```sh
+sda-admin file update-event -file-id <FILE_UUID> -event disabled -reason "file set to disabled, broken checksum, don't ingest"
 ```
 
 ## Create a dataset from a list of accession IDs and a dataset ID

--- a/sda-admin/file/file.go
+++ b/sda-admin/file/file.go
@@ -28,6 +28,10 @@ type RequestBodyFileAccession struct {
 	User        string `json:"user"`
 }
 
+type RequestBodyUpdateReason struct {
+	Reason string `json:"reason"`
+}
+
 // List fetches and prints all files for username, auto-paginating.
 //
 // When stdout is a TTY (interactive session), each page is printed as it
@@ -242,4 +246,40 @@ func RotateKey(apiURI, token, fileID string) error {
 	}
 
 	return nil
+}
+
+func GetEvent(apiURI, token, fileID string) ([]byte, error) {
+	parsedURL, err := url.Parse(apiURI)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedURL.Path = path.Join(parsedURL.Path, "file", "events", fileID)
+	responseBody, err := helpers.GetReq(parsedURL.String(), token, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+}
+
+func PostEvent(apiURI, token, fileID, event, reason string) ([]byte, error) {
+	parsedURL, err := url.Parse(apiURI)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := RequestBodyUpdateReason{Reason: reason}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedURL.Path = path.Join(parsedURL.Path, "file", "events", fileID, event)
+	responseBody, err := helpers.PostReq(parsedURL.String(), token, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
 }

--- a/sda-admin/file/file_test.go
+++ b/sda-admin/file/file_test.go
@@ -3,6 +3,7 @@ package file
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path"
@@ -250,6 +251,38 @@ func TestRotateKey_Failure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "post request failed")
 	mockHelpers.AssertExpectations(t)
+}
+
+func TestGetEvent_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/file/events/file123", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	body, err := GetEvent(server.URL, "test-token", "file123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, `{"status":"ok"}`, string(body))
+}
+
+func TestPostEvent_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/file/events/file123/created", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	body, err := PostEvent(server.URL, "test-token", "file123", "created", "initial upload")
+
+	assert.NoError(t, err)
+	assert.Equal(t, `{"status":"ok"}`, string(body))
 }
 
 func TestListMultiPage(t *testing.T) {

--- a/sda-admin/main.go
+++ b/sda-admin/main.go
@@ -32,6 +32,10 @@ Commands:
                                 Assign accession ID to a file.
   file rotatekey -file-id FILEUUID
                                 Rotate encryption key for a specific file.
+  file get-event -file-id FILEUUID
+                                Retrieve the event / status for a given file
+  file update-event -file-id FILEUUID -event EVENT
+                                Update the event / status for a given file
   dataset create -user SUBMISSION_USER -dataset-id DATASET_ID accessionID [accessionID ...]
                                 Create a dataset from a list of accession IDs and a dataset ID.
   dataset release -dataset-id DATASET_ID
@@ -105,6 +109,23 @@ Options:
   -user USERNAME       Specify the username associated with the file.
   -fileid FILEUUID     Specify the file ID of the file to assign the accession ID.
   -accession-id ID     Specify the accession ID to assign to the file.`
+
+var getFileEventUsage = `Usage with file path and user: sda-admin file get-event -fileid <FILE_ID>
+Usage with file ID: sda-admin file get-event -fileid <FILE_ID>
+
+	Get the latest event associated with a file by providing the file id
+
+Options:
+  -fileid FILEUUID     Specify the file ID of the file to assign the accession ID.`
+
+var updateFileEventUsage = `Usage with fileid and event: sda-admin file update-event -fileid <FILE_ID> -event <EVENT>
+Usage with file ID: sda-admin file update-event -fileid <FILE_ID> -event <EVENT>
+
+	Append the file_event_log with a new event for the given fileid
+
+Options:
+  -fileid <FILE_ID>     Specify the file ID of the file to assign the accession ID.
+	-event <EVENT>        Specity the event to update the file with`
 
 var fileRotateKeyUsage = `Usage: sda-admin file rotatekey -file-id FILEUUID
   Rotate encryption key for a specific file.
@@ -282,6 +303,10 @@ func handleHelpFile() error {
 		_, _ = fmt.Println(fileAccessionUsage)
 	case flag.Arg(2) == "rotatekey":
 		_, _ = fmt.Println(fileRotateKeyUsage)
+	case flag.Arg(2) == "get-event":
+		_, _ = fmt.Println(getFileEventUsage)
+	case flag.Arg(2) == "update-event":
+		_, _ = fmt.Println(updateFileEventUsage)
 	default:
 		return fmt.Errorf("unknown subcommand '%s' for '%s'.\n%s", flag.Arg(2), flag.Arg(1), fileUsage)
 	}
@@ -367,6 +392,14 @@ func handleFileCommand() error {
 		}
 	case "rotatekey":
 		if err := handleFileRotateKeyCommand(); err != nil {
+			return err
+		}
+	case "get-event":
+		if err := handleFileGetEvent(); err != nil {
+			return err
+		}
+	case "update-event":
+		if err := handleFileUpdateEvent(); err != nil {
 			return err
 		}
 	default:
@@ -460,6 +493,46 @@ func handleFileRotateKeyCommand() error {
 	if err != nil {
 		return fmt.Errorf("error: failed to rotate key for file, reason: %v", err)
 	}
+
+	return nil
+}
+
+func handleFileGetEvent() error {
+	var fileID string
+	fileGetEventCmd := flag.NewFlagSet("get-event", flag.ExitOnError)
+	fileGetEventCmd.StringVar(&fileID, "file-id", "", "File ID (UUID) to rotate key for")
+
+	if err := fileGetEventCmd.Parse(flag.Args()[2:]); err != nil {
+		return fmt.Errorf("error: failed to parse command line arguments, reason: %v", err)
+	}
+
+	body, err := file.GetEvent(apiURI, token, fileID)
+	if err != nil {
+		return fmt.Errorf("could not get event for file %s, reason: %v", fileID, err)
+	}
+
+	fmt.Printf("response: %s", body)
+
+	return nil
+}
+
+func handleFileUpdateEvent() error {
+	var fileID, event, reason string
+	fileGetEventCmd := flag.NewFlagSet("update-event", flag.ExitOnError)
+	fileGetEventCmd.StringVar(&fileID, "file-id", "", "File ID (UUID) to append event to")
+	fileGetEventCmd.StringVar(&event, "event", "", "Event to append")
+	fileGetEventCmd.StringVar(&reason, "reason", "", "Reason for changing the event_log")
+
+	if err := fileGetEventCmd.Parse(flag.Args()[2:]); err != nil {
+		return fmt.Errorf("error: failed to parse command line arguments, reason: %v", err)
+	}
+
+	_, err := file.PostEvent(apiURI, token, fileID, event, reason)
+	if err != nil {
+		return fmt.Errorf("could not get event for file %s, reason: %v", fileID, err)
+	}
+
+	fmt.Printf("appended event '%s' for file '%s'", event, fileID)
 
 	return nil
 }

--- a/sda-admin/main.go
+++ b/sda-admin/main.go
@@ -32,7 +32,7 @@ Commands:
                                 Assign accession ID to a file.
   file rotatekey -file-id FILEUUID
                                 Rotate encryption key for a specific file.
-  file get-event -file-id FILEUUID
+  file get-events -file-id FILEUUID
                                 Retrieve the event / status for a given file
   file update-event -file-id FILEUUID -event EVENT
                                 Update the event / status for a given file
@@ -110,8 +110,8 @@ Options:
   -fileid FILEUUID     Specify the file ID of the file to assign the accession ID.
   -accession-id ID     Specify the accession ID to assign to the file.`
 
-var getFileEventUsage = `Usage with file path and user: sda-admin file get-event -fileid <FILE_ID>
-Usage with file ID: sda-admin file get-event -fileid <FILE_ID>
+var getFileEventUsage = `Usage with file path and user: sda-admin file get-events -fileid <FILE_ID>
+Usage with file ID: sda-admin file get-events -fileid <FILE_ID>
 
 	Get the latest event associated with a file by providing the file id
 
@@ -303,7 +303,7 @@ func handleHelpFile() error {
 		_, _ = fmt.Println(fileAccessionUsage)
 	case flag.Arg(2) == "rotatekey":
 		_, _ = fmt.Println(fileRotateKeyUsage)
-	case flag.Arg(2) == "get-event":
+	case flag.Arg(2) == "get-events":
 		_, _ = fmt.Println(getFileEventUsage)
 	case flag.Arg(2) == "update-event":
 		_, _ = fmt.Println(updateFileEventUsage)
@@ -394,7 +394,7 @@ func handleFileCommand() error {
 		if err := handleFileRotateKeyCommand(); err != nil {
 			return err
 		}
-	case "get-event":
+	case "get-events":
 		if err := handleFileGetEvent(); err != nil {
 			return err
 		}
@@ -499,7 +499,7 @@ func handleFileRotateKeyCommand() error {
 
 func handleFileGetEvent() error {
 	var fileID string
-	fileGetEventCmd := flag.NewFlagSet("get-event", flag.ExitOnError)
+	fileGetEventCmd := flag.NewFlagSet("get-events", flag.ExitOnError)
 	fileGetEventCmd.StringVar(&fileID, "file-id", "", "File ID (UUID) to rotate key for")
 
 	if err := fileGetEventCmd.Parse(flag.Args()[2:]); err != nil {

--- a/sda-admin/main.go
+++ b/sda-admin/main.go
@@ -529,7 +529,7 @@ func handleFileUpdateEvent() error {
 
 	_, err := file.PostEvent(apiURI, token, fileID, event, reason)
 	if err != nil {
-		return fmt.Errorf("could not get event for file %s, reason: %v", fileID, err)
+		return fmt.Errorf("could not set event for file %s, reason: %v", fileID, err)
 	}
 
 	fmt.Printf("appended event '%s' for file '%s'", event, fileID)

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -210,8 +212,8 @@ func setup(conf *config.Config) (*http.Server, error) {
 	r.DELETE("/file/:username/:fileid", rbac(e), deleteFile)            // Delete a file from inbox
 	// submission endpoints below here
 	r.POST("/file/ingest", rbac(e), ingestFile)                      // start ingestion of a file
-	r.GET("/file/events/:fileid", rbac(e), getFileEvent)             // get file events associated with a file
-	r.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)  // get file events associated with a file
+	r.GET("/file/events/:fileid", rbac(e), getFileEvents)            // get file events associated with a file
+	r.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)  // append a file_event to the file_event_log for a given fileid
 	r.POST("/file/accession", rbac(e), setAccession)                 // assign accession ID to a file
 	r.PUT("/file/verify/:accession", rbac(e), reVerifyFile)          // trigger reverification of a file
 	r.POST("/file/rotatekey/:fileid", rbac(e), rotateKeyFile)        // trigger key rotation for a file
@@ -1334,7 +1336,17 @@ func updateFileEvent(c *gin.Context) {
 	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
 	event := strings.TrimPrefix(c.Param("event"), "/")
 
-	var updateEvent schema.UpdateEvent
+	token, err := auth.Authenticate(c.Request)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, err.Error())
+
+		return
+	}
+
+	type updateFileEventBody struct {
+		Reason string `json:"reason"`
+	}
+	updateEvent := &updateFileEventBody{}
 	if err := c.BindJSON(&updateEvent); err != nil {
 		c.AbortWithStatusJSON(
 			http.StatusBadRequest,
@@ -1345,42 +1357,56 @@ func updateFileEvent(c *gin.Context) {
 		)
 	}
 
-	token, err := auth.Authenticate(c.Request)
-	if err != nil {
-		c.JSON(401, err.Error())
-
-		return
+	if updateEvent.Reason == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "no reason recieved", "status": http.StatusBadRequest})
 	}
 
-	detailsMap := map[string]string{"reason": updateEvent.Reason}
-	details, err := json.Marshal(detailsMap)
+	details, err := json.Marshal(updateEvent)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to encode reason"})
 
 		return
 	}
 
-	err = Conf.API.DB.UpdateFileEventLog(fileID, event, token.Subject(), string(details), "{}")
+	fileEvents, err := db.GetFileEvents(c)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"fileID": fileID, "event": event, "reason": string(details)})
+	if !slices.Contains(fileEvents, event) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("event: '%s' not allowed", event))
+
+		return
+	}
+
+	err = db.UpdateFileEventLog(c, fileID, event, token.Subject(), string(details), "{}")
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("file: '%s' not found", fileID))
+
+			return
+		}
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
-func getFileEvent(c *gin.Context) {
+func getFileEvents(c *gin.Context) {
 	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
 
-	status, err := Conf.API.DB.GetFileStatus(fileID)
+	statusHistory, err := db.GetFileStatusHistory(c, fileID)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": status})
+	c.JSON(http.StatusOK, statusHistory)
 }
 
 func reVerifyFile(c *gin.Context) {

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -210,6 +210,8 @@ func setup(conf *config.Config) (*http.Server, error) {
 	r.DELETE("/file/:username/:fileid", rbac(e), deleteFile)            // Delete a file from inbox
 	// submission endpoints below here
 	r.POST("/file/ingest", rbac(e), ingestFile)                      // start ingestion of a file
+	r.GET("/file/events/:fileid", rbac(e), getFileEvent)             // get file events associated with a file
+	r.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)  // get file events associated with a file
 	r.POST("/file/accession", rbac(e), setAccession)                 // assign accession ID to a file
 	r.PUT("/file/verify/:accession", rbac(e), reVerifyFile)          // trigger reverification of a file
 	r.POST("/file/rotatekey/:fileid", rbac(e), rotateKeyFile)        // trigger key rotation for a file
@@ -298,7 +300,7 @@ func checkDB(ctx context.Context, db database.Database, timeout time.Duration) e
 
 func auditLog(auditFields log.Fields) {
 	auditFields["audit"] = true
-	Conf.API.AuditLogger.WithFields(auditFields).Info("Incoming audit event")
+	Conf.API.AuditLogger.WithFields(auditFields).Info("incoming audit event")
 }
 
 func rbac(e *casbin.Enforcer) gin.HandlerFunc {
@@ -1326,6 +1328,59 @@ func reVerify(c *gin.Context, accessionID string) (*gin.Context, error) {
 	}
 
 	return c, nil
+}
+
+func updateFileEvent(c *gin.Context) {
+	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
+	event := strings.TrimPrefix(c.Param("event"), "/")
+
+	var updateEvent schema.UpdateEvent
+	if err := c.BindJSON(&updateEvent); err != nil {
+		c.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			gin.H{
+				"error":  "json decoding : " + err.Error(),
+				"status": http.StatusBadRequest,
+			},
+		)
+	}
+
+	token, err := auth.Authenticate(c.Request)
+	if err != nil {
+		c.JSON(401, err.Error())
+
+		return
+	}
+
+	detailsMap := map[string]string{"reason": updateEvent.Reason}
+	details, err := json.Marshal(detailsMap)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to encode reason"})
+
+		return
+	}
+
+	err = Conf.API.DB.UpdateFileEventLog(fileID, event, token.Subject(), string(details), "{}")
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"fileID": fileID, "event": event, "reason": string(details)})
+}
+
+func getFileEvent(c *gin.Context) {
+	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
+
+	status, err := Conf.API.DB.GetFileStatus(fileID)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": status})
 }
 
 func reVerifyFile(c *gin.Context) {

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -210,6 +210,8 @@ func setup(conf *config.Config) (*http.Server, error) {
 	r.DELETE("/file/:username/:fileid", rbac(e), deleteFile)            // Delete a file from inbox
 	// submission endpoints below here
 	r.POST("/file/ingest", rbac(e), ingestFile)                      // start ingestion of a file
+	r.GET("/file/events/:fileid", rbac(e), getFileEvent)             // get file events associated with a file
+	r.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)  // get file events associated with a file
 	r.POST("/file/accession", rbac(e), setAccession)                 // assign accession ID to a file
 	r.PUT("/file/verify/:accession", rbac(e), reVerifyFile)          // trigger reverification of a file
 	r.POST("/file/rotatekey/:fileid", rbac(e), rotateKeyFile)        // trigger key rotation for a file
@@ -298,7 +300,7 @@ func checkDB(ctx context.Context, db database.Database, timeout time.Duration) e
 
 func auditLog(auditFields log.Fields) {
 	auditFields["audit"] = true
-	Conf.API.AuditLogger.WithFields(auditFields).Info("Incoming audit event")
+	Conf.API.AuditLogger.WithFields(auditFields).Info("incoming audit event")
 }
 
 func rbac(e *casbin.Enforcer) gin.HandlerFunc {
@@ -1327,6 +1329,59 @@ func reVerify(c *gin.Context, accessionID string) (*gin.Context, error) {
 	}
 
 	return c, nil
+}
+
+func updateFileEvent(c *gin.Context) {
+	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
+	event := strings.TrimPrefix(c.Param("event"), "/")
+
+	var updateEvent schema.UpdateEvent
+	if err := c.BindJSON(&updateEvent); err != nil {
+		c.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			gin.H{
+				"error":  "json decoding : " + err.Error(),
+				"status": http.StatusBadRequest,
+			},
+		)
+	}
+
+	token, err := auth.Authenticate(c.Request)
+	if err != nil {
+		c.JSON(401, err.Error())
+
+		return
+	}
+
+	detailsMap := map[string]string{"reason": updateEvent.Reason}
+	details, err := json.Marshal(detailsMap)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to encode reason"})
+
+		return
+	}
+
+	err = Conf.API.DB.UpdateFileEventLog(fileID, event, token.Subject(), string(details), "{}")
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"fileID": fileID, "event": event, "reason": string(details)})
+}
+
+func getFileEvent(c *gin.Context) {
+	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
+
+	status, err := Conf.API.DB.GetFileStatus(fileID)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": status})
 }
 
 func reVerifyFile(c *gin.Context) {

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -15,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -210,8 +212,8 @@ func setup(conf *config.Config) (*http.Server, error) {
 	r.DELETE("/file/:username/:fileid", rbac(e), deleteFile)            // Delete a file from inbox
 	// submission endpoints below here
 	r.POST("/file/ingest", rbac(e), ingestFile)                      // start ingestion of a file
-	r.GET("/file/events/:fileid", rbac(e), getFileEvent)             // get file events associated with a file
-	r.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)  // get file events associated with a file
+	r.GET("/file/events/:fileid", rbac(e), getFileEvents)            // get file events associated with a file
+	r.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)  // append a file_event to the file_event_log for a given fileid
 	r.POST("/file/accession", rbac(e), setAccession)                 // assign accession ID to a file
 	r.PUT("/file/verify/:accession", rbac(e), reVerifyFile)          // trigger reverification of a file
 	r.POST("/file/rotatekey/:fileid", rbac(e), rotateKeyFile)        // trigger key rotation for a file
@@ -1335,7 +1337,17 @@ func updateFileEvent(c *gin.Context) {
 	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
 	event := strings.TrimPrefix(c.Param("event"), "/")
 
-	var updateEvent schema.UpdateEvent
+	token, err := auth.Authenticate(c.Request)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, err.Error())
+
+		return
+	}
+
+	type updateFileEventBody struct {
+		Reason string `json:"reason"`
+	}
+	updateEvent := &updateFileEventBody{}
 	if err := c.BindJSON(&updateEvent); err != nil {
 		c.AbortWithStatusJSON(
 			http.StatusBadRequest,
@@ -1346,42 +1358,56 @@ func updateFileEvent(c *gin.Context) {
 		)
 	}
 
-	token, err := auth.Authenticate(c.Request)
-	if err != nil {
-		c.JSON(401, err.Error())
-
-		return
+	if updateEvent.Reason == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "no reason recieved", "status": http.StatusBadRequest})
 	}
 
-	detailsMap := map[string]string{"reason": updateEvent.Reason}
-	details, err := json.Marshal(detailsMap)
+	details, err := json.Marshal(updateEvent)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to encode reason"})
 
 		return
 	}
 
-	err = Conf.API.DB.UpdateFileEventLog(fileID, event, token.Subject(), string(details), "{}")
+	fileEvents, err := db.GetFileEvents(c)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"fileID": fileID, "event": event, "reason": string(details)})
+	if !slices.Contains(fileEvents, event) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("event: '%s' not allowed", event))
+
+		return
+	}
+
+	err = db.UpdateFileEventLog(c, fileID, event, token.Subject(), string(details), "{}")
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			c.AbortWithStatusJSON(http.StatusNotFound, fmt.Sprintf("file: '%s' not found", fileID))
+
+			return
+		}
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	c.Status(http.StatusOK)
 }
 
-func getFileEvent(c *gin.Context) {
+func getFileEvents(c *gin.Context) {
 	fileID := strings.TrimPrefix(c.Param("fileid"), "/")
 
-	status, err := Conf.API.DB.GetFileStatus(fileID)
+	statusHistory, err := db.GetFileStatusHistory(c, fileID)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": status})
+	c.JSON(http.StatusOK, statusHistory)
 }
 
 func reVerifyFile(c *gin.Context) {

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	_ "github.com/lib/pq"
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/crypt4gh/streaming"
@@ -488,6 +489,7 @@ func (s *TestSuite) SetupSuite() {
 	{"role":"submission","path":"/dataset/release/*dataset","action":"POST"},
 	{"role":"submission","path":"/file/ingest","action":"POST"},
 	{"role":"submission","path":"/file/accession","action":"POST"},
+	{"role":"admin","path":"/file/events/:fileid/:event","action":"POST"},
 	{"role":"submission","path":"/users","action":"GET"},
 	{"role":"submission","path":"/users/:username/files","action":"GET"},
 	{"role":"submission","path":"/users/:username/file/:fileid","action":"GET"},
@@ -754,6 +756,134 @@ func (s *TestSuite) TestAPIGetFiles() {
 		}
 	}
 	assert.NoError(s.T(), err)
+}
+
+func (s *TestSuite) TestAPIUpdateEvent_NoError() {
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(s.T(), setupJwtAuth())
+	m, err := model.NewModelFromString(jsonadapter.Model)
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC model")
+	}
+	e, err := casbin.NewEnforcer(m, jsonadapter.NewAdapter(&s.RBAC))
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC enforcer")
+	}
+
+	fileID, err := db.RegisterFile(context.Background(), nil, s.inboxDir, "submission_b/TestUpdateEvent.c4gh", "dummy")
+	if err != nil {
+		s.FailNow("failed to register file in database")
+	}
+
+	w := httptest.NewRecorder()
+	jsonBody := `{"reason": "setting event"}`
+	r := httptest.NewRequest("POST", fmt.Sprintf("http://%s:%d/file/events/%s/disabled", Conf.API.Host, Conf.API.Port, fileID), strings.NewReader(jsonBody))
+	r.Header.Add("Authorization", "Bearer "+s.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)
+
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(s.T(), http.StatusOK, okResponse.StatusCode)
+}
+
+func (s *TestSuite) TestAPIUpdateEvent_BadFileID() {
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(s.T(), setupJwtAuth())
+	m, err := model.NewModelFromString(jsonadapter.Model)
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC model")
+	}
+	e, err := casbin.NewEnforcer(m, jsonadapter.NewAdapter(&s.RBAC))
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC enforcer")
+	}
+
+	fileID := uuid.NewString()
+
+	w := httptest.NewRecorder()
+	jsonBody := `{"reason": "setting event"}`
+	r := httptest.NewRequest("POST", fmt.Sprintf("http://%s:%d/file/events/%s/uploaded", Conf.API.Host, Conf.API.Port, fileID), strings.NewReader(jsonBody))
+	r.Header.Add("Authorization", "Bearer "+s.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)
+
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(s.T(), http.StatusNotFound, okResponse.StatusCode)
+}
+
+func (s *TestSuite) TestAPIUpdateEvent_BadEvent() {
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(s.T(), setupJwtAuth())
+	m, err := model.NewModelFromString(jsonadapter.Model)
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC model")
+	}
+	e, err := casbin.NewEnforcer(m, jsonadapter.NewAdapter(&s.RBAC))
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC enforcer")
+	}
+
+	fileID, err := db.RegisterFile(context.Background(), nil, s.inboxDir, "submission_b/TestUpdateEventBadEvent.c4gh", "dummy")
+	if err != nil {
+		s.FailNow("failed to register file in database")
+	}
+
+	w := httptest.NewRecorder()
+	jsonBody := `{"reason": "setting event"}`
+	r := httptest.NewRequest("POST", fmt.Sprintf("http://%s:%d/file/events/%s/badevent", Conf.API.Host, Conf.API.Port, fileID), strings.NewReader(jsonBody))
+	r.Header.Add("Authorization", "Bearer "+s.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)
+
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(s.T(), http.StatusBadRequest, okResponse.StatusCode)
+}
+
+func (s *TestSuite) TestAPIUpdateEvent_NoMessage() {
+	gin.SetMode(gin.ReleaseMode)
+	assert.NoError(s.T(), setupJwtAuth())
+	m, err := model.NewModelFromString(jsonadapter.Model)
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC model")
+	}
+	e, err := casbin.NewEnforcer(m, jsonadapter.NewAdapter(&s.RBAC))
+	if err != nil {
+		s.T().Logf("failure: %v", err)
+		s.FailNow("failed to setup RBAC enforcer")
+	}
+
+	fileID, err := db.RegisterFile(context.Background(), nil, s.inboxDir, "submission_b/TestUpdateEventNoMessage.c4gh", "dummy")
+	if err != nil {
+		s.FailNow("failed to register file in database")
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", fmt.Sprintf("http://%s:%d/file/events/%s/badevent", Conf.API.Host, Conf.API.Port, fileID), nil)
+	r.Header.Add("Authorization", "Bearer "+s.Token)
+
+	_, router := gin.CreateTestContext(w)
+	router.POST("/file/events/:fileid/:event", rbac(e), updateFileEvent)
+
+	router.ServeHTTP(w, r)
+	okResponse := w.Result()
+	defer okResponse.Body.Close()
+	assert.Equal(s.T(), http.StatusBadRequest, okResponse.StatusCode)
 }
 
 func (s *TestSuite) TestAPIGetFiles_SubmissionFileSize() {

--- a/sda/cmd/api/swagger_v1.yml
+++ b/sda/cmd/api/swagger_v1.yml
@@ -229,6 +229,66 @@ paths:
           description: Authentication failure.
         "500":
           description: Internal application error.
+  /file/events/{fileID}:
+    get:
+      description: Get the latest event associated with a given fileid
+      parameters:
+        - name: fileid
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The unique identifier of the file.
+      responses:
+        '200':
+          description: File status retrieved successfully.
+        '401':
+          description: Authentication failure.
+        '500':
+          description: Internal server error.
+  /file/events/{fileID}/{event}:
+    post:
+      description: Logs an event for a specific file. The reason is extracted from the request body and stored alongside the event.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: fileid
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The unique identifier of the file.
+        - name: event
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The event type to log (e.g. "uploaded", "disabled").
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  description: Human-readable reason for the event.
+            example:
+              reason: "File event changed to disabled due to incorrect upload from user"
+      responses:
+        '200':
+          description: Event logged successfully.
+        '400':
+          description: Bad request — JSON decoding failed.
+        '401':
+          description: Authentication failure.
+        '404':
+          description: Not found — file not found
+        '500':
+          description: Internal server error.
   /file/{userName}/{fileID}:
     delete:
       description: Delete a file from the inbox

--- a/sda/internal/database/database.go
+++ b/sda/internal/database/database.go
@@ -67,6 +67,9 @@ type functions interface {
 	// GetFileStatus get the latest event for a file id
 	GetFileStatus(ctx context.Context, fileID string) (string, error)
 
+	// GetFileStatusHistory gets all events for a file id
+	GetFileStatusHistory(ctx context.Context, fileID string) ([]FileStatus, error)
+
 	// GetHeader retrieves the file header
 	GetHeader(ctx context.Context, fileID string) ([]byte, error)
 
@@ -185,6 +188,9 @@ type functions interface {
 
 	// GetFileDetails retrieves user, path and correlation id by giving the file id
 	GetFileDetails(ctx context.Context, fileID, event string) (*FileDetails, error)
+
+	// GetFileEvents retrieves the event types that can be registered in the file_event_log table
+	GetFileEvents(ctx context.Context) ([]string, error)
 
 	// GetSizeAndObjectCountOfLocation Sums the size and count of the files in a location
 	GetSizeAndObjectCountOfLocation(ctx context.Context, location string) (uint64, uint64, error)

--- a/sda/internal/database/models.go
+++ b/sda/internal/database/models.go
@@ -1,5 +1,7 @@
 package database
 
+import "database/sql"
+
 type FileInfo struct {
 	Size              int64
 	Path              string
@@ -28,6 +30,14 @@ type ArchiveData struct {
 
 	BackupFilePath string
 	BackupLocation string
+}
+
+type FileStatus struct {
+	Event     string
+	User      string
+	Details   sql.NullString
+	Message   sql.NullString
+	CreatedAt string
 }
 
 type SubmissionFileInfo struct {

--- a/sda/internal/database/postgres/method_get_file_events.go
+++ b/sda/internal/database/postgres/method_get_file_events.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+)
+
+const getFileEventsQuery = "getFileEvents"
+
+func init() {
+	queries[getFileEventsQuery] = "SELECT title from sda.file_events"
+}
+
+func (db *pgDb) getFileEvents(ctx context.Context, tx *sql.Tx) ([]string, error) {
+	stmt, err := db.getPreparedStmt(tx, getFileEventsQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	var fileEvents []string
+	for rows.Next() {
+		var title string
+		if err := rows.Scan(&title); err != nil {
+			return nil, err
+		}
+		fileEvents = append(fileEvents, title)
+	}
+
+	return fileEvents, nil
+}

--- a/sda/internal/database/postgres/method_get_file_events.go
+++ b/sda/internal/database/postgres/method_get_file_events.go
@@ -21,10 +21,8 @@ func (db *pgDb) getFileEvents(ctx context.Context, tx *sql.Tx) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
-	if rows.Err() != nil {
-		return nil, rows.Err()
-	}
 
 	var fileEvents []string
 	for rows.Next() {
@@ -33,6 +31,10 @@ func (db *pgDb) getFileEvents(ctx context.Context, tx *sql.Tx) ([]string, error)
 			return nil, err
 		}
 		fileEvents = append(fileEvents, title)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return fileEvents, nil

--- a/sda/internal/database/postgres/method_get_file_events.go
+++ b/sda/internal/database/postgres/method_get_file_events.go
@@ -23,7 +23,6 @@ func (db *pgDb) getFileEvents(ctx context.Context, tx *sql.Tx) ([]string, error)
 	}
 	defer rows.Close()
 
-
 	var fileEvents []string
 	for rows.Next() {
 		var title string

--- a/sda/internal/database/postgres/method_get_file_status_history.go
+++ b/sda/internal/database/postgres/method_get_file_status_history.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
+)
+
+const getFileStatusHistoryQuery = "getFileStatus"
+
+func init() {
+	queries[getFileStatusHistoryQuery] = `
+SELECT event, user_id, details, message, started_at
+FROM sda.file_event_log 
+WHERE file_id = $1 
+`
+}
+
+func (db *pgDb) getFileStatusHistory(ctx context.Context, tx *sql.Tx, fileID string) ([]database.FileStatus, error) {
+	stmt, err := db.getPreparedStmt(tx, getFileStatusHistoryQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := stmt.QueryContext(ctx, fileID)
+	if err != nil {
+		return nil, err
+	}
+
+	var fileInfo []database.FileStatus
+	for rows.Next() {
+		var f database.FileStatus
+		if err := rows.Scan(&f.Event, &f.User, &f.Details, &f.Message, &f.CreatedAt); err != nil {
+			return nil, err
+		}
+		fileInfo = append(fileInfo, f)
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	return fileInfo, nil
+}

--- a/sda/internal/database/postgres/method_get_file_status_history.go
+++ b/sda/internal/database/postgres/method_get_file_status_history.go
@@ -7,7 +7,7 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
 )
 
-const getFileStatusHistoryQuery = "getFileStatus"
+const getFileStatusHistoryQuery = "getFileStatusHistory"
 
 func init() {
 	queries[getFileStatusHistoryQuery] = `

--- a/sda/internal/database/postgres/method_get_file_status_history.go
+++ b/sda/internal/database/postgres/method_get_file_status_history.go
@@ -27,6 +27,7 @@ func (db *pgDb) getFileStatusHistory(ctx context.Context, tx *sql.Tx, fileID str
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var fileInfo []database.FileStatus
 	for rows.Next() {

--- a/sda/internal/database/postgres/postgres.go
+++ b/sda/internal/database/postgres/postgres.go
@@ -187,6 +187,10 @@ func (db *pgDb) GetFileStatus(ctx context.Context, fileID string) (string, error
 	return db.getFileStatus(ctx, nil, fileID)
 }
 
+func (db *pgDb) GetFileStatusHistory(ctx context.Context, fileID string) ([]database.FileStatus, error) {
+	return db.getFileStatusHistory(ctx, nil, fileID)
+}
+
 func (db *pgDb) GetHeader(ctx context.Context, fileID string) ([]byte, error) {
 	return db.getHeader(ctx, nil, fileID)
 }
@@ -329,6 +333,10 @@ func (db *pgDb) GetDatasetFileIDs(ctx context.Context, datasetID string) ([]stri
 
 func (db *pgDb) GetFileDetails(ctx context.Context, fileID, event string) (*database.FileDetails, error) {
 	return db.getFileDetails(ctx, nil, fileID, event)
+}
+
+func (db *pgDb) GetFileEvents(ctx context.Context) ([]string, error) {
+	return db.getFileEvents(ctx, nil)
 }
 
 func (db *pgDb) GetSizeAndObjectCountOfLocation(ctx context.Context, location string) (uint64, uint64, error) {

--- a/sda/internal/database/postgres/tx.go
+++ b/sda/internal/database/postgres/tx.go
@@ -70,6 +70,10 @@ func (tx *pgTx) GetFileStatus(ctx context.Context, fileID string) (string, error
 	return tx.getFileStatus(ctx, tx.tx, fileID)
 }
 
+func (tx *pgTx) GetFileStatusHistory(ctx context.Context, fileID string) ([]database.FileStatus, error) {
+	return tx.getFileStatusHistory(ctx, tx.tx, fileID)
+}
+
 func (tx *pgTx) GetHeader(ctx context.Context, fileID string) ([]byte, error) {
 	return tx.getHeader(ctx, tx.tx, fileID)
 }

--- a/sda/internal/schema/schema.go
+++ b/sda/internal/schema/schema.go
@@ -153,6 +153,10 @@ type IngestionUserError struct {
 	Reason   string `json:"reason"`
 }
 
+type UpdateEvent struct {
+	Reason string `json:"reason"`
+}
+
 type IngestionVerification struct {
 	User               string      `json:"user"`
 	FilePath           string      `json:"filepath"`

--- a/sda/internal/schema/schema.go
+++ b/sda/internal/schema/schema.go
@@ -153,10 +153,6 @@ type IngestionUserError struct {
 	Reason   string `json:"reason"`
 }
 
-type UpdateEvent struct {
-	Reason string `json:"reason"`
-}
-
 type IngestionVerification struct {
 	User               string      `json:"user"`
 	FilePath           string      `json:"filepath"`

--- a/sda/internal/storage/v2/locationbroker/location_broker_test.go
+++ b/sda/internal/storage/v2/locationbroker/location_broker_test.go
@@ -66,6 +66,10 @@ func (m *mockDatabase) GetFileStatus(_ context.Context, _ string) (string, error
 	panic("function not expected to be called in unit tests")
 }
 
+func (m *mockDatabase) GetFileStatusHistory(ctx context.Context, fileID string) ([]database.FileStatus, error) {
+	panic("function not expected to be called in unit tests")
+}
+
 func (m *mockDatabase) GetHeader(_ context.Context, _ string) ([]byte, error) {
 	panic("function not expected to be called in unit tests")
 }
@@ -207,6 +211,10 @@ func (m *mockDatabase) GetDatasetFileIDs(_ context.Context, _ string) ([]string,
 }
 
 func (m *mockDatabase) GetFileDetails(_ context.Context, fileUUID, event string) (*database.FileDetails, error) {
+	panic("function not expected to be called in unit tests")
+}
+
+func (m *mockDatabase) GetFileEvents(_ context.Context) ([]string, error) {
 	panic("function not expected to be called in unit tests")
 }
 

--- a/sda/internal/storage/v2/posix/writer/writer_test.go
+++ b/sda/internal/storage/v2/posix/writer/writer_test.go
@@ -401,6 +401,10 @@ func (m *notImplementedDatabase) GetFileStatus(_ context.Context, _ string) (str
 	panic("function not expected to be called in unit tests")
 }
 
+func (m *notImplementedDatabase) GetFileStatusHistory(ctx context.Context, fileID string) ([]database.FileStatus, error) {
+	panic("function not expected to be called in unit tests")
+}
+
 func (m *notImplementedDatabase) GetHeader(_ context.Context, _ string) ([]byte, error) {
 	panic("function not expected to be called in unit tests")
 }
@@ -542,6 +546,10 @@ func (m *notImplementedDatabase) GetDatasetFileIDs(_ context.Context, _ string) 
 }
 
 func (m *notImplementedDatabase) GetFileDetails(_ context.Context, fileUUID, event string) (*database.FileDetails, error) {
+	panic("function not expected to be called in unit tests")
+}
+
+func (m *notImplementedDatabase) GetFileEvents(_ context.Context) ([]string, error) {
 	panic("function not expected to be called in unit tests")
 }
 

--- a/sda/internal/storage/v2/s3/writer/writer_test.go
+++ b/sda/internal/storage/v2/s3/writer/writer_test.go
@@ -416,6 +416,10 @@ func (m *notImplementedDatabase) GetFileStatus(_ context.Context, _ string) (str
 	panic("function not expected to be called in unit tests")
 }
 
+func (m *notImplementedDatabase) GetFileStatusHistory(ctx context.Context, fileID string) ([]database.FileStatus, error) {
+	panic("function not expected to be called in unit tests")
+}
+
 func (m *notImplementedDatabase) GetHeader(_ context.Context, _ string) ([]byte, error) {
 	panic("function not expected to be called in unit tests")
 }
@@ -557,6 +561,10 @@ func (m *notImplementedDatabase) GetDatasetFileIDs(_ context.Context, _ string) 
 }
 
 func (m *notImplementedDatabase) GetFileDetails(_ context.Context, fileUUID, event string) (*database.FileDetails, error) {
+	panic("function not expected to be called in unit tests")
+}
+
+func (m *notImplementedDatabase) GetFileEvents(_ context.Context) ([]string, error) {
 	panic("function not expected to be called in unit tests")
 }
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes issue #1151

## Description
Extends admin api with the endpoints `GET /file/events/:fileid` and `POST /file/events/:fileid/:event` which should address the following needs described in the issue:

- [x] List file events with sda-admin.
- [x] Create a new file-event log, with the admin-user as the triggering user (probably the token subject).
- [x] Add reason in the file event log as well so we know why this was done.
- [x] It should not be possible to delete events, just add new ones to take precedence.

## How to test

upload a file, call `GET /file/events/:fileid` to see the event associated with it. Call `POST /file/events/:fileid/:event` with a new event to change it.