### PR TITLE
fix/manual releases, no commit in jobs, rely on changelog having been updated

### DIFF
--- a/.github/workflows/release_sda.yml
+++ b/.github/workflows/release_sda.yml
@@ -94,7 +94,6 @@ jobs:
 
       - name: Create and push tag
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_VERSION: ${{ inputs.version }}
         run: |
           git tag "v${TARGET_VERSION}"

--- a/.github/workflows/release_sda.yml
+++ b/.github/workflows/release_sda.yml
@@ -37,36 +37,29 @@ jobs:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-
+          
           # Validate target version format
           if ! [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?$ ]]; then
             echo "$TARGET_VERSION: Version must match MAJOR.MINOR.PATCH[-suffix]"
             exit 1
           fi
 
-          # Extract previous version from changelog
-          PREVIOUS_VERSION=$(
+          CHANGELOG_VERSION=$(
             grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?\]' sda/CHANGELOG.md \
             | head -n1 \
             | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?)\].*/\1/'
           )
 
-          if [ -z "$PREVIOUS_VERSION" ]; then
-            echo "Could not determine previous version from the sda/CHANGELOG.md"
+          if [ -z "$CHANGELOG_VERSION" ]; then
+            echo "Could not determine current version from the sda/CHANGELOG.md"
             exit 1
           fi
 
-          echo "Previous version: $PREVIOUS_VERSION"
-          echo "Target version:   $TARGET_VERSION"
-
-          # Compare versions
-          LOWEST=$(printf '%s\n%s\n' "$PREVIOUS_VERSION" "$TARGET_VERSION" | sort -V | head -n1)
-
-          if [ "$LOWEST" != "$PREVIOUS_VERSION" ] || [ "$TARGET_VERSION" = "$PREVIOUS_VERSION" ]; then
-            echo "Target version must be greater than previous version"
+          if [ "$CHANGELOG_VERSION" != "${TARGET_VERSION}" ]; then
+            echo "Latest version in changelog is $CHANGELOG_VERSION, target version is ${TARGET_VERSION}"
             exit 1
           fi
-          
+
           UNRELEASED_CONTENT=$(
             awk '
             /^## \[Unreleased\]/ { in_section=1; next }
@@ -74,58 +67,46 @@ jobs:
             in_section { print }
             ' sda/CHANGELOG.md
           )
-      
+
           # Remove blank lines and whitespace
           UNRELEASED_CONTENT_CLEAN=$(echo "$UNRELEASED_CONTENT" | sed '/^[[:space:]]*$/d')
-      
-          if [ -z "$UNRELEASED_CONTENT_CLEAN" ]; then
-          echo "Unreleased section is empty"
-          exit 1
+
+          if [ -n "$UNRELEASED_CONTENT_CLEAN" ]; then
+            echo "Unreleased section is not empty"
+            exit 1
           fi
 
-      - name: Update CHANGELOG.md
+           CONTENT_TO_BE_RELEASED=$(
+            awk "
+            /^## \[${TARGET_VERSION}\]/ { in_section=1; next }
+            /^## \[/ && in_section { exit }
+            in_section { print }
+            " sda/CHANGELOG.md
+          )
+
+          # Remove blank lines and whitespace
+          CONTENT_TO_BE_RELEASED_CLEAN=$(echo "$CONTENT_TO_BE_RELEASED" | sed '/^[[:space:]]*$/d')
+
+          if [ -z "$CONTENT_TO_BE_RELEASED_CLEAN" ]; then
+            echo "Changelog entry for ${TARGET_VERSION} is empty"
+            exit 1
+          fi
+
+      - name: Create and push tag
         env:
-          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_VERSION: ${{ inputs.version }}
         run: |
-          TODAY=$(date +%Y-%m-%d)
-          sed -i "0,/## \\[Unreleased\\]/s//## [Unreleased]\n\n## [${VERSION}] - ${TODAY}/" sda/CHANGELOG.md
+          git tag "v${TARGET_VERSION}"
+          git push origin "v${TARGET_VERSION}"
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Commit changelog
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          git add sda/CHANGELOG.md
-
-          # Skip commit if nothing changed
-          git diff --cached --quiet && exit 0
-
-          git commit -m "chore(sda): SDA Release ${VERSION}"
-
-      - name: Create tag
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          git tag "v${VERSION}"
-
-      - name: Push commit and tag
-        env:
-          VERSION: ${{ inputs.version }}
-          BRANCH_NAME: ${{ github.ref_name }}
-        run: |
-          git push origin "HEAD:${BRANCH_NAME}"
-          git push origin "v${VERSION}"
 
       - name: Extract release notes
         env:
