### PR TITLE
fix(download): include JWK/JWT alg in visa signature rejection log

### DIFF
--- a/sda/cmd/download/visa/validator.go
+++ b/sda/cmd/download/visa/validator.go
@@ -298,7 +298,21 @@ func (v *Validator) validateSingleVisa(ctx context.Context, identity Identity, v
 		jwt.WithValidate(true),
 	)
 	if err != nil {
-		return nil, zeroTime, fmt.Errorf("visa signature/claims validation failed: %w", err)
+		jwtAlg := sigs[0].ProtectedHeaders().Algorithm()
+		kid := sigs[0].ProtectedHeaders().KeyID()
+
+		var jwkAlgs []string
+		for i := 0; i < keySet.Len(); i++ {
+			if k, ok := keySet.Key(i); ok {
+				if a := k.Algorithm(); a != nil && a.String() != "" {
+					jwkAlgs = append(jwkAlgs, a.String())
+				}
+			}
+		}
+
+		return nil, zeroTime, fmt.Errorf(
+			"visa signature/claims validation failed (jwt_alg=%s, jwk_alg=%v, kid=%s, iss=%s, jku=%s): %w",
+			jwtAlg, jwkAlgs, kid, visaIssuer, jkuURL, err)
 	}
 
 	// 5. Identity binding check

--- a/sda/cmd/download/visa/validator_test.go
+++ b/sda/cmd/download/visa/validator_test.go
@@ -4,9 +4,13 @@ package visa
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,6 +97,72 @@ func TestGetVisaDatasets_SuffixExtraction(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, []string{"EGAD005"}, result.Datasets)
+}
+
+func TestGetVisaDatasets_AlgMismatchDiagnostics(t *testing.T) {
+	origLevel := log.GetLevel()
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() { log.SetLevel(origLevel) })
+
+	hook := logtest.NewGlobal()
+	t.Cleanup(func() { hook.Reset() })
+
+	priv, pub, kid := newRSAKeyPair(t)
+	require.NoError(t, pub.Set(jwk.AlgorithmKey, "RSA-OAEP-256"))
+
+	jwksServer := newJWKSServer(t, pub)
+	t.Cleanup(jwksServer.Close)
+
+	issuer := "https://visa-issuer.example"
+	jku := jwksServer.URL
+	visaClaim := baseVisaClaim("EGAD999")
+	visaJWT := signVisaJWT(t, priv, jku, kid, issuer, "user-123", visaClaim, time.Now().Add(1*time.Hour))
+
+	userinfoServer := newUserinfoServer(t, []string{visaJWT})
+	t.Cleanup(userinfoServer.Close)
+
+	cfg := ValidatorConfig{
+		Source:             "userinfo",
+		UserinfoURL:        userinfoServer.URL,
+		DatasetIDMode:      "raw",
+		ValidateAsserted:   true,
+		IdentityMode:       "broker-bound",
+		ClockSkew:          0,
+		MaxVisas:           200,
+		MaxJWKSPerReq:      10,
+		MaxVisaSize:        16 * 1024,
+		JWKCacheTTL:        5 * time.Minute,
+		ValidationCacheTTL: 2 * time.Minute,
+		UserinfoCacheTTL:   1 * time.Minute,
+	}
+
+	checker := &fakeDatasetChecker{existing: map[string]bool{"EGAD999": true}}
+	trustedIssuers := []TrustedIssuer{{ISS: issuer, JKU: jku}}
+
+	validator, err := NewValidator(cfg, trustedIssuers, checker)
+	require.NoError(t, err)
+
+	identity := Identity{Issuer: "https://broker.example", Subject: "user-123"}
+
+	result, err := validator.GetVisaDatasets(context.Background(), identity, "opaque-token", "userinfo")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Datasets, "visa with mismatched JWK alg should be rejected")
+
+	var rejectionLog string
+	for _, entry := range hook.Entries {
+		if strings.Contains(entry.Message, "rejected") {
+			rejectionLog = entry.Message
+
+			break
+		}
+	}
+	require.NotEmpty(t, rejectionLog, "expected a rejection log entry")
+	assert.Contains(t, rejectionLog, "jwt_alg=RS256")
+	assert.Contains(t, rejectionLog, "jwk_alg=[RSA-OAEP-256]")
+	assert.Contains(t, rejectionLog, "kid="+kid)
+	assert.Contains(t, rejectionLog, "iss="+issuer)
+	assert.Contains(t, rejectionLog, "jku="+jku)
 }
 
 func baseVisaClaim(value string) map[string]any {


### PR DESCRIPTION
## Related issue(s) and PR(s)
Closes #2437

## Description

When visa signature verification fails, the rejection log now includes `jwt_alg`, `jwk_alg`, `kid`, `iss`, and `jku`. Operators can spot a JWK algorithm mismatch (e.g. REMS publishing `RSA-OAEP-256` on a key actually used to sign with `RS256`) directly from the log line instead of reading source.

One-line-per-rejected-visa format is kept.

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

## How to test

`go test -tags visas ./cmd/download/visa/` — `TestGetVisaDatasets_AlgMismatchDiagnostics` sets a wrong `alg` on the JWK, signs a visa with RS256, and asserts the rejection log contains all five diagnostic fields.
