### PR TITLE
feat(sda): config-driven projectCode inbox-path reconstruction

### DIFF
--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -544,7 +544,7 @@ func deleteFile(c *gin.Context) {
 		return
 	}
 
-	filePath = helper.UnanonymizeFilepath(filePath, submissionUser)
+	filePath = helper.ResolveInboxPath(filePath, submissionUser, Conf.Inbox)
 	for count := 1; count <= 5; count++ {
 		err = inboxWriter.RemoveFile(c, location, filePath)
 		if err == nil {
@@ -639,9 +639,10 @@ func downloadFile(c *gin.Context) {
 
 	// Get inbox file handle #noqa
 	file, err := inboxReader.NewFileReader(c, location,
-		helper.UnanonymizeFilepath(
+		helper.ResolveInboxPath(
 			filePath,
 			strings.TrimPrefix(c.Param("username"), "/"),
+			Conf.Inbox,
 		),
 	)
 	if err != nil {

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -43,6 +43,7 @@ type Ingest struct {
 	ArchiveKeyList []*[32]byte
 	db             database.Database
 	InboxReader    storage.Reader
+	InboxConfig    helper.InboxConfig
 	Broker         brokerv2.Broker
 }
 
@@ -69,6 +70,7 @@ func run() error {
 	if err = configv2.Load(); err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
+	app.InboxConfig = config.LoadInboxConfig()
 
 	app.Broker, err = rabbitmq.NewRabbitMQBroker(context.Background())
 	if err != nil {
@@ -297,7 +299,8 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		// Catch all for implementations inbox uploading that does not register the file in the DB, e.g. for those not using S3inbox or sftpInbox
 		// Since we dont have the submission location in storage, we need to look through all configured storage locations.
 		var findFileErr, registerErr error
-		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, message.Key)
+		// Resolve the anonymized submission path to its physical inbox path before locating it.
+		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(message.Key, user, app.InboxConfig))
 
 		// Ideally this transaction should span the whole message processing, but for now just spans the RegisterFile
 		tx, err := app.db.BeginTransaction(ctx)
@@ -336,7 +339,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		return nil, fmt.Errorf("cannot ingest file with status: %s", status)
 	}
 
-	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.UnanonymizeFilepath(filePath, user))
+	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.InboxConfig))
 	if err != nil {
 		log.Errorf("failed to read file, due to: %v", err)
 

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -27,6 +27,7 @@ import (
 var db database.Database
 var inboxWriter storage.Writer
 var mqBroker *broker.AMQPBroker
+var inboxConfig helper.InboxConfig
 
 func main() {
 	if err := run(); err != nil {
@@ -46,6 +47,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to load config, due to: %v", err)
 	}
+	inboxConfig = conf.Inbox
 
 	db, err = postgres.NewPostgresSQLDatabase()
 	if err != nil {
@@ -264,9 +266,9 @@ func handleMessage(ctx context.Context, delivered amqp.Delivery) {
 	}
 
 	for _, fileMappingData := range filesToCleanFromInbox {
-		unanonymizedSubmissionFilePath := helper.UnanonymizeFilepath(fileMappingData.SubmissionFilePath, fileMappingData.User)
-		if err := inboxWriter.RemoveFile(ctx, fileMappingData.SubmissionLocation, unanonymizedSubmissionFilePath); err != nil {
-			log.Errorf("removal of file id: %s at location: %s, path: %s failed, reason: %v", fileMappingData.FileID, fileMappingData.SubmissionLocation, unanonymizedSubmissionFilePath, err)
+		resolvedSubmissionPath := helper.ResolveInboxPath(fileMappingData.SubmissionFilePath, fileMappingData.User, inboxConfig)
+		if err := inboxWriter.RemoveFile(ctx, fileMappingData.SubmissionLocation, resolvedSubmissionPath); err != nil {
+			log.Errorf("removal of file id: %s at location: %s, path: %s failed, reason: %v", fileMappingData.FileID, fileMappingData.SubmissionLocation, resolvedSubmissionPath, err)
 		}
 	}
 

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
+	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -40,6 +41,7 @@ type Config struct {
 	ReEncrypt    ReEncConfig
 	Auth         AuthConf
 	RotateKey    RotateKeyConf
+	Inbox        helper.InboxConfig
 }
 
 type Grpc struct {
@@ -376,6 +378,7 @@ func NewConfig(app string) (*Config, error) {
 			return nil, err
 		}
 		c.configSchemas()
+		c.configInbox()
 
 		c.API.Grpc, err = configReEncryptClient()
 		if err != nil {
@@ -451,6 +454,7 @@ func NewConfig(app string) (*Config, error) {
 		}
 
 		c.configSchemas()
+		c.configInbox()
 	case "notify":
 		c.configSMTP()
 
@@ -766,6 +770,24 @@ func (c *Config) configReEncryptServer() (err error) {
 	}
 
 	return nil
+}
+
+// LoadInboxConfig reads the per-user inbox directory layout from the shared viper instance. An
+// empty (absent) project code yields stock SDA behavior, so deployments that omit the section are
+// unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
+// (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
+// the same viper instance.
+func LoadInboxConfig() helper.InboxConfig {
+	return helper.InboxConfig{
+		ProjectCode:          viper.GetString("storage.inbox.projectCode"),
+		ProjectCodeDelimiter: viper.GetString("storage.inbox.projectCodeDelimiter"),
+	}
+}
+
+// configInbox populates the inbox layout config for services that resolve anonymized submission
+// paths back to their physical inbox path (mapper, api).
+func (c *Config) configInbox() {
+	c.Inbox = LoadInboxConfig()
 }
 
 // configSchemas configures the schemas to load depending on

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -611,4 +612,28 @@ func (ts *ConfigTestSuite) TestConfigAuth_OIDC() {
 	viper.Set("oidc.redirectUrl", "http://auth/oidc/login")
 	_, err = NewConfig("auth")
 	assert.NoError(ts.T(), err, "unexpected failure")
+}
+
+func (ts *ConfigTestSuite) TestLoadInboxConfig_readsNestedStorageInboxKeys() {
+	// Each service loads its config.yaml into the shared global viper (mapper/api via NewConfig,
+	// ingest via config/v2). LoadInboxConfig then reads it. Prove the nested storage.inbox.* block
+	// flattens to the dotted keys it reads — the seam the projectCode resolver depends on.
+	viper.Reset()
+	viper.SetConfigType("yaml")
+	cfg := "storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n"
+	assert.NoError(ts.T(), viper.ReadConfig(bytes.NewBufferString(cfg)))
+
+	got := LoadInboxConfig()
+	assert.Equal(ts.T(), "p11", got.ProjectCode)
+	assert.Equal(ts.T(), "-", got.ProjectCodeDelimiter)
+}
+
+func (ts *ConfigTestSuite) TestLoadInboxConfig_absentSectionIsStock() {
+	// With no storage.inbox section LoadInboxConfig yields the zero value, which ResolveInboxPath
+	// treats as stock SDA behavior — so deployments that omit it (e.g. the Swedish node) are
+	// unaffected.
+	viper.Reset()
+	got := LoadInboxConfig()
+	assert.Equal(ts.T(), "", got.ProjectCode)
+	assert.Equal(ts.T(), "", got.ProjectCodeDelimiter)
 }

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -464,3 +464,39 @@ func UnanonymizeFilepath(fp string, username string) string {
 
 	return filepath.Join(strings.Replace(username, "@", "_", 1), fp)
 }
+
+// InboxConfig describes how a deployment names its per-user inbox directories, so an
+// anonymized submission path (the user prefix stripped) can be resolved back to the physical
+// inbox-relative path. An empty ProjectCode selects stock SDA behavior.
+type InboxConfig struct {
+	// ProjectCode optionally prefixes the per-user inbox directory (e.g. "p11"). Empty keeps the
+	// stock layout where the directory is the normalized username (see UnanonymizeFilepath).
+	ProjectCode string
+	// ProjectCodeDelimiter separates ProjectCode from the username (e.g. "-"). Unused when
+	// ProjectCode is empty.
+	ProjectCodeDelimiter string
+}
+
+// ResolveInboxPath reconstructs the physical inbox-relative path for an anonymized submission
+// filePath. An already-resolved path (e.g. on reprocessing) is returned unchanged.
+//
+// With no ProjectCode it is the stock round-trip, deferring to UnanonymizeFilepath (normalize the
+// username — first "@"->"_" — and prepend "<user>/"), so existing deployments are unaffected.
+//
+// With a ProjectCode it rebuilds "<ProjectCode><delimiter><username>/<filePath>" using the RAW
+// username. Whether to normalize is derived from the project code rather than configured
+// separately: a project code denotes a TSD-style inbox namespaced by project (e.g. FEGA-Norway's
+// "p11-dummy@elixir-europe.org/files/..."), which stores the username verbatim. No current
+// deployment needs a project code together with normalization; add an explicit toggle if one does.
+func ResolveInboxPath(filePath, username string, cfg InboxConfig) string {
+	if cfg.ProjectCode == "" {
+		return UnanonymizeFilepath(filePath, username)
+	}
+
+	userDir := cfg.ProjectCode + cfg.ProjectCodeDelimiter + username
+	if strings.HasPrefix(filePath, userDir) {
+		return filePath
+	}
+
+	return filepath.Join(userDir, filePath)
+}

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -179,3 +179,31 @@ func (ts *HelperTest) TestUnanonymizeFilepath_oldMessage() {
 	newPath := UnanonymizeFilepath(filePath, userName)
 	assert.Equal(ts.T(), filePath, newPath)
 }
+
+func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser() {
+	// With no project code ResolveInboxPath defers to the stock UnanonymizeFilepath: the first
+	// "@" becomes "_" and the username directory is prepended unless the path already starts with
+	// it. These assertions keep existing deployments pinned.
+	stockDefault := InboxConfig{}
+	user := "test.user@demo.org"
+	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
+		ResolveInboxPath("files/x.raw.enc", user, stockDefault))
+	// Already-prefixed path is returned unchanged.
+	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
+		ResolveInboxPath("test.user_demo.org/files/x.raw.enc", user, stockDefault))
+}
+
+func (ts *HelperTest) TestResolveInboxPath_projectCode_reconstructsRawUserDir() {
+	// FEGA-Norway: anonymized "/files/x" is rebuilt under the project-code-prefixed RAW username
+	// (the "@" is not normalized to "_" when a project code is configured).
+	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	got := ResolveInboxPath("/files/x.raw.enc", "dummy@elixir-europe.org", cfg)
+	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc", got)
+}
+
+func (ts *HelperTest) TestResolveInboxPath_projectCode_alreadyPrefixed_unchanged() {
+	// An already-resolved path (e.g. on reprocessing) is returned as-is, not double-prefixed.
+	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	fp := "p11-dummy@elixir-europe.org/files/x.raw.enc"
+	assert.Equal(ts.T(), fp, ResolveInboxPath(fp, "dummy@elixir-europe.org", cfg))
+}


### PR DESCRIPTION
## Problem (relates to #2429)

In the FEGA-Norway deployment, inbox files land under a project-code-prefixed per-user directory — `p11-dummy@elixir-europe.org/files/x.raw.enc` (TSD upload, **not** s3inbox). Stock SDA's read-side `UnanonymizeFilepath` assumes the per-user directory is exactly the username, so it mis-resolves the path and ingest/mapper can't find or clean the file.

## Approach — config-driven reconstruction (additive, default == stock)

The FEGA-Norway proxy anonymizes the path it publishes to `/files/<file>` (project code + username stripped — see ELIXIR-NO/FEGA-Norway#819), so the message stays a clean, node-agnostic path. SDA reconstructs the physical inbox path from config:

- `storage.inbox.projectCode` — optional per-user-directory prefix (e.g. `p11`); empty (the default) ⇒ stock layout.
- `storage.inbox.projectCodeDelimiter` — separator between the project code and the username (e.g. `-`).

`ResolveInboxPath(filePath, user, InboxConfig)` reconstructs the per-user directory and joins the path under it:

- **No project code** → defers to the stock `UnanonymizeFilepath` (normalize the username, prepend `<user>/`), so existing deployments are byte-for-byte unaffected.
- **A project code** → rebuilds `<projectCode><delimiter><username>/<path>` using the raw username. Whether to normalize is **derived from the project code** rather than a separate toggle: a project code denotes a TSD-style inbox that stores the raw username verbatim. (No current deployment needs a project code *with* normalization; an explicit toggle can be added if one ever does.)

`helper.go` is **purely additive** — only `InboxConfig` + `ResolveInboxPath` are added; `AnonymizeFilepath`/`UnanonymizeFilepath` are left untouched. Config flows through a single `config.LoadInboxConfig` read (mapper/api via `NewConfig`; ingest directly, since on `main` it loads through `config/v2` but shares the same viper instance). Wired into every inbox-path site: ingest (find + read), mapper (delete), api (delete + read). FEGA-Norway sets `projectCode=p11`, `projectCodeDelimiter="-"`.

## Verification

`go build`/`vet`/`test` green, including unit tests for `ResolveInboxPath` and a `LoadInboxConfig` seam test (nested `storage.inbox.*` YAML → the dotted keys it reads). End-to-end in the FEGA-Norway stack: the full pipeline ran green (9/9) on the `v3.1.61` images we deploy — exercising ingest's reconstruction and the mapper's inbox cleanup — and ingest's reconstruction is re-confirmed on the `v3.1.72` images. Design rationale + the stock-behavior trace: ELIXIR-NO/FEGA-Norway#820.
