### PR TITLE
feat(sda): config-driven projectCode inbox paths + non-s3inbox ingest catch-all fix

### DIFF
--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configurable project-code inbox paths: `storage.inbox.projectCode` and
+  `storage.inbox.projectCodeDelimiter` reconstruct the physical per-user inbox directory
+  (`<projectCode><delimiter><username>/...`) from an anonymized submission path. Defaults are
+  empty, so the stock inbox layout is unchanged.
+
+### Fixed
+
+- Ingest: a file first registered by the ingest service (the non-s3inbox `status ""` path) was
+  written to the database but never archived. Restored reading the submission file path (not the
+  broker correlation id) and the fall-through to archive after registration.
+
 ## [3.1.72] - 2026-05-29
 
 ### Fixed

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -544,7 +544,7 @@ func deleteFile(c *gin.Context) {
 		return
 	}
 
-	filePath = helper.UnanonymizeFilepath(filePath, submissionUser)
+	filePath = helper.ResolveInboxPath(filePath, submissionUser, Conf.Inbox)
 	for count := 1; count <= 5; count++ {
 		err = inboxWriter.RemoveFile(c, location, filePath)
 		if err == nil {
@@ -639,9 +639,10 @@ func downloadFile(c *gin.Context) {
 
 	// Get inbox file handle #noqa
 	file, err := inboxReader.NewFileReader(c, location,
-		helper.UnanonymizeFilepath(
+		helper.ResolveInboxPath(
 			filePath,
 			strings.TrimPrefix(c.Param("username"), "/"),
+			Conf.Inbox,
 		),
 	)
 	if err != nil {

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -70,7 +70,10 @@ func run() error {
 	if err = configv2.Load(); err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
-	app.InboxProjectConfig = config.LoadInboxProjectConfig()
+	app.InboxProjectConfig, err = config.LoadInboxProjectConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load inbox project config: %v", err)
+	}
 
 	app.Broker, err = rabbitmq.NewRabbitMQBroker(context.Background())
 	if err != nil {

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -43,6 +43,7 @@ type Ingest struct {
 	ArchiveKeyList []*[32]byte
 	db             database.Database
 	InboxReader    storage.Reader
+	InboxConfig    helper.InboxConfig
 	Broker         brokerv2.Broker
 }
 
@@ -69,6 +70,7 @@ func run() error {
 	if err = configv2.Load(); err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
+	app.InboxConfig = config.LoadInboxConfig()
 
 	app.Broker, err = rabbitmq.NewRabbitMQBroker(context.Background())
 	if err != nil {
@@ -297,7 +299,8 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		// Catch all for implementations inbox uploading that does not register the file in the DB, e.g. for those not using S3inbox or sftpInbox
 		// Since we dont have the submission location in storage, we need to look through all configured storage locations.
 		var findFileErr, registerErr error
-		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, message.Key)
+		// Resolve the anonymized submission path to its physical inbox path before locating it.
+		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(message.Key, user, app.InboxConfig))
 
 		// Ideally this transaction should span the whole message processing, but for now just spans the RegisterFile
 		tx, err := app.db.BeginTransaction(ctx)
@@ -336,7 +339,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		return nil, fmt.Errorf("cannot ingest file with status: %s", status)
 	}
 
-	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.UnanonymizeFilepath(filePath, user))
+	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.InboxConfig))
 	if err != nil {
 		log.Errorf("failed to read file, due to: %v", err)
 

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -37,14 +37,14 @@ import (
 )
 
 type Ingest struct {
-	ArchiveWriter  storage.Writer
-	BackupWriter   storage.Writer
-	ArchiveReader  storage.Reader
-	ArchiveKeyList []*[32]byte
-	db             database.Database
-	InboxReader    storage.Reader
-	InboxConfig    helper.InboxConfig
-	Broker         brokerv2.Broker
+	ArchiveWriter      storage.Writer
+	BackupWriter       storage.Writer
+	ArchiveReader      storage.Reader
+	ArchiveKeyList     []*[32]byte
+	db                 database.Database
+	InboxReader        storage.Reader
+	InboxProjectConfig helper.InboxProjectConfig
+	Broker             brokerv2.Broker
 }
 
 type decryptResult struct {
@@ -70,7 +70,7 @@ func run() error {
 	if err = configv2.Load(); err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
-	app.InboxConfig = config.LoadInboxConfig()
+	app.InboxProjectConfig = config.LoadInboxProjectConfig()
 
 	app.Broker, err = rabbitmq.NewRabbitMQBroker(context.Background())
 	if err != nil {
@@ -301,7 +301,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		var findFileErr, registerErr error
 		// message.Key is the broker correlation-id, not the submission path; use the trigger's
 		// filePath and resolve it to the physical inbox path before locating it.
-		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.InboxConfig))
+		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
 
 		// Ideally this transaction should span the whole message processing, but for now just spans the RegisterFile
 		tx, err := app.db.BeginTransaction(ctx)
@@ -343,7 +343,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		return nil, fmt.Errorf("cannot ingest file with status: %s", status)
 	}
 
-	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.InboxConfig))
+	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
 	if err != nil {
 		log.Errorf("failed to read file, due to: %v", err)
 

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -341,7 +341,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		// upload stuck at "registered", so verify never runs.
 
 	default:
-		log.Warnf("file: %s recieved ingestion trigger with status: %s", fileID, status)
+		log.Warnf("file: %s received ingestion trigger with status: %s", fileID, status)
 
 		return nil, fmt.Errorf("cannot ingest file with status: %s", status)
 	}

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -299,8 +299,9 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		// Catch all for implementations inbox uploading that does not register the file in the DB, e.g. for those not using S3inbox or sftpInbox
 		// Since we dont have the submission location in storage, we need to look through all configured storage locations.
 		var findFileErr, registerErr error
-		// Resolve the anonymized submission path to its physical inbox path before locating it.
-		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(message.Key, user, app.InboxConfig))
+		// message.Key is the broker correlation-id, not the submission path; use the trigger's
+		// filePath and resolve it to the physical inbox path before locating it.
+		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.InboxConfig))
 
 		// Ideally this transaction should span the whole message processing, but for now just spans the RegisterFile
 		tx, err := app.db.BeginTransaction(ctx)
@@ -311,7 +312,8 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		}
 
 		// Register file even if FindFile didnt succeed with submissionLocation == "", as we will add an error file event log to it in that case
