### PR TITLE
docs(rfc): RFC-0003 Rename the `api` app

### DIFF
--- a/docs/rfcs/0003-rename-api-app.md
+++ b/docs/rfcs/0003-rename-api-app.md
@@ -1,0 +1,27 @@
+---
+status: exploring
+date: "2026-05-28"
+authors:
+   - "@jbygdell"
+consulted: []
+informed: []
+---
+
+# Rename the API app
+
+## Context and Problem Statement
+
+Currently the management API is located under `sda/cmd/api` and when built the container command becomes `sda-api`. Since it can perform administrative tasks it is easy to refer to it as `sda-admin`, somthing that conflicts with the CLI tool with the same name.
+
+## Decision Drivers
+
+* **Consistency** - applications should have a name that is related to the tasks they perform
+
+## Considered Options
+
+* **`admin-api`** - Not a good choice since through RBAC restrictions submitters can also use the app.
+* **`manager` or `management`** - Possible new name that is better describes the application.
+
+## Open Questions
+
+* Decide on renaming the API app


### PR DESCRIPTION
## Description

The API used to perform administrative tasks is simply called `api`. That's not a very apt name considering that all other apps are named by the tasks they perform.
Changing the name to `admin` is not a good way to go since it then will clash with the CLI tool `sda-admin`.

The api app should be renamed with some key considerations taken into account. 
* Name should be descriptive 
* Name should not easily be confused with another app or tool.