-          VERSION: ${{ inputs.version }}
+          TARGET_VERSION: ${{ inputs.version }}
         run: |
           awk "
-            /^## \\[${VERSION}\\]/ { in_section=1; next }
+            /^## \\[${TARGET_VERSION}\\]/ { in_section=1; next }
             /^## \\[/ && in_section { exit }
             in_section { print }
           " sda/CHANGELOG.md > RELEASE_NOTES.md

--- a/.github/workflows/release_sda.yml
+++ b/.github/workflows/release_sda.yml
@@ -96,6 +96,8 @@ jobs:
         env:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
+          
           git tag "v${TARGET_VERSION}"
           git push origin "v${TARGET_VERSION}"
 
@@ -104,6 +106,7 @@ jobs:
         env:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           awk "
             /^## \\[${TARGET_VERSION}\\]/ { in_section=1; next }
             /^## \\[/ && in_section { exit }

--- a/.github/workflows/release_sda_admin.yml
+++ b/.github/workflows/release_sda_admin.yml
@@ -37,36 +37,29 @@ jobs:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-
+          
           # Validate target version format
           if ! [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?$ ]]; then
             echo "$TARGET_VERSION: Version must match MAJOR.MINOR.PATCH[-suffix]"
             exit 1
           fi
-
-          # Extract previous version from changelog
-          PREVIOUS_VERSION=$(
+          
+          CHANGELOG_VERSION=$(
             grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?\]' sda-admin/CHANGELOG.md \
             | head -n1 \
             | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?)\].*/\1/'
           )
-
-          if [ -z "$PREVIOUS_VERSION" ]; then
-            echo "Could not determine previous version from the sda-admin/CHANGELOG.md"
+          
+          if [ -z "$CHANGELOG_VERSION" ]; then
+            echo "Could not determine current version from the sda-admin/CHANGELOG.md"
             exit 1
           fi
-
-          echo "Previous version: $PREVIOUS_VERSION"
-          echo "Target version:   $TARGET_VERSION"
-
-          # Compare versions
-          LOWEST=$(printf '%s\n%s\n' "$PREVIOUS_VERSION" "$TARGET_VERSION" | sort -V | head -n1)
-
-          if [ "$LOWEST" != "$PREVIOUS_VERSION" ] || [ "$TARGET_VERSION" = "$PREVIOUS_VERSION" ]; then
-            echo "Target version must be greater than previous version"
+          
+          if [ "$CHANGELOG_VERSION" != "${TARGET_VERSION}" ]; then
+            echo "Latest version in changelog is $CHANGELOG_VERSION, target version is ${TARGET_VERSION}"
             exit 1
           fi
-              
+          
           UNRELEASED_CONTENT=$(
             awk '
             /^## \[Unreleased\]/ { in_section=1; next }
@@ -74,58 +67,45 @@ jobs:
             in_section { print }
             ' sda-admin/CHANGELOG.md
           )
-      
+          
           # Remove blank lines and whitespace
           UNRELEASED_CONTENT_CLEAN=$(echo "$UNRELEASED_CONTENT" | sed '/^[[:space:]]*$/d')
-      
-          if [ -z "$UNRELEASED_CONTENT_CLEAN" ]; then
-          echo "Unreleased section is empty"
-          exit 1
+          
+          if [ -n "$UNRELEASED_CONTENT_CLEAN" ]; then
+            echo "Unreleased section is not empty"
+            exit 1
+          fi
+          
+          CONTENT_TO_BE_RELEASED=$(
+            awk "
+            /^## \[${TARGET_VERSION}\]/ { in_section=1; next }
+            /^## \[/ && in_section { exit }
+            in_section { print }
+            " sda-admin/CHANGELOG.md
+          )
+          
+          # Remove blank lines and whitespace
+          CONTENT_TO_BE_RELEASED_CLEAN=$(echo "$CONTENT_TO_BE_RELEASED" | sed '/^[[:space:]]*$/d')
+          
+          if [ -z "$CONTENT_TO_BE_RELEASED_CLEAN" ]; then
+            echo "Changelog entry for ${TARGET_VERSION} is empty"
+            exit 1
           fi
 
