### PR TITLE
fix(sda-svc): download-v2 populate api TLS config and update default probes to use HTTPS

### DIFF
--- a/charts/sda-svc/Chart.yaml
+++ b/charts/sda-svc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sda-svc
-version: 3.4.1
+version: 3.4.2
 appVersion: v3.1.37
 kubeVersion: '>= 1.26.0'
 description: Components for Sensitive Data Archive (SDA) installation

--- a/charts/sda-svc/templates/download-v2-secrets.yaml
+++ b/charts/sda-svc/templates/download-v2-secrets.yaml
@@ -51,7 +51,7 @@ stringData:
       pubkey-url: {{ .Values.global.downloadV2.jwt.pubkeyURL }}
       allow-all-data: {{ .Values.global.downloadV2.jwt.allowAllData }}
     oidc:
-      issuer: {{ .Values.global.oidc.provider | trimSuffix "/" }}
+      issuer: {{ .Values.global.oidc.provider }}
       audience: {{ .Values.global.oidc.id }}
     session:
       expiration: {{ .Values.global.downloadV2.session.expiration }}

--- a/charts/sda-svc/templates/download-v2-secrets.yaml
+++ b/charts/sda-svc/templates/download-v2-secrets.yaml
@@ -13,6 +13,10 @@ stringData:
     api:
       host: "0.0.0.0"
       port: 8080
+      {{- if .Values.global.tls.enabled }}
+      server-cert: {{ template "tlsPath" . }}/tls.crt
+      server-key: {{ template "tlsPath" . }}/tls.key
+      {{- end }}
     db:
       host: {{ .Values.global.db.host }}
       port: {{ .Values.global.db.port }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -648,7 +648,7 @@ downloadV2:
     httpGet:
       path: /health/live
       port: download-v2
-      scheme: HTTP
+      scheme: HTTPS
     initialDelaySeconds: 10
     periodSeconds: 30
     timeoutSeconds: 5
@@ -656,7 +656,7 @@ downloadV2:
     httpGet:
       path: /health/ready
       port: download-v2
-      scheme: HTTP
+      scheme: HTTPS
     periodSeconds: 10
     timeoutSeconds: 9
   resources:


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #2345 .


# Description
Download-v2 populate api.server-cert and api.server-key if tls is enabled
Set HTTPS scheme on the default liveness/readiness probes to align with other services default probes
Do not trim the trailing "/" when setting the oidc.issuer

