### PR TITLE
ci(sda): run visa-tagged unit tests in pr_code_tests

### DIFF
--- a/.github/workflows/pr_code_tests.yml
+++ b/.github/workflows/pr_code_tests.yml
@@ -7,6 +7,7 @@ on:
       - "sda-download/**"
       - "sda-validator/orchestrator/**"
       - "sda-admin/**"
+      - ".github/workflows/pr_code_tests.yml"
 
 env:
   go-version: '1.25'
@@ -86,17 +87,33 @@ jobs:
         run: |
           cd sda
           go get -v -t ./...
+          go get -v -t -tags=visas ./cmd/download/...
       - name: Test
         run: |
           cd sda
           go test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
+      - name: Test download v2 visa unit tests
+        run: |
+          cd sda
+          go test -v -tags=visas -coverprofile=coverage-visas.txt -covermode=atomic ./cmd/download/...
+
       - name: Codecov
         uses: codecov/codecov-action@v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./sda/coverage.txt
+          files: ./sda/coverage.txt
+          disable_search: true
           flags: unittests
+          fail_ci_if_error: false
+
+      - name: Codecov (download v2 visa)
+        uses: codecov/codecov-action@v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./sda/coverage-visas.txt
+          disable_search: true
+          flags: download-v2-visas
           fail_ci_if_error: false
 
   test_sda_admin:


### PR DESCRIPTION
## Related issue(s) and PR(s)

Closes #1190.

## Description

Visa tests under `sda/cmd/download/` sit behind `//go:build visas` and were never compiled by the workflow's `go test ./...`. This PR adds a second `go test -tags=visas ./cmd/download/...` step in the `test_sda` job plus a Codecov upload under flag `download-v2-visas`, so the visa unit suite (321 tests) runs on every PR. The `sync.Once` constraint that forced the build-tag split is left for a future refactor.

Folded in from a multi-model diff review:

- `.github/workflows/pr_code_tests.yml` added to `pull_request.paths` so workflow-only PRs (like this one) trigger CI.
- Both `test_sda` Codecov uploads switched from `file:` to `files:` with `disable_search: true`, so `coverage.txt` and `coverage-visas.txt` don't cross-pollute the `unittests` and `download-v2-visas` flags.
- `Get dependencies` pre-fetches visa-tagged deps so the test step doesn't fetch on demand.

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

## How to test

```bash
cd sda
go test -v -tags=visas -count=1 ./cmd/download/...
```

321 tests pass. After merge, the `Test sensitive-data-archive` job shows a new `Test download v2 visa unit tests` step.