-      - name: Update CHANGELOG.md
+      - name: Create and push tag
         env:
-          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_VERSION: ${{ inputs.version }}
         run: |
-          TODAY=$(date +%Y-%m-%d)
-          sed -i "0,/## \\[Unreleased\\]/s//## [Unreleased]\n\n## [${VERSION}] - ${TODAY}/" sda-admin/CHANGELOG.md
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Commit changelog
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          git add sda-admin/CHANGELOG.md
-
-          # Skip commit if nothing changed
-          git diff --cached --quiet && exit 0
-
-          git commit -m "chore(sda-admin): SDA Admin Release ${VERSION}"
-
-      - name: Create tag
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          git tag "sda-admin-${VERSION}"
-
-      - name: Push commit and tag
-        env:
-          VERSION: ${{ inputs.version }}
-          BRANCH_NAME: ${{ github.ref_name }}
-        run: |
-          git push origin "HEAD:${BRANCH_NAME}"
-          git push origin "sda-admin-${VERSION}"
+          git tag "sda-admin-${TARGET_VERSION}"
+          git push origin "sda-admin-${TARGET_VERSION}"
 
       - name: Extract release notes
         env:
-          VERSION: ${{ inputs.version }}
+          TARGET_VERSION: ${{ inputs.version }}
         run: |
           awk "
-            /^## \\[${VERSION}\\]/ { in_section=1; next }
+            /^## \\[${TARGET_VERSION}\\]/ { in_section=1; next }
             /^## \\[/ && in_section { exit }
             in_section { print }
           " sda-admin/CHANGELOG.md > RELEASE_NOTES.md
@@ -133,27 +113,27 @@ jobs:
       - name: Draft release
         uses: softprops/action-gh-release@v3
         with:
+          name: sda-admin-${{ inputs.version }}
           tag_name: "sda-admin-${{ inputs.version }}"
           make_latest: false
           generate_release_notes: false
-          name: sda-admin-${{ inputs.version }}
           body_path: RELEASE_NOTES.md
           draft: true
 
   package:
-    needs: [prepare_release]
+    needs: [ prepare_release ]
     permissions:
       contents: write
       packages: write
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-          # List of GOOS and GOARCH pairs from `go tool dist list`
-          goosarch:
-            - "linux/amd64"
-            - "windows/amd64"
-            - "darwin/amd64"
-            - "darwin/arm64"
+      matrix:
+        # List of GOOS and GOARCH pairs from `go tool dist list`
+        goosarch:
+          - "linux/amd64"
+          - "windows/amd64"
+          - "darwin/amd64"
+          - "darwin/arm64"
     steps:
       - name: Checkout release tag
         uses: actions/checkout@v6
@@ -164,7 +144,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version:  '>=1.22'
+          go-version: '>=1.22'
         id: go
 
       - name: Get dependencies
@@ -180,13 +160,13 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-            GOOSARCH=${{ matrix.goosarch }}
-            GOOS=${GOOSARCH%/*}
-            GOARCH=${GOOSARCH#*/}
-            BINARY_NAME=sda-admin_${VERSION}_${GOOS}_${GOARCH}
-            echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
-            echo "GOOS=$GOOS" >> $GITHUB_ENV
-            echo "GOARCH=$GOARCH" >> $GITHUB_ENV
+          GOOSARCH=${{ matrix.goosarch }}
+          GOOS=${GOOSARCH%/*}
+          GOARCH=${GOOSARCH#*/}
+          BINARY_NAME=sda-admin_${VERSION}_${GOOS}_${GOARCH}
+          echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
+          echo "GOOS=$GOOS" >> $GITHUB_ENV
+          echo "GOARCH=$GOARCH" >> $GITHUB_ENV
 
       - name: Build
         if: ${{ matrix.goosarch != 'windows/amd64' }}
@@ -194,7 +174,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           cd sda-admin
-          go build -o "$BINARY_NAME" -v -ldflags="-s -w -X 'main.version=$VERSION'"
+          go build -o "$BINARY_NAME" -v -ldflags="-s -w -X 'main.version=${VERSION}'"
           tar -czf "$BINARY_NAME.tgz" "$BINARY_NAME" ../LICENSE
           echo "ARTIFACT"="$BINARY_NAME.tgz" >> $GITHUB_ENV
 