-		fileID, registerErr = tx.RegisterFile(ctx, &fileID, submissionLocation, message.Key, user)
+		// Store the anonymized submission path (filePath), not the correlation-id, so the mapper can resolve it back on cleanup.
+		fileID, registerErr = tx.RegisterFile(ctx, &fileID, submissionLocation, filePath, user)
 		if registerErr != nil {
 			log.Errorf("failed to register file, fileID: %s, reason: (%s)", fileID, registerErr.Error())
 			if err := tx.Rollback(); err != nil {
@@ -331,7 +333,9 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 			return []func(){app.errorQueue(message), app.setErrorEvent(findFileErr.Error(), message)}, nil
 		}
 
-		return nil, nil
+		// File is now registered; fall through to read + decrypt + archive in a single pass, the same
+		// way a pre-registered "uploaded" file is handled. Returning here would leave a non-s3inbox
+		// upload stuck at "registered", so verify never runs.
 
 	default:
 		log.Warnf("file: %s recieved ingestion trigger with status: %s", fileID, status)

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -432,7 +432,7 @@ func (ts *TestSuite) TestIngestFile_NotRegistered_FallsThroughToArchive() {
 
 	fileID, err := ts.ingest.db.GetFileIDByUserPathAndStatus(context.Background(), ts.UserName, ts.filePath, "archived")
 	assert.NoError(ts.T(), err, "non-registered file should reach 'archived' in one pass, not park at 'registered'")
-	assert.NotEmpty(ts.T(), fileID, "expected an archived file for the non-registered upload")
+	assert.Equal(ts.T(), correlationID, fileID, "catch-all must register the file under the message correlation-id, finalize looks the file up by it")
 }
 
 func (ts *TestSuite) TestIngestFile_NoSubmissionLocation() {

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -420,6 +420,21 @@ func (ts *TestSuite) TestIngestFile_BaseCase() {
 	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
 }
 
+func (ts *TestSuite) TestIngestFile_NotRegistered_FallsThroughToArchive() {
+	// Non-s3inbox flow (e.g. FEGA-Norway via TSD): nothing pre-registers the file, so ingest's
+	// catch-all (status "") is the first registration point. It must register AND archive in one
+	// pass; an early return after RegisterFile would park the file at "registered" and verify would
+	// never run. Guards the v3.1.72 catch-all regression.
+	correlationID := uuid.New().String()
+	message := createMessage("ingest", ts.filePath, ts.UserName, correlationID)
+	_, err := ts.ingest.handleMessage(context.Background(), message)
+	assert.NoError(ts.T(), err, "unexpected error ingesting a non-registered file")
+
+	fileID, err := ts.ingest.db.GetFileIDByUserPathAndStatus(context.Background(), ts.UserName, ts.filePath, "archived")
+	assert.NoError(ts.T(), err, "non-registered file should reach 'archived' in one pass, not park at 'registered'")
+	assert.NotEmpty(ts.T(), fileID, "expected an archived file for the non-registered upload")
+}
+
 func (ts *TestSuite) TestIngestFile_NoSubmissionLocation() {
 	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, "/inbox", ts.filePath, ts.UserName)
 	assert.NoError(ts.T(), err, "failed to register file in database")

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -27,7 +27,7 @@ import (
 var db database.Database
 var inboxWriter storage.Writer
 var mqBroker *broker.AMQPBroker
-var inboxConfig helper.InboxConfig
+var inboxConfig helper.InboxProjectConfig
 
 func main() {
 	if err := run(); err != nil {

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -27,6 +27,7 @@ import (
 var db database.Database
 var inboxWriter storage.Writer
 var mqBroker *broker.AMQPBroker
+var inboxConfig helper.InboxConfig
 
 func main() {
 	if err := run(); err != nil {
@@ -46,6 +47,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to load config, due to: %v", err)
 	}
+	inboxConfig = conf.Inbox
 
 	db, err = postgres.NewPostgresSQLDatabase()
 	if err != nil {
@@ -264,9 +266,9 @@ func handleMessage(ctx context.Context, delivered amqp.Delivery) {
 	}
 
 	for _, fileMappingData := range filesToCleanFromInbox {
-		unanonymizedSubmissionFilePath := helper.UnanonymizeFilepath(fileMappingData.SubmissionFilePath, fileMappingData.User)
-		if err := inboxWriter.RemoveFile(ctx, fileMappingData.SubmissionLocation, unanonymizedSubmissionFilePath); err != nil {
-			log.Errorf("removal of file id: %s at location: %s, path: %s failed, reason: %v", fileMappingData.FileID, fileMappingData.SubmissionLocation, unanonymizedSubmissionFilePath, err)
+		resolvedSubmissionPath := helper.ResolveInboxPath(fileMappingData.SubmissionFilePath, fileMappingData.User, inboxConfig)
+		if err := inboxWriter.RemoveFile(ctx, fileMappingData.SubmissionLocation, resolvedSubmissionPath); err != nil {
+			log.Errorf("removal of file id: %s at location: %s, path: %s failed, reason: %v", fileMappingData.FileID, fileMappingData.SubmissionLocation, resolvedSubmissionPath, err)
 		}
 	}
 

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
@@ -783,9 +782,9 @@ func (c *Config) configReEncryptServer() (err error) {
 // An absent section yields the zero value, which is stock SDA behavior, so deployments that omit it
 // are unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
 // (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
-// the same viper instance. Setting only one of the two keys is an error, as is a delimiter that is
-// not a single separator character: it joins code and username into one directory name, so letters,
-// digits and "/" would corrupt the layout.
+// the same viper instance. Setting only one of the two keys is an error. The delimiter joins code
+// and username into one inbox directory name, so only "-", "_" and "." are accepted: anything else
+// (letters, digits, "/", whitespace) would corrupt or split the layout.
 func LoadInboxProjectConfig() (helper.InboxProjectConfig, error) {
 	cfg := helper.InboxProjectConfig{
 		Code:      viper.GetString("storage.inbox.projectCode"),
@@ -798,9 +797,10 @@ func LoadInboxProjectConfig() (helper.InboxProjectConfig, error) {
 		return helper.InboxProjectConfig{}, errors.New("storage.inbox.projectCode and storage.inbox.projectCodeDelimiter must be set together")
 	}
 
-	r := []rune(cfg.Delimiter)
-	if len(r) != 1 || unicode.IsLetter(r[0]) || unicode.IsDigit(r[0]) || r[0] == '/' {
-		return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCodeDelimiter %q is not a delimiter character", cfg.Delimiter)
+	switch cfg.Delimiter {
+	case "-", "_", ".":
+	default:
+		return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCodeDelimiter %q is not a delimiter character (use \"-\", \"_\" or \".\")", cfg.Delimiter)
 	}
 
 	return cfg, nil

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	ReEncrypt    ReEncConfig
 	Auth         AuthConf
 	RotateKey    RotateKeyConf
-	Inbox        helper.InboxConfig
+	Inbox        helper.InboxProjectConfig
 }
 
 type Grpc struct {
@@ -378,7 +378,7 @@ func NewConfig(app string) (*Config, error) {
 			return nil, err
 		}
 		c.configSchemas()
-		c.configInbox()
+		c.configInboxProject()
 
 		c.API.Grpc, err = configReEncryptClient()
 		if err != nil {
@@ -454,7 +454,7 @@ func NewConfig(app string) (*Config, error) {
 		}
 
 		c.configSchemas()
-		c.configInbox()
+		c.configInboxProject()
 	case "notify":
 		c.configSMTP()
 
@@ -772,22 +772,22 @@ func (c *Config) configReEncryptServer() (err error) {
 	return nil
 }
 
-// LoadInboxConfig reads the per-user inbox directory layout from the shared viper instance. An
+// LoadInboxProjectConfig reads the per-user inbox directory layout from the shared viper instance. An
 // empty (absent) project code yields stock SDA behavior, so deployments that omit the section are
 // unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
 // (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
 // the same viper instance.
-func LoadInboxConfig() helper.InboxConfig {
-	return helper.InboxConfig{
-		ProjectCode:          viper.GetString("storage.inbox.projectCode"),
-		ProjectCodeDelimiter: viper.GetString("storage.inbox.projectCodeDelimiter"),
+func LoadInboxProjectConfig() helper.InboxProjectConfig {
+	return helper.InboxProjectConfig{
+		Code:      viper.GetString("storage.inbox.projectCode"),
+		Delimiter: viper.GetString("storage.inbox.projectCodeDelimiter"),
 	}
 }
 
-// configInbox populates the inbox layout config for services that resolve anonymized submission
+// configInboxProject populates the inbox layout config for services that resolve anonymized submission
 // paths back to their physical inbox path (mapper, api).
-func (c *Config) configInbox() {
-	c.Inbox = LoadInboxConfig()
+func (c *Config) configInboxProject() {
+	c.Inbox = LoadInboxProjectConfig()
 }
 
 // configSchemas configures the schemas to load depending on

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
+	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -40,6 +41,7 @@ type Config struct {
 	ReEncrypt    ReEncConfig
 	Auth         AuthConf
 	RotateKey    RotateKeyConf
+	Inbox        helper.InboxConfig
 }
 
 type Grpc struct {
@@ -376,6 +378,7 @@ func NewConfig(app string) (*Config, error) {
 			return nil, err
 		}
 		c.configSchemas()
+		c.configInbox()
 
 		c.API.Grpc, err = configReEncryptClient()
 		if err != nil {
@@ -451,6 +454,7 @@ func NewConfig(app string) (*Config, error) {
 		}
 
 		c.configSchemas()
+		c.configInbox()
 	case "notify":
 		c.configSMTP()
 
@@ -766,6 +770,24 @@ func (c *Config) configReEncryptServer() (err error) {
 	}
 
 	return nil
+}
+
+// LoadInboxConfig reads the per-user inbox directory layout from the shared viper instance. An
+// empty (absent) project code yields stock SDA behavior, so deployments that omit the section are
+// unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
+// (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
+// the same viper instance.
+func LoadInboxConfig() helper.InboxConfig {
+	return helper.InboxConfig{
+		ProjectCode:          viper.GetString("storage.inbox.projectCode"),
+		ProjectCodeDelimiter: viper.GetString("storage.inbox.projectCodeDelimiter"),
+	}
+}
+
+// configInbox populates the inbox layout config for services that resolve anonymized submission
+// paths back to their physical inbox path (mapper, api).
+func (c *Config) configInbox() {
+	c.Inbox = LoadInboxConfig()
 }
 
 // configSchemas configures the schemas to load depending on

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
@@ -782,9 +783,10 @@ func (c *Config) configReEncryptServer() (err error) {
 // An absent section yields the zero value, which is stock SDA behavior, so deployments that omit it
 // are unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
 // (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
-// the same viper instance. Setting only one of the two keys is an error. The delimiter joins code
-// and username into one inbox directory name, so only "-", "_" and "." are accepted: anything else
-// (letters, digits, "/", whitespace) would corrupt or split the layout.
+// the same viper instance. Setting only one of the two keys is an error. Code and delimiter join
+// with the username into ONE inbox directory name, so the delimiter is restricted to "-", "_" or
+// "." and the code must not contain path separators, whitespace or control characters: anything
+// else would corrupt or split the layout.
 func LoadInboxProjectConfig() (helper.InboxProjectConfig, error) {
 	cfg := helper.InboxProjectConfig{
 		Code:      viper.GetString("storage.inbox.projectCode"),
@@ -801,6 +803,12 @@ func LoadInboxProjectConfig() (helper.InboxProjectConfig, error) {
 	case "-", "_", ".":
 	default:
 		return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCodeDelimiter %q is not a delimiter character (use \"-\", \"_\" or \".\")", cfg.Delimiter)
+	}
+
+	for _, r := range cfg.Code {
+		if r == '/' || r == '\\' || unicode.IsSpace(r) || unicode.IsControl(r) {
+			return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCode %q must not contain path separators or whitespace", cfg.Code)
+		}
 	}
 
 	return cfg, nil

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
@@ -378,7 +379,10 @@ func NewConfig(app string) (*Config, error) {
 			return nil, err
 		}
 		c.configSchemas()
-		c.configInboxProject()
+		c.Inbox, err = LoadInboxProjectConfig()
+		if err != nil {
+			return nil, err
+		}
 
 		c.API.Grpc, err = configReEncryptClient()
 		if err != nil {
@@ -454,7 +458,10 @@ func NewConfig(app string) (*Config, error) {
 		}
 
 		c.configSchemas()
-		c.configInboxProject()
+		c.Inbox, err = LoadInboxProjectConfig()
+		if err != nil {
+			return nil, err
+		}
 	case "notify":
 		c.configSMTP()
 
@@ -772,22 +779,31 @@ func (c *Config) configReEncryptServer() (err error) {
 	return nil
 }
 
-// LoadInboxProjectConfig reads the per-user inbox directory layout from the shared viper instance. An
-// empty (absent) project code yields stock SDA behavior, so deployments that omit the section are
-// unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
+// LoadInboxProjectConfig reads the per-user inbox directory layout from the shared viper instance.
+// An absent section yields the zero value, which is stock SDA behavior, so deployments that omit it
+// are unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
 // (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
-// the same viper instance.
-func LoadInboxProjectConfig() helper.InboxProjectConfig {
-	return helper.InboxProjectConfig{
+// the same viper instance. Setting only one of the two keys is an error, as is a delimiter that is
+// not a single separator character: it joins code and username into one directory name, so letters,
+// digits and "/" would corrupt the layout.
+func LoadInboxProjectConfig() (helper.InboxProjectConfig, error) {
+	cfg := helper.InboxProjectConfig{
 		Code:      viper.GetString("storage.inbox.projectCode"),
 		Delimiter: viper.GetString("storage.inbox.projectCodeDelimiter"),
 	}
-}
+	switch {
+	case cfg.Code == "" && cfg.Delimiter == "":
+		return cfg, nil
+	case cfg.Code == "" || cfg.Delimiter == "":
+		return helper.InboxProjectConfig{}, errors.New("storage.inbox.projectCode and storage.inbox.projectCodeDelimiter must be set together")
+	}
 
-// configInboxProject populates the inbox layout config for services that resolve anonymized submission
-// paths back to their physical inbox path (mapper, api).
-func (c *Config) configInboxProject() {
-	c.Inbox = LoadInboxProjectConfig()
+	r := []rune(cfg.Delimiter)
+	if len(r) != 1 || unicode.IsLetter(r[0]) || unicode.IsDigit(r[0]) || r[0] == '/' {
+		return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCodeDelimiter %q is not a delimiter character", cfg.Delimiter)
+	}
+
+	return cfg, nil
 }
 
 // configSchemas configures the schemas to load depending on

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -614,26 +614,26 @@ func (ts *ConfigTestSuite) TestConfigAuth_OIDC() {
 	assert.NoError(ts.T(), err, "unexpected failure")
 }
 
-func (ts *ConfigTestSuite) TestLoadInboxConfig_readsNestedStorageInboxKeys() {
+func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_readsNestedStorageInboxKeys() {
 	// Each service loads its config.yaml into the shared global viper (mapper/api via NewConfig,
-	// ingest via config/v2). LoadInboxConfig then reads it. Prove the nested storage.inbox.* block
+	// ingest via config/v2). LoadInboxProjectConfig then reads it. Prove the nested storage.inbox.* block
 	// flattens to the dotted keys it reads — the seam the projectCode resolver depends on.
 	viper.Reset()
 	viper.SetConfigType("yaml")
 	cfg := "storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n"
 	assert.NoError(ts.T(), viper.ReadConfig(bytes.NewBufferString(cfg)))
 
-	got := LoadInboxConfig()
-	assert.Equal(ts.T(), "p11", got.ProjectCode)
-	assert.Equal(ts.T(), "-", got.ProjectCodeDelimiter)
+	got := LoadInboxProjectConfig()
+	assert.Equal(ts.T(), "p11", got.Code)
+	assert.Equal(ts.T(), "-", got.Delimiter)
 }
 
-func (ts *ConfigTestSuite) TestLoadInboxConfig_absentSectionIsStock() {
-	// With no storage.inbox section LoadInboxConfig yields the zero value, which ResolveInboxPath
+func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_absentSectionIsStock() {
+	// With no storage.inbox section LoadInboxProjectConfig yields the zero value, which ResolveInboxPath
 	// treats as stock SDA behavior — so deployments that omit it (e.g. the Swedish node) are
 	// unaffected.
 	viper.Reset()
-	got := LoadInboxConfig()
-	assert.Equal(ts.T(), "", got.ProjectCode)
-	assert.Equal(ts.T(), "", got.ProjectCodeDelimiter)
+	got := LoadInboxProjectConfig()
+	assert.Equal(ts.T(), "", got.Code)
+	assert.Equal(ts.T(), "", got.Delimiter)
 }

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -616,24 +616,73 @@ func (ts *ConfigTestSuite) TestConfigAuth_OIDC() {
 
 func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_readsNestedStorageInboxKeys() {
 	// Each service loads its config.yaml into the shared global viper (mapper/api via NewConfig,
-	// ingest via config/v2). LoadInboxProjectConfig then reads it. Prove the nested storage.inbox.* block
-	// flattens to the dotted keys it reads — the seam the projectCode resolver depends on.
+	// ingest via config/v2). LoadInboxProjectConfig then reads it. Prove the nested storage.inbox.*
+	// block flattens to the dotted keys it reads: the seam the projectCode resolver depends on.
 	viper.Reset()
 	viper.SetConfigType("yaml")
 	cfg := "storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n"
 	assert.NoError(ts.T(), viper.ReadConfig(bytes.NewBufferString(cfg)))
 
-	got := LoadInboxProjectConfig()
+	got, err := LoadInboxProjectConfig()
+	assert.NoError(ts.T(), err)
 	assert.Equal(ts.T(), "p11", got.Code)
 	assert.Equal(ts.T(), "-", got.Delimiter)
 }
 
 func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_absentSectionIsStock() {
-	// With no storage.inbox section LoadInboxProjectConfig yields the zero value, which ResolveInboxPath
-	// treats as stock SDA behavior — so deployments that omit it (e.g. the Swedish node) are
-	// unaffected.
+	// With no storage.inbox section LoadInboxProjectConfig yields the zero value, which
+	// ResolveInboxPath treats as stock SDA behavior, so deployments that omit it (e.g. the Swedish
+	// node) are unaffected.
 	viper.Reset()
-	got := LoadInboxProjectConfig()
+	got, err := LoadInboxProjectConfig()
+	assert.NoError(ts.T(), err)
 	assert.Equal(ts.T(), "", got.Code)
 	assert.Equal(ts.T(), "", got.Delimiter)
+}
+
+func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_halfConfigured_errors() {
+	// A project code without a delimiter would silently glue code and username together
+	// ("p11username"); a delimiter without a code would be silently ignored. Both are
+	// misconfigurations that must fail at startup, not produce garbage paths at runtime.
+	viper.Reset()
+	viper.Set("storage.inbox.projectCode", "p11")
+	_, err := LoadInboxProjectConfig()
+	assert.ErrorContains(ts.T(), err, "must be set together")
+
+	viper.Reset()
+	viper.Set("storage.inbox.projectCodeDelimiter", "-")
+	_, err = LoadInboxProjectConfig()
+	assert.ErrorContains(ts.T(), err, "must be set together")
+}
+
+func (ts *ConfigTestSuite) TestNewConfig_inboxProjectMisconfig_failsStartup() {
+	// The loader's validation must propagate out of NewConfig: a half-configured inbox project
+	// section stops the service at startup instead of producing garbage paths at runtime.
+	viper.Set("storage.inbox.projectCode", "p11")
+	defer viper.Reset()
+
+	_, err := NewConfig("mapper")
+	assert.ErrorContains(ts.T(), err, "must be set together")
+}
+
+func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_delimiterMustBeSeparatorCharacter() {
+	// The delimiter joins code and username into ONE inbox directory name ("p11-user"), so it must
+	// be a single character that is not a letter, not a digit, and not "/" (a slash would split the
+	// user directory across two path segments and break the on-disk layout assumption).
+	load := func(delimiter string) error {
+		viper.Reset()
+		viper.Set("storage.inbox.projectCode", "p11")
+		viper.Set("storage.inbox.projectCodeDelimiter", delimiter)
+		_, err := LoadInboxProjectConfig()
+
+		return err
+	}
+
+	for _, bad := range []string{"x", "Q", "1", "/", "--", "p11"} {
+		assert.ErrorContains(ts.T(), load(bad), "not a delimiter character",
+			"delimiter %q should be rejected", bad)
+	}
+	for _, good := range []string{"-", "_", "."} {
+		assert.NoError(ts.T(), load(good), "delimiter %q should be accepted", good)
+	}
 }

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -666,9 +666,10 @@ func (ts *ConfigTestSuite) TestNewConfig_inboxProjectMisconfig_failsStartup() {
 }
 
 func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_delimiterMustBeSeparatorCharacter() {
-	// The delimiter joins code and username into ONE inbox directory name ("p11-user"), so it must
-	// be a single character that is not a letter, not a digit, and not "/" (a slash would split the
-	// user directory across two path segments and break the on-disk layout assumption).
+	// The delimiter joins code and username into ONE inbox directory name ("p11-user"), so only the
+	// whitelisted separators "-", "_" and "." are accepted. Letters and digits would blur the
+	// code/username boundary, "/" would split the directory across two path segments, and
+	// whitespace or control characters would produce miserable directory names.
 	load := func(delimiter string) error {
 		viper.Reset()
 		viper.Set("storage.inbox.projectCode", "p11")
@@ -678,7 +679,7 @@ func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_delimiterMustBeSeparatorCh
 		return err
 	}
 
-	for _, bad := range []string{"x", "Q", "1", "/", "--", "p11"} {
+	for _, bad := range []string{"x", "Q", "1", "/", "\\", " ", "\t", "\n", "+", "★", "--", "p11"} {
 		assert.ErrorContains(ts.T(), load(bad), "not a delimiter character",
 			"delimiter %q should be rejected", bad)
 	}

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -655,6 +655,28 @@ func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_halfConfigured_errors() {
 	assert.ErrorContains(ts.T(), err, "must be set together")
 }
 
+func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_projectCodeMustBeSingleSegment() {
+	// The code prefixes ONE per-user directory name. Path separators would silently split it into
+	// multiple segments ("p11/" -> "p11/-user/..."), and whitespace or control characters produce
+	// directory names no deployment intends. Free text otherwise: codes are deployment-specific.
+	load := func(code string) error {
+		viper.Reset()
+		viper.Set("storage.inbox.projectCode", code)
+		viper.Set("storage.inbox.projectCodeDelimiter", "-")
+		_, err := LoadInboxProjectConfig()
+
+		return err
+	}
+
+	for _, bad := range []string{"p11/", "/p11", "p\\11", "p 11", "p\t11", "p\n11"} {
+		assert.ErrorContains(ts.T(), load(bad), "must not contain",
+			"project code %q should be rejected", bad)
+	}
+	for _, good := range []string{"p11", "fega-no", "P11.x"} {
+		assert.NoError(ts.T(), load(good), "project code %q should be accepted", good)
+	}
+}
+
 func (ts *ConfigTestSuite) TestNewConfig_inboxProjectMisconfig_failsStartup() {
 	// The loader's validation must propagate out of NewConfig: a half-configured inbox project
 	// section stops the service at startup instead of producing garbage paths at runtime.

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -611,4 +612,28 @@ func (ts *ConfigTestSuite) TestConfigAuth_OIDC() {
 	viper.Set("oidc.redirectUrl", "http://auth/oidc/login")
 	_, err = NewConfig("auth")
 	assert.NoError(ts.T(), err, "unexpected failure")
+}
+
+func (ts *ConfigTestSuite) TestLoadInboxConfig_readsNestedStorageInboxKeys() {
+	// Each service loads its config.yaml into the shared global viper (mapper/api via NewConfig,
+	// ingest via config/v2). LoadInboxConfig then reads it. Prove the nested storage.inbox.* block
+	// flattens to the dotted keys it reads — the seam the projectCode resolver depends on.
+	viper.Reset()
+	viper.SetConfigType("yaml")
+	cfg := "storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n"
+	assert.NoError(ts.T(), viper.ReadConfig(bytes.NewBufferString(cfg)))
+
+	got := LoadInboxConfig()
+	assert.Equal(ts.T(), "p11", got.ProjectCode)
+	assert.Equal(ts.T(), "-", got.ProjectCodeDelimiter)
+}
+
+func (ts *ConfigTestSuite) TestLoadInboxConfig_absentSectionIsStock() {
+	// With no storage.inbox section LoadInboxConfig yields the zero value, which ResolveInboxPath
+	// treats as stock SDA behavior — so deployments that omit it (e.g. the Swedish node) are
+	// unaffected.
+	viper.Reset()
+	got := LoadInboxConfig()
+	assert.Equal(ts.T(), "", got.ProjectCode)
+	assert.Equal(ts.T(), "", got.ProjectCodeDelimiter)
 }

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -465,36 +465,36 @@ func UnanonymizeFilepath(fp string, username string) string {
 	return filepath.Join(strings.Replace(username, "@", "_", 1), fp)
 }
 
-// InboxConfig describes how a deployment names its per-user inbox directories, so an
+// InboxProjectConfig describes how a deployment names its per-user inbox directories, so an
 // anonymized submission path (the user prefix stripped) can be resolved back to the physical
-// inbox-relative path. An empty ProjectCode selects stock SDA behavior.
-type InboxConfig struct {
-	// ProjectCode optionally prefixes the per-user inbox directory (e.g. "p11"). Empty keeps the
+// inbox-relative path. An empty Code selects stock SDA behavior.
+type InboxProjectConfig struct {
+	// Code optionally prefixes the per-user inbox directory (e.g. "p11"). Empty keeps the
 	// stock layout where the directory is the normalized username (see UnanonymizeFilepath).
-	ProjectCode string
-	// ProjectCodeDelimiter separates ProjectCode from the username (e.g. "-"). Unused when
-	// ProjectCode is empty.
-	ProjectCodeDelimiter string
+	Code string
+	// Delimiter separates Code from the username (e.g. "-"). Unused when
+	// Code is empty.
+	Delimiter string
 }
 
 // ResolveInboxPath reconstructs the physical inbox-relative path for an anonymized submission
 // filePath. An already-resolved path (e.g. on reprocessing) is returned as-is, with any leading
 // separator normalized away.
 //
-// With no ProjectCode it is the stock round-trip, deferring to UnanonymizeFilepath (normalize the
+// With no Code it is the stock round-trip, deferring to UnanonymizeFilepath (normalize the
 // username — first "@"->"_" — and prepend "<user>/"), so existing deployments are unaffected.
 //
-// With a ProjectCode it rebuilds "<ProjectCode><delimiter><username>/<filePath>" using the RAW
+// With a Code it rebuilds "<Code><delimiter><username>/<filePath>" using the RAW
 // username. Whether to normalize is derived from the project code rather than configured
 // separately: a project code denotes a TSD-style inbox namespaced by project (e.g. FEGA-Norway's
 // "p11-dummy@elixir-europe.org/files/..."), which stores the username verbatim. No current
 // deployment needs a project code together with normalization; add an explicit toggle if one does.
-func ResolveInboxPath(filePath, username string, cfg InboxConfig) string {
-	if cfg.ProjectCode == "" {
+func ResolveInboxPath(filePath, username string, cfg InboxProjectConfig) string {
+	if cfg.Code == "" {
 		return UnanonymizeFilepath(filePath, username)
 	}
 
-	userDir := cfg.ProjectCode + cfg.ProjectCodeDelimiter + username
+	userDir := cfg.Code + cfg.Delimiter + username
 	// Tolerate a leading separator from older proxy formats (e.g. "/p11-user/files/..."); without
 	// stripping it the prefix check below misses and userDir gets prepended a second time.
 	relPath := strings.TrimPrefix(filePath, "/")

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -478,17 +478,19 @@ type InboxProjectConfig struct {
 }
 
 // ResolveInboxPath reconstructs the physical inbox-relative path for an anonymized submission
-// filePath. An already-resolved path (e.g. on reprocessing) is returned as-is, with any leading
-// separator normalized away.
+// filePath.
 //
-// With no Code it is the stock round-trip, deferring to UnanonymizeFilepath (normalize the
-// username — first "@"->"_" — and prepend "<user>/"), so existing deployments are unaffected.
+// With no Code it is the stock round-trip, deferring to UnanonymizeFilepath unchanged (normalize
+// the username, first "@" -> "_", and prepend "<user>/"), so existing deployments are unaffected,
+// edge inputs included.
 //
-// With a Code it rebuilds "<Code><delimiter><username>/<filePath>" using the RAW
-// username. Whether to normalize is derived from the project code rather than configured
-// separately: a project code denotes a TSD-style inbox namespaced by project (e.g. FEGA-Norway's
-// "p11-dummy@elixir-europe.org/files/..."), which stores the username verbatim. No current
-// deployment needs a project code together with normalization; add an explicit toggle if one does.
+// With a Code it rebuilds "<Code><delimiter><username>/<filePath>" using the RAW username. In
+// this branch an already-resolved path (e.g. on reprocessing) is returned as-is, with any leading
+// separator normalized away. Whether to normalize is derived from the project code rather than
+// configured separately: a project code denotes a TSD-style inbox namespaced by project (e.g.
+// FEGA-Norway's "p11-dummy@elixir-europe.org/files/..."), which stores the username verbatim. No
+// current deployment needs a project code together with normalization; add an explicit toggle if
+// one does.
 func ResolveInboxPath(filePath, username string, cfg InboxProjectConfig) string {
 	if cfg.Code == "" {
 		return UnanonymizeFilepath(filePath, username)

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -495,9 +495,9 @@ func ResolveInboxPath(filePath, username string, cfg InboxProjectConfig) string 
 	}
 
 	userDir := cfg.Code + cfg.Delimiter + username
-	// Tolerate a leading separator from older proxy formats (e.g. "/p11-user/files/..."); without
-	// stripping it the prefix check below misses and userDir gets prepended a second time.
-	relPath := strings.TrimPrefix(filePath, "/")
+	// Tolerate leading separators from older proxy formats (e.g. "/p11-user/files/..."); without
+	// stripping them the prefix check below misses and userDir gets prepended a second time.
+	relPath := strings.TrimLeft(filePath, "/")
 	// Treat as already-resolved only on a path-segment boundary, so "p11-user2/..." is not mistaken
 	// for the "p11-user" directory. A submission path always has a file component, so relPath is
 	// never the bare userDir.

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -464,3 +464,39 @@ func UnanonymizeFilepath(fp string, username string) string {
 
 	return filepath.Join(strings.Replace(username, "@", "_", 1), fp)
 }
+
+// InboxConfig describes how a deployment names its per-user inbox directories, so an
+// anonymized submission path (the user prefix stripped) can be resolved back to the physical
+// inbox-relative path. An empty ProjectCode selects stock SDA behavior.
+type InboxConfig struct {
+	// ProjectCode optionally prefixes the per-user inbox directory (e.g. "p11"). Empty keeps the
+	// stock layout where the directory is the normalized username (see UnanonymizeFilepath).
+	ProjectCode string
+	// ProjectCodeDelimiter separates ProjectCode from the username (e.g. "-"). Unused when
+	// ProjectCode is empty.
+	ProjectCodeDelimiter string
+}
+
+// ResolveInboxPath reconstructs the physical inbox-relative path for an anonymized submission
+// filePath. An already-resolved path (e.g. on reprocessing) is returned unchanged.
+//
+// With no ProjectCode it is the stock round-trip, deferring to UnanonymizeFilepath (normalize the
+// username — first "@"->"_" — and prepend "<user>/"), so existing deployments are unaffected.
+//
+// With a ProjectCode it rebuilds "<ProjectCode><delimiter><username>/<filePath>" using the RAW
+// username. Whether to normalize is derived from the project code rather than configured
+// separately: a project code denotes a TSD-style inbox namespaced by project (e.g. FEGA-Norway's
+// "p11-dummy@elixir-europe.org/files/..."), which stores the username verbatim. No current
+// deployment needs a project code together with normalization; add an explicit toggle if one does.
+func ResolveInboxPath(filePath, username string, cfg InboxConfig) string {
+	if cfg.ProjectCode == "" {
+		return UnanonymizeFilepath(filePath, username)
+	}
+
+	userDir := cfg.ProjectCode + cfg.ProjectCodeDelimiter + username
+	if strings.HasPrefix(filePath, userDir) {
+		return filePath
+	}
+
+	return filepath.Join(userDir, filePath)
+}

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -478,7 +478,8 @@ type InboxConfig struct {
 }
 
 // ResolveInboxPath reconstructs the physical inbox-relative path for an anonymized submission
-// filePath. An already-resolved path (e.g. on reprocessing) is returned unchanged.
+// filePath. An already-resolved path (e.g. on reprocessing) is returned as-is, with any leading
+// separator normalized away.
 //
 // With no ProjectCode it is the stock round-trip, deferring to UnanonymizeFilepath (normalize the
 // username — first "@"->"_" — and prepend "<user>/"), so existing deployments are unaffected.
@@ -494,9 +495,14 @@ func ResolveInboxPath(filePath, username string, cfg InboxConfig) string {
 	}
 
 	userDir := cfg.ProjectCode + cfg.ProjectCodeDelimiter + username
-	if strings.HasPrefix(filePath, userDir) {
-		return filePath
+	// Tolerate a leading separator from older proxy formats (e.g. "/p11-user/files/..."); without
+	// stripping it the prefix check below misses and userDir gets prepended a second time.
+	relPath := strings.TrimPrefix(filePath, "/")
+	// Treat as already-resolved only on a path-segment boundary, so "p11-user2/..." is not mistaken
+	// for the "p11-user" directory.
+	if relPath == userDir || strings.HasPrefix(relPath, userDir+"/") {
+		return relPath
 	}
 
-	return filepath.Join(userDir, filePath)
+	return filepath.Join(userDir, relPath)
 }

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -499,8 +499,9 @@ func ResolveInboxPath(filePath, username string, cfg InboxProjectConfig) string 
 	// stripping it the prefix check below misses and userDir gets prepended a second time.
 	relPath := strings.TrimPrefix(filePath, "/")
 	// Treat as already-resolved only on a path-segment boundary, so "p11-user2/..." is not mistaken
-	// for the "p11-user" directory.
-	if relPath == userDir || strings.HasPrefix(relPath, userDir+"/") {
+	// for the "p11-user" directory. A submission path always has a file component, so relPath is
+	// never the bare userDir.
+	if strings.HasPrefix(relPath, userDir+"/") {
 		return relPath
 	}
 

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -184,7 +184,7 @@ func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser()
 	// With no project code ResolveInboxPath defers to the stock UnanonymizeFilepath: the first
 	// "@" becomes "_" and the username directory is prepended unless the path already starts with
 	// it. These assertions keep existing deployments pinned.
-	stockDefault := InboxConfig{}
+	stockDefault := InboxProjectConfig{}
 	user := "test.user@demo.org"
 	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
 		ResolveInboxPath("files/x.raw.enc", user, stockDefault))
@@ -196,14 +196,14 @@ func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser()
 func (ts *HelperTest) TestResolveInboxPath_projectCode_reconstructsRawUserDir() {
 	// FEGA-Norway: anonymized "/files/x" is rebuilt under the project-code-prefixed RAW username
 	// (the "@" is not normalized to "_" when a project code is configured).
-	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	got := ResolveInboxPath("/files/x.raw.enc", "dummy@elixir-europe.org", cfg)
 	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc", got)
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_alreadyPrefixed_unchanged() {
 	// An already-resolved path (e.g. on reprocessing) is returned as-is, not double-prefixed.
-	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	fp := "p11-dummy@elixir-europe.org/files/x.raw.enc"
 	assert.Equal(ts.T(), fp, ResolveInboxPath(fp, "dummy@elixir-europe.org", cfg))
 }
@@ -212,7 +212,7 @@ func (ts *HelperTest) TestResolveInboxPath_projectCode_leadingSeparator_notDoubl
 	// Older proxy formats can send an already-resolved path with a leading "/". The leading
 	// separator must be normalized away, not cause the user directory to be prepended a second time
 	// ("/p11-user/files/x" -> "p11-user/p11-user/files/x").
-	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc",
 		ResolveInboxPath("/p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", cfg))
 }
@@ -220,7 +220,7 @@ func (ts *HelperTest) TestResolveInboxPath_projectCode_leadingSeparator_notDoubl
 func (ts *HelperTest) TestResolveInboxPath_projectCode_segmentBoundary() {
 	// The already-resolved check holds on a path-segment boundary: "p11-user2/..." belongs to a
 	// different user and must not be treated as already under the "p11-user" directory.
-	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	assert.Equal(ts.T(), "p11-user/p11-user2/files/x.raw.enc",
 		ResolveInboxPath("p11-user2/files/x.raw.enc", "user", cfg))
 }

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -179,3 +179,31 @@ func (ts *HelperTest) TestUnanonymizeFilepath_oldMessage() {
 	newPath := UnanonymizeFilepath(filePath, userName)
 	assert.Equal(ts.T(), filePath, newPath)
 }
+
+func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser() {
+	// With no project code ResolveInboxPath defers to the stock UnanonymizeFilepath: the first
+	// "@" becomes "_" and the username directory is prepended unless the path already starts with
+	// it. These assertions keep existing deployments pinned.
+	stockDefault := InboxConfig{}
+	user := "test.user@demo.org"
+	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
+		ResolveInboxPath("files/x.raw.enc", user, stockDefault))
+	// Already-prefixed path is returned unchanged.
+	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
+		ResolveInboxPath("test.user_demo.org/files/x.raw.enc", user, stockDefault))
+}
+
+func (ts *HelperTest) TestResolveInboxPath_projectCode_reconstructsRawUserDir() {
+	// FEGA-Norway: anonymized "/files/x" is rebuilt under the project-code-prefixed RAW username
+	// (the "@" is not normalized to "_" when a project code is configured).
+	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	got := ResolveInboxPath("/files/x.raw.enc", "dummy@elixir-europe.org", cfg)
+	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc", got)
+}
+
+func (ts *HelperTest) TestResolveInboxPath_projectCode_alreadyPrefixed_unchanged() {
+	// An already-resolved path (e.g. on reprocessing) is returned as-is, not double-prefixed.
+	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	fp := "p11-dummy@elixir-europe.org/files/x.raw.enc"
+	assert.Equal(ts.T(), fp, ResolveInboxPath(fp, "dummy@elixir-europe.org", cfg))
+}

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -180,6 +180,15 @@ func (ts *HelperTest) TestUnanonymizeFilepath_oldMessage() {
 	assert.Equal(ts.T(), filePath, newPath)
 }
 
+func (ts *HelperTest) TestUnanonymizeFilepath_leadingSeparator() {
+	// A leading "/" must not drop the username directory: Go's filepath.Join concatenates and
+	// cleans, it does not treat a leading "/" in a later element as an absolute path. So an
+	// anonymized "/files/x" still resolves under the user directory.
+	userName := "test.user@demo.org"
+	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
+		UnanonymizeFilepath("/files/x.raw.enc", userName))
+}
+
 func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser() {
 	// With no project code ResolveInboxPath defers to the stock UnanonymizeFilepath: the first
 	// "@" becomes "_" and the username directory is prepended unless the path already starts with
@@ -191,6 +200,16 @@ func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser()
 	// Already-prefixed path is returned unchanged.
 	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
 		ResolveInboxPath("test.user_demo.org/files/x.raw.enc", user, stockDefault))
+}
+
+func (ts *HelperTest) TestResolveInboxPath_stockDefault_leadingSeparator() {
+	// Stock branch (no project code): a leading "/" on the anonymized path is harmless. The userDir
+	// prefix is still applied, refuting the assumption that filepath.Join treats a leading "/" as
+	// absolute and drops the prefix.
+	stockDefault := InboxProjectConfig{}
+	user := "test.user@demo.org"
+	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
+		ResolveInboxPath("/files/x.raw.enc", user, stockDefault))
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_reconstructsRawUserDir() {

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -234,6 +234,10 @@ func (ts *HelperTest) TestResolveInboxPath_projectCode_leadingSeparator_notDoubl
 	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc",
 		ResolveInboxPath("/p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", cfg))
+	// All leading separators are stripped, so repeated slashes cannot sneak past the
+	// already-resolved check either.
+	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc",
+		ResolveInboxPath("//p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", cfg))
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_segmentBoundary() {

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -207,3 +207,20 @@ func (ts *HelperTest) TestResolveInboxPath_projectCode_alreadyPrefixed_unchanged
 	fp := "p11-dummy@elixir-europe.org/files/x.raw.enc"
 	assert.Equal(ts.T(), fp, ResolveInboxPath(fp, "dummy@elixir-europe.org", cfg))
 }
+
+func (ts *HelperTest) TestResolveInboxPath_projectCode_leadingSeparator_notDoubled() {
+	// Older proxy formats can send an already-resolved path with a leading "/". The leading
+	// separator must be normalized away, not cause the user directory to be prepended a second time
+	// ("/p11-user/files/x" -> "p11-user/p11-user/files/x").
+	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc",
+		ResolveInboxPath("/p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", cfg))
+}
+
+func (ts *HelperTest) TestResolveInboxPath_projectCode_segmentBoundary() {
+	// The already-resolved check holds on a path-segment boundary: "p11-user2/..." belongs to a
+	// different user and must not be treated as already under the "p11-user" directory.
+	cfg := InboxConfig{ProjectCode: "p11", ProjectCodeDelimiter: "-"}
+	assert.Equal(ts.T(), "p11-user/p11-user2/files/x.raw.enc",
+		ResolveInboxPath("p11-user2/files/x.raw.enc", "user", cfg))
+}


### PR DESCRIPTION
> **Supersedes #2464.** Moved to an upstream branch so the Docker image-build and integration-test CI can run (a fork PR can't push to `ghcr.io/neicnordic`). The design was reviewed on #2464; review continues here.

This PR makes two related changes on the read/ingest side of the inbox path, both surfaced by the FEGA-Norway deployment (TSD upload, **not** s3inbox):

1. config-driven projectCode inbox-path reconstruction (additive, default == stock), relates to #2429
2. fix for the non-s3inbox ingest catch-all regression, see #2467

---

## 1. projectCode inbox-path reconstruction

In the FEGA-Norway deployment, inbox files land under a project-code-prefixed per-user directory: `p11-dummy@elixir-europe.org/files/x.raw.enc`. Stock SDA's read-side `UnanonymizeFilepath` assumes the per-user directory is exactly the username, so it mis-resolves the path and ingest/mapper can't find or clean the file.

The FEGA-Norway proxy anonymizes the path it publishes to `/files/<file>` (project code + username stripped, see ELIXIR-NO/FEGA-Norway#819), so the message stays a clean, node-agnostic path. SDA reconstructs the physical inbox path from config:

- `storage.inbox.projectCode`: optional per-user-directory prefix (e.g. `p11`); empty (the default) means stock layout.
- `storage.inbox.projectCodeDelimiter`: separator between the project code and the username (e.g. `-`).

The loader validates the pair at startup: setting only one of the two keys is an error, the delimiter is restricted to an allowlist (`-`, `_`, `.`), and the code must not contain path separators or whitespace, so a misconfiguration fails the service instead of producing garbage paths at runtime. Both keys absent (the default) skips validation entirely.

`ResolveInboxPath(filePath, user, InboxProjectConfig)` reconstructs the per-user directory and joins the path under it:

- **No project code** falls back to the stock `UnanonymizeFilepath` (normalize the username, prepend `<user>/`), so existing deployments are byte-for-byte unaffected.
- **A project code** rebuilds `<projectCode><delimiter><username>/<path>` using the raw username. Whether to normalize is **derived from the project code** rather than a separate toggle: a project code denotes a TSD-style inbox that stores the raw username verbatim.

`helper.go` is **purely additive**: only `InboxProjectConfig` + `ResolveInboxPath` are added; `AnonymizeFilepath`/`UnanonymizeFilepath` are untouched. Config flows through a single `config.LoadInboxProjectConfig` read (mapper/api via `NewConfig`; ingest directly, since on `main` it loads through `config/v2` but shares the same viper instance). Wired into every inbox-path site: ingest (find + read), mapper (delete), api (delete + read). FEGA-Norway sets `projectCode=p11`, `projectCodeDelimiter="-"`.

## 2. non-s3inbox ingest catch-all fix

The status `""` catch-all, where ingest is the **first** registration point because the upload side does not pre-register via s3inbox/sftp-inbox, regressed in the v2 migration. It located and registered the file using `message.Key` (the broker correlation-id) instead of the trigger filepath, and returned after `RegisterFile` without archiving, so a non-registered upload parked at `registered` and verify never ran. Restored to use the trigger filepath for `FindFile`/`RegisterFile` and to fall through to read + decrypt + archive in one pass, the same way a pre-registered `uploaded` file is handled. Full root cause in #2467.

This path is invisible to the existing SDA CI because every integration flow uploads via s3inbox (which pre-registers), so nothing enters the catch-all. Added a regression test that drives status `""` through to `archived`.

## Verification

`go build`/`vet`/`test` green, including unit tests for `ResolveInboxPath`, a `LoadInboxProjectConfig` seam test (nested `storage.inbox.*` YAML to the dotted keys it reads), validation tests (half-configured keys, delimiter allowlist, project-code denylist, error propagation out of `NewConfig`), and a new ingest regression test driving status `""` to registered then archived under the message correlation-id. End-to-end in the FEGA-Norway stack on the `v3.1.72` images: the full pipeline ran **green (9/9)** and a file walked `registered -> submitted -> archived -> verified -> ready`, exercising the projectCode reconstruction, the catch-all fix, and the mapper inbox cleanup. Design rationale + stock-behavior trace: ELIXIR-NO/FEGA-Norway#820.

## Commits (kept separate so the regression fix is reviewable apart from the additive work)

- `feat(sda): config-driven projectCode inbox-path reconstruction`, the additive feature
- `fix(helper): harden ResolveInboxPath for leading separator and segment boundary`, leading `/`, path-segment boundary
- `fix(ingest): register and archive non-s3inbox uploads in one pass`, the catch-all regression fix (#2467)
- `refactor: rename InboxConfig to InboxProjectConfig per review`

The remaining commits are review follow-ups: hardening tests, startup validation of the new config keys, and doc/typo fixes. See the commit list for the full set.

---

Fixes #2429
Fixes #2467