@@ -204,7 +184,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           cd sda-admin
-          go build -o "$BINARY_NAME" -v -ldflags="-s -w -X 'main.version=$VERSION'"
+          go build -o "$BINARY_NAME" -v -ldflags="-s -w -X 'main.version=${VERSION}'"
           zip "$BINARY_NAME.zip" "$BINARY_NAME" ../LICENSE
           echo "ARTIFACT"="$BINARY_NAME.zip" >> $GITHUB_ENV
 

--- a/.github/workflows/release_sda_admin.yml
+++ b/.github/workflows/release_sda_admin.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           git tag "sda-admin-${TARGET_VERSION}"
           git push origin "sda-admin-${TARGET_VERSION}"
 
@@ -103,6 +104,7 @@ jobs:
         env:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           awk "
             /^## \\[${TARGET_VERSION}\\]/ { in_section=1; next }
             /^## \\[/ && in_section { exit }

--- a/.github/workflows/release_sda_admin.yml
+++ b/.github/workflows/release_sda_admin.yml
@@ -94,7 +94,6 @@ jobs:
 
       - name: Create and push tag
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_VERSION: ${{ inputs.version }}
         run: |
           git tag "sda-admin-${TARGET_VERSION}"

--- a/.github/workflows/release_sda_svc_chart.yml
+++ b/.github/workflows/release_sda_svc_chart.yml
@@ -128,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          
+          set -euo pipefail
           VERSION=$(yq '.version' charts/sda-svc/Chart.yaml)
           
           awk "

--- a/.github/workflows/release_sda_svc_chart.yml
+++ b/.github/workflows/release_sda_svc_chart.yml
@@ -9,10 +9,8 @@ on:
         type: string
 
 jobs:
-  prepare_release:
+  validate_release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -24,12 +22,12 @@ jobs:
           BRANCH="${GITHUB_REF#refs/heads/}"
 
           echo "Branch: $BRANCH"
-      
+
           if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^hotfix/ ]]; then
-          echo "Workflow may only run on:"
-          echo "  - main"
-          echo "  - hotfix/*"
-          exit 1
+            echo "Workflow may only run on:"
+            echo "  - main"
+            echo "  - hotfix/*"
+            exit 1
           fi
 
       - name: Validate target version
@@ -37,36 +35,37 @@ jobs:
           TARGET_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-
+          
           # Validate target version format
-          if ! [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?$ ]]; then
-            echo "$TARGET_VERSION: Version must match MAJOR.MINOR.PATCH[-suffix]"
+           if ! [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?$ ]]; then
+             echo "$TARGET_VERSION: Version must match MAJOR.MINOR.PATCH[-suffix]"
+             exit 1
+           fi
+
+          CHART_VERSION=$(yq '.version' charts/sda-svc/Chart.yaml)
+          
+          if [ "$CHART_VERSION" != "${TARGET_VERSION}" ]; then
+            echo "Target version and Version specified in charts/sda-svc/Chart.yaml differs, chart version: is $CHART_VERSION, target version: ${TARGET_VERSION}"
             exit 1
           fi
+          
 
-          # Extract previous version from changelog
-          PREVIOUS_VERSION=$(
+          CHANGELOG_VERSION=$(
             grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?\]' charts/sda-svc/CHANGELOG.md \
             | head -n1 \
             | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9]+([.-][A-Za-z0-9]+)*)?)\].*/\1/'
           )
 
-          if [ -z "$PREVIOUS_VERSION" ]; then
-            echo "Could not determine previous version from the charts/sda-svc/CHANGELOG.md"
+          if [ -z "$CHANGELOG_VERSION" ]; then
+            echo "Could not determine current version from the charts/sda-svc/CHANGELOG.md"
             exit 1
           fi
 
-          echo "Previous version: $PREVIOUS_VERSION"
-          echo "Target version:   $TARGET_VERSION"
-
-          # Compare versions
-          LOWEST=$(printf '%s\n%s\n' "$PREVIOUS_VERSION" "$TARGET_VERSION" | sort -V | head -n1)
-
-          if [ "$LOWEST" != "$PREVIOUS_VERSION" ] || [ "$TARGET_VERSION" = "$PREVIOUS_VERSION" ]; then
-            echo "Target version must be greater than previous version"
+          if [ "$CHANGELOG_VERSION" != "${TARGET_VERSION}" ]; then
+            echo "Latest version in changelog is $CHANGELOG_VERSION, target version is ${TARGET_VERSION}"
             exit 1
           fi
-          
+
           UNRELEASED_CONTENT=$(
             awk '
             /^## \[Unreleased\]/ { in_section=1; next }
@@ -74,62 +73,40 @@ jobs:
             in_section { print }
             ' charts/sda-svc/CHANGELOG.md
           )
-      
+
           # Remove blank lines and whitespace
           UNRELEASED_CONTENT_CLEAN=$(echo "$UNRELEASED_CONTENT" | sed '/^[[:space:]]*$/d')
-      
-          if [ -z "$UNRELEASED_CONTENT_CLEAN" ]; then
-          echo "Unreleased section is empty"
-          exit 1
+
+          if [ -n "$UNRELEASED_CONTENT_CLEAN" ]; then
+            echo "Unreleased section is not empty"
+            exit 1
           fi
 
-      - name: Update CHANGELOG.md
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          TODAY=$(date +%Y-%m-%d)
-          sed -i "0,/## \\[Unreleased\\]/s//## [Unreleased]\n\n## [${VERSION}] - ${TODAY}/" charts/sda-svc/CHANGELOG.md
+           CONTENT_TO_BE_RELEASED=$(
+            awk "
+            /^## \[${TARGET_VERSION}\]/ { in_section=1; next }
+            /^## \[/ && in_section { exit }
+            in_section { print }
+            " charts/sda-svc/CHANGELOG.md
+          )
 
-      - name: Update Chart.yaml
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          yq -i '.version = "'${VERSION}'"' charts/sda-svc/Chart.yaml
+          # Remove blank lines and whitespace
+          CONTENT_TO_BE_RELEASED_CLEAN=$(echo "$CONTENT_TO_BE_RELEASED" | sed '/^[[:space:]]*$/d')
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Commit changelog
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          git add charts/sda-svc/CHANGELOG.md
-          git add charts/sda-svc/Chart.yaml
-          
-          # Skip commit if nothing changed
-          git diff --cached --quiet && exit 0
-
-          git commit -m "chore(sda-svc): sda-svc Helm Chart Release ${VERSION}"
-
-      - name: Push commit
-        env:
-          VERSION: ${{ inputs.version }}
-          BRANCH_NAME: ${{ github.ref_name }}
-        run: |
-          git push origin "HEAD:${BRANCH_NAME}"
+          if [ -z "$CONTENT_TO_BE_RELEASED_CLEAN" ]; then
+            echo "Changelog entry for ${TARGET_VERSION} is empty"
+            exit 1
+          fi
 
   package:
-    needs: [prepare_release]
+    needs: [validate_release]
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout latest (including changelog.md update from
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - name: Configure Git
@@ -141,22 +118,25 @@ jobs:
         uses: azure/setup-helm@v5
 
       - name: Run chart-releaser
+        id: chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Extract release notes
+      - name: Update release notes
+        if: ${{ steps.chart-releaser.outputs.changed_charts }}
         env:
-          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          
+          VERSION=$(yq '.version' charts/sda-svc/Chart.yaml)
+          
           awk "
             /^## \\[${VERSION}\\]/ { in_section=1; next }
             /^## \\[/ && in_section { exit }
             in_section { print }
           " charts/sda-svc/CHANGELOG.md > RELEASE_NOTES.md
 
-      - name: Update release notes
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release edit "sda-svc-${{ inputs.version }}" --notes-file RELEASE_NOTES.md
+          gh release edit "sda-svc-${VERSION}" --notes-file RELEASE_NOTES.md
+
+          


### PR DESCRIPTION
# Related issue(s) and PR(s)
This PR relates to #2439 and #2433 .


# Description
There is issues with first iteration of the workflows introduced by #2439 , as the github actions can not push commits to main, so we need to rework the actions to rely on the changelog having been updated already.

This PR updates actions to not update changelog as part of release pipeline, as we can not push that commit in main, instead rely on changelog having been updated, validate changelog instead

## How to test
Test pipeline once workflow is in main.