### PR TITLE
feature/sda-download Handle file download when file is present in multiple datasets

### DIFF
--- a/sda-download/api/middleware/middleware_test.go
+++ b/sda-download/api/middleware/middleware_test.go
@@ -235,7 +235,9 @@ func TestTokenMiddleware_Success_FromCache(t *testing.T) {
 
 	r.AddCookie(&http.Cookie{
 		Name:  "sda_session_key",
-		Value: "key",
+		Value: "key", Secure: true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	// Now that we are modifying the request context, we need to place the context test inside the handler

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -234,9 +235,17 @@ func Download(c *gin.Context) {
 	fileID := c.Param("fileid")
 
 	// Check user has permissions for this file (as part of a dataset)
-	dataset, err := database.CheckFilePermission(fileID)
+	datasetsAccessions, err := database.GetDatasetsContainingFile(fileID)
 	if err != nil {
-		c.String(http.StatusNotFound, "file not found")
+		if errors.Is(err, sql.ErrNoRows) {
+			log.Debugf("user requested to view file: %s, but file is not found or not present in any dataset", fileID)
+			c.String(http.StatusNotFound, "file not found")
+
+			return
+		}
+
+		log.Debugf("database error when checking datasets containing file: %s, error: %v", fileID, err)
+		c.String(http.StatusInternalServerError, "database error")
 
 		return
 	}
@@ -247,14 +256,19 @@ func Download(c *gin.Context) {
 	// Verify user has permission to datafile
 	permission := false
 	for d := range cache.Datasets {
-		if cache.Datasets[d] == dataset {
-			permission = true
+		for _, datasetAccession := range datasetsAccessions {
+			if cache.Datasets[d] == datasetAccession {
+				permission = true
 
+				break
+			}
+		}
+		if permission {
 			break
 		}
 	}
 	if !permission {
-		log.Debugf("user requested to view file, but does not have permissions for dataset %s", dataset)
+		log.Debugf("user requested to view file: %s, but does not have permissions for any dataset which contains file", fileID)
 		c.String(http.StatusUnauthorized, "unauthorised")
 
 		return

--- a/sda-download/api/sda/sda.go
+++ b/sda-download/api/sda/sda.go
@@ -238,13 +238,13 @@ func Download(c *gin.Context) {
 	datasetsAccessions, err := database.GetDatasetsContainingFile(fileID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			log.Debugf("user requested to view file: %s, but file is not found or not present in any dataset", fileID)
+			log.Debugf("user requested to view file: %s, but file is not found or not present in any dataset", sanitizeString(fileID))
 			c.String(http.StatusNotFound, "file not found")
 
 			return
 		}
 
-		log.Debugf("database error when checking datasets containing file: %s, error: %v", fileID, err)
+		log.Debugf("database error when checking datasets containing file: %s, error: %v", sanitizeString(fileID), err)
 		c.String(http.StatusInternalServerError, "database error")
 
 		return
@@ -268,7 +268,7 @@ func Download(c *gin.Context) {
 		}
 	}
 	if !permission {
-		log.Debugf("user requested to view file: %s, but does not have permissions for any dataset which contains file", fileID)
+		log.Debugf("user requested to view file: %s, but does not have permissions for any dataset which contains file", sanitizeString(fileID))
 		c.String(http.StatusUnauthorized, "unauthorised")
 
 		return

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -736,6 +736,289 @@ func (f *fakeGRPC) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Grpc-status", "0")
 }
 
+func TestDownload_FileInMultipleDatasets_NoPermission(t *testing.T) {
+	privateKeyFilePath, err := GenerateTestC4ghKey(t)
+	assert.NoError(t, err)
+
+	// Save original to-be-mocked functions
+	originalCheckFilePermission := database.GetDatasetsContainingFile
+	originalGetCacheFromContext := middleware.GetCacheFromContext
+	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
+	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
+
+	// Substitute mock functions
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset2", "dataset3", "dataset4"}, nil
+	}
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
+		return session.Cache{
+			Datasets: []string{"dataset1"},
+		}
+	}
+
+	viper.Set("c4gh.transientKeyPath", privateKeyFilePath)
+	viper.Set("c4gh.transientPassphrase", "password")
+	config.Config.C4GH.PrivateKey, config.Config.C4GH.PublicKeyB64, err = config.GetC4GHKeys()
+	assert.NoError(t, err, "Could not load c4gh keys")
+
+	// Mock request and response holders
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = &http.Request{Method: "GET"}
+	c.Request.Header = http.Header{"Client-Public-Key": []string{""}}
+
+	// Test the outcomes of the handler
+	Download(c)
+	response := w.Result()
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	expectedStatusCode := 401
+	expectedBody := []byte("unauthorised")
+
+	if response.StatusCode != expectedStatusCode {
+		t.Errorf("TestDownload_Fail_NoPermissions failed, got %d expected %d", response.StatusCode, expectedStatusCode)
+	}
+	if !bytes.Equal(body, []byte(expectedBody)) {
+		// visual byte comparison in terminal (easier to find string differences)
+		t.Error(body)
+		t.Error([]byte(expectedBody))
+		t.Errorf("TestDownload_Fail_NoPermissions failed, got %s expected %s", string(body), string(expectedBody))
+	}
+
+	// Return mock functions to originals
+	database.GetDatasetsContainingFile = originalCheckFilePermission
+	middleware.GetCacheFromContext = originalGetCacheFromContext
+	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
+	config.Config.C4GH.PrivateKey = originalC4ghPrivateKeyFilepath
+	viper.Set("c4gh.transientKeyPath", "")
+	viper.Set("c4gh.transientPassphrase", "")
+}
+
+func TestDownload_FileInMultipleDatasets(t *testing.T) {
+	privateKeyFilePath, err := GenerateTestC4ghKey(t)
+	assert.NoError(t, err)
+
+	// Save original to-be-mocked functions
+	originalCheckFilePermission := database.GetDatasetsContainingFile
+	originalGetCacheFromContext := middleware.GetCacheFromContext
+	originalGetFile := database.GetFile
+	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
+	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
+
+	tempDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tempDir, "config.yaml"), []byte(fmt.Sprintf(`
+storage:
+  archive:
+    posix:
+    - path: %s
+`, tempDir)), 0600); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetConfigType("yaml")
+	viper.SetConfigFile(filepath.Join(tempDir, "config.yaml"))
+
+	if err := viper.ReadInConfig(); err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	ArchiveReader, _ = storage.NewReader(context.TODO(), "archive")
+
+	// Fix to run fake GRPC server
+	faker := fakeGRPC{t: t}
+	server := httptest.NewUnstartedServer(&faker)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	// Figure out IP, port
+	serverdetails := strings.Split(server.Listener.Addr().String(), ":")
+
+	// Set up TLS for fake server
+	keyfile, err := os.CreateTemp("", "key")
+	assert.NoError(t, err, "Could not create temp file for key")
+	defer os.Remove(keyfile.Name())
+	privdata, err := x509.MarshalPKCS8PrivateKey(server.TLS.Certificates[0].PrivateKey)
+	assert.NoError(t, err, "Could not marshal private key")
+
+	privPEM := "-----BEGIN PRIVATE KEY-----\n" + base64.StdEncoding.EncodeToString(privdata) + "\n-----END PRIVATE KEY-----\n"
+	_, err = keyfile.Write([]byte(privPEM))
+	assert.NoError(t, err, "Could not write private key")
+	_ = keyfile.Close()
+
+	certfile, err := os.CreateTemp("", "cert")
+	assert.NoError(t, err, "Could not create temp file for cert")
+	defer os.Remove(certfile.Name())
+	pubPEM := "-----BEGIN CERTIFICATE-----\n" + base64.StdEncoding.EncodeToString(server.Certificate().Raw) + "\n-----END CERTIFICATE-----\n"
+	_, err = certfile.Write([]byte(pubPEM))
+	assert.NoError(t, err, "Could not write public key")
+	_ = certfile.Close()
+
+	// Configure Reencrypt to use fake server
+	config.Config.Reencrypt.Host = serverdetails[0]
+	port, _ := strconv.ParseInt(serverdetails[1], 10, 32)
+	config.Config.Reencrypt.Port = int(port)
+	config.Config.Reencrypt.CACert = certfile.Name()
+	config.Config.Reencrypt.ClientCert = certfile.Name()
+	config.Config.Reencrypt.ClientKey = keyfile.Name()
+	config.Config.Reencrypt.Timeout = 10
+
+	viper.Set("c4gh.transientKeyPath", privateKeyFilePath)
+	viper.Set("c4gh.transientPassphrase", "password")
+	config.Config.C4GH.PrivateKey, config.Config.C4GH.PublicKeyB64, err = config.GetC4GHKeys()
+	assert.NoError(t, err, "Could not load c4gh keys")
+
+	// Make a file to hold the archive file
+	datafile, err := os.Create(filepath.Join(tempDir, "datafile.txt"))
+	assert.NoError(t, err, "Could not create datafile for test")
+	datafileName := datafile.Name()
+	defer os.Remove(datafileName)
+
+	tempKey, err := base64.StdEncoding.DecodeString(config.Config.C4GH.PublicKeyB64)
+	assert.NoError(t, err, "Could not decode public key envelope")
+
+	// Decode public key
+	pubKeyReader := bytes.NewReader(tempKey)
+	publicKey, err := keys.ReadPublicKey(pubKeyReader)
+	assert.NoError(t, err, "Could not decode public key")
+
+	// Reader list for archive file
+	readerPublicKeyList := [][chacha20poly1305.KeySize]byte{}
+	readerPublicKeyList = append(readerPublicKeyList, [32]byte(publicKey))
+	faker.pubkey = [32]byte(publicKey)
+
+	bufferWriter := bytes.Buffer{}
+	dataWriter, err := streaming.NewCrypt4GHWriter(&bufferWriter, config.Config.C4GH.PrivateKey, readerPublicKeyList, nil)
+	assert.NoError(t, err, "Could not make crypt4gh writer for test")
+
+	// Write some data to the file
+	for i := 0; i < 1000; i++ {
+		_, err = dataWriter.Write([]byte("data"))
+		assert.NoError(t, err, "Could not write to crypt4gh writer for test")
+	}
+	dataWriter.Close()
+
+	// We have now written a crypt4gh to our buffer, prepare it for use
+	// by separating out the header and write the rest to the file
+
+	headerBytes, err := headers.ReadHeader(&bufferWriter)
+	assert.NoError(t, err, "Could not get header")
+
+	_, err = io.Copy(datafile, &bufferWriter)
+	assert.NoError(t, err, "Could not write temporary file")
+	_ = datafile.Close()
+
+	// Substitute mock functions
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset2", "dataset3", "dataset1"}, nil
+	}
+	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
+		return session.Cache{
+			Datasets: []string{"dataset1"},
+		}
+	}
+	database.GetFile = func(_ string) (*database.FileDownload, error) {
+		fileDetails := &database.FileDownload{
+			ArchivePath:     strings.TrimPrefix(datafileName, tempDir+"/"),
+			ArchiveSize:     0,
+			ArchiveLocation: tempDir,
+			Header:          headerBytes,
+		}
+
+		return fileDetails, nil
+	}
+
+	// Test download, should work and return the whole file
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = &http.Request{Method: "GET", URL: &url.URL{}}
+
+	Download(c)
+	response := w.Result()
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+
+	assert.Equal(t, 200, response.StatusCode, "Unexpected status code from download")
+	// We only check
+	assert.Equal(t, []byte(strings.Repeat("data", 1000)), body, "Unexpected body from download")
+
+	// Test download with specified coordinates, should return a small bit of the file
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = &http.Request{Method: "GET", URL: &url.URL{Path: "/somepath", RawQuery: "startCoordinate=5&endCoordinate=10"}}
+	// Test the outcomes of the handler
+	Download(c)
+	response = w.Result()
+	defer response.Body.Close()
+	body, _ = io.ReadAll(response.Body)
+
+	assert.Equal(t, 200, response.StatusCode, "Unexpected status code from download")
+	assert.Equal(t, []byte("atada"), body, "Unexpected body from download")
+
+	// Test encrypted download, should work and give output that is crypt4gh
+	// encrypted
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = &http.Request{Method: "GET", URL: &url.URL{Path: "/mocks3/somepath", RawQuery: "filename=somepath"}}
+	c.Request.Header = http.Header{"Client-Public-Key": []string{config.Config.C4GH.PublicKeyB64},
+		"Range": []string{"bytes=0-10"}}
+
+	c.Params = make(gin.Params, 1)
+	c.Params[0] = gin.Param{Key: "type", Value: "encrypted"}
+
+	Download(c)
+	response = w.Result()
+	defer response.Body.Close()
+	body, _ = io.ReadAll(response.Body)
+
+	assert.Equal(t, 200, response.StatusCode, "Unexpected status code from download")
+	assert.Equal(t, []byte("crypt4gh"), body[:8], "Unexpected body from download")
+
+	// Test encrypted download, should work even when AllowedUnencryptedDownload is false
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = &http.Request{Method: "GET", URL: &url.URL{Path: "/mocks3/somepath", RawQuery: "filename=somepath"}}
+	c.Request.Header = http.Header{"Client-Public-Key": []string{config.Config.C4GH.PublicKeyB64},
+		"Range": []string{"bytes=0-10"}}
+
+	c.Params = make(gin.Params, 1)
+	c.Params[0] = gin.Param{Key: "type", Value: "encrypted"}
+
+	Download(c)
+	response = w.Result()
+	defer response.Body.Close()
+	body, _ = io.ReadAll(response.Body)
+
+	assert.Equal(t, 200, response.StatusCode, "Unexpected status code from download")
+	assert.Equal(t, []byte("crypt4gh"), body[:8], "Unexpected body from download")
+
+	// Test encrypted download without passing the key, should fail
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = &http.Request{Method: "GET", URL: &url.URL{Path: "/mocks3/somepath", RawQuery: "filename=somepath"}}
+	c.Params = make(gin.Params, 1)
+	c.Params[0] = gin.Param{Key: "type", Value: "encrypted"}
+
+	Download(c)
+	response = w.Result()
+	defer response.Body.Close()
+	body, _ = io.ReadAll(response.Body)
+
+	assert.Equal(t, 400, response.StatusCode, "Unexpected status code from download")
+	assert.Equal(t, []byte("c4gh pub"), body[:8], "Unexpected body from download")
+
+	// Return mock functions to originals
+	database.GetDatasetsContainingFile = originalCheckFilePermission
+	middleware.GetCacheFromContext = originalGetCacheFromContext
+	database.GetFile = originalGetFile
+	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
+	config.Config.C4GH.PrivateKey = originalC4ghPrivateKeyFilepath
+	viper.Set("c4gh.transientKeyPath", "")
+	viper.Set("c4gh.transientPassphrase", "")
+}
+
 func TestDownload_Whole_Range_Encrypted(t *testing.T) {
 	privateKeyFilePath, err := GenerateTestC4ghKey(t)
 	assert.NoError(t, err)

--- a/sda-download/api/sda/sda_test.go
+++ b/sda-download/api/sda/sda_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"database/sql"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -380,13 +381,13 @@ func TestDownload_Fail_FileNotFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Save original to-be-mocked functions and config
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
 	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "", errors.New("file not found")
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return nil, sql.ErrNoRows
 	}
 
 	viper.Set("c4gh.transientKeyPath", privateKeyFilePath)
@@ -419,7 +420,7 @@ func TestDownload_Fail_FileNotFound(t *testing.T) {
 	}
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
 	config.Config.C4GH.PrivateKey = originalC4ghPrivateKeyFilepath
 	viper.Set("c4gh.transientKeyPath", "")
@@ -431,15 +432,15 @@ func TestDownload_Fail_NoPermissions(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Save original to-be-mocked functions
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
 	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
 		// nolint:goconst
-		return "dataset1", nil
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{}
@@ -475,7 +476,7 @@ func TestDownload_Fail_NoPermissions(t *testing.T) {
 	}
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
 	config.Config.C4GH.PrivateKey = originalC4ghPrivateKeyFilepath
@@ -488,15 +489,15 @@ func TestDownload_Fail_GetFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Save original to-be-mocked functions
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
 	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -537,7 +538,7 @@ func TestDownload_Fail_GetFile(t *testing.T) {
 	}
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
@@ -551,7 +552,7 @@ func TestDownload_Fail_OpenFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Save original to-be-mocked functions
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
@@ -579,8 +580,8 @@ storage:
 	ArchiveReader, _ = storage.NewReader(context.Background(), "archive")
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -631,7 +632,7 @@ storage:
 	}
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
@@ -740,7 +741,7 @@ func TestDownload_Whole_Range_Encrypted(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Save original to-be-mocked functions
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
@@ -852,8 +853,8 @@ storage:
 	_ = datafile.Close()
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -951,7 +952,7 @@ storage:
 	assert.Equal(t, []byte("c4gh pub"), body[:8], "Unexpected body from download")
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
@@ -983,13 +984,13 @@ func GenerateTestC4ghKey(t *testing.T) (string, error) {
 }
 
 func TestDownload_InvalidRange_NoEnd(t *testing.T) {
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -1028,18 +1029,18 @@ func TestDownload_InvalidRange_NoEnd(t *testing.T) {
 	assert.Contains(t, string(body), "Range header byte coordinates invalid")
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 }
 func TestDownload_InvalidRange_NoStart(t *testing.T) {
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -1078,19 +1079,19 @@ func TestDownload_InvalidRange_NoStart(t *testing.T) {
 	assert.Contains(t, string(body), "Range header byte coordinates invalid")
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 }
 
 func TestDownload_ArchiveLocationUnset(t *testing.T) {
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -1126,19 +1127,19 @@ func TestDownload_ArchiveLocationUnset(t *testing.T) {
 	assert.Contains(t, string(body), "archive location not known")
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 }
 
 func TestDownload_InvalidRange_NegativeStart(t *testing.T) {
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -1176,21 +1177,21 @@ func TestDownload_InvalidRange_NegativeStart(t *testing.T) {
 	assert.Contains(t, string(body), "Range header byte coordinates invalid")
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 }
 
 func TestDownload_Range_FromStartOfFile(t *testing.T) {
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
 	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -1281,7 +1282,7 @@ func TestDownload_Range_FromStartOfFile(t *testing.T) {
 	assert.Equal(t, "mock header;this", string(body))
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger
@@ -1292,15 +1293,15 @@ func TestDownload_Range_FromStartOfFile(t *testing.T) {
 }
 
 func TestDownload_Range_FromMiddleOfFile(t *testing.T) {
-	originalCheckFilePermission := database.CheckFilePermission
+	originalCheckFilePermission := database.GetDatasetsContainingFile
 	originalGetCacheFromContext := middleware.GetCacheFromContext
 	originalGetFile := database.GetFile
 	originalServeUnencryptedDataTrigger := config.Config.C4GH.PublicKeyB64
 	originalC4ghPrivateKeyFilepath := config.Config.C4GH.PrivateKey
 
 	// Substitute mock functions
-	database.CheckFilePermission = func(_ string) (string, error) {
-		return "dataset1", nil
+	database.GetDatasetsContainingFile = func(_ string) ([]string, error) {
+		return []string{"dataset1"}, nil
 	}
 	middleware.GetCacheFromContext = func(_ *gin.Context) session.Cache {
 		return session.Cache{
@@ -1391,7 +1392,7 @@ func TestDownload_Range_FromMiddleOfFile(t *testing.T) {
 	assert.Equal(t, "this is a mock", string(body))
 
 	// Return mock functions to originals
-	database.CheckFilePermission = originalCheckFilePermission
+	database.GetDatasetsContainingFile = originalCheckFilePermission
 	middleware.GetCacheFromContext = originalGetCacheFromContext
 	database.GetFile = originalGetFile
 	config.Config.C4GH.PublicKeyB64 = originalServeUnencryptedDataTrigger

--- a/sda-download/internal/config/config.go
+++ b/sda-download/internal/config/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/neicnordic/crypt4gh/keys"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 )
 
 const POSIX = "posix"
@@ -349,10 +348,16 @@ func (c *Map) appConfig() error {
 		log.Infoln("Internal c4gh key-pair loaded")
 	}
 
-	if !slices.Contains(availableMiddlewares, c.App.Middleware) {
-		err := fmt.Errorf("app.middleware value=%v is not one of allowed values=%v", c.App.Middleware, availableMiddlewares)
+	validMiddleware := false
+	for _, availableMiddleware := range availableMiddlewares {
+		if c.App.Middleware == availableMiddleware {
+			validMiddleware = true
 
-		return err
+			break
+		}
+	}
+	if !validMiddleware {
+		return fmt.Errorf("app.middleware value=%v is not one of allowed values=%v", c.App.Middleware, availableMiddlewares)
 	}
 
 	return nil

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -360,16 +360,16 @@ FROM sda.files
 	return fileStableID, nil
 }
 
-// CheckFilePermission checks if user has permissions to access the dataset the file is a part of
-var CheckFilePermission = func(fileID string) (string, error) {
+// GetDatasetsContainingFile returns the accession ids of all datasets which contains the file
+var GetDatasetsContainingFile = func(fileID string) ([]string, error) {
 	var (
-		r           = ""
+		r     []string
 		err   error = nil
 		count       = 0
 	)
 
 	for count < dbRetryTimes {
-		r, err = DB.checkFilePermission(fileID)
+		r, err = DB.getDatasetsContainingFile(fileID)
 		if err != nil {
 			count++
 
@@ -382,8 +382,8 @@ var CheckFilePermission = func(fileID string) (string, error) {
 	return r, err
 }
 
-// checkFilePermission is the actual function performing work for CheckFilePermission
-func (dbs *SQLdb) checkFilePermission(fileID string) (string, error) {
+// getDatasetsContainingFile is the actual function performing work for GetDatasetsContainingFile
+func (dbs *SQLdb) getDatasetsContainingFile(fileID string) ([]string, error) {
 	dbs.checkAndReconnectIfNeeded()
 
 	log.Debugf("check permissions for file with %s", sanitizeString(fileID))
@@ -396,14 +396,36 @@ func (dbs *SQLdb) checkFilePermission(fileID string) (string, error) {
 		WHERE files.stable_id = $1;
 	`
 
-	var datasetName string
-	if err := db.QueryRow(query, fileID).Scan(&datasetName); err != nil {
-		log.Errorf("requested file with %s does not exist", sanitizeString(fileID))
+	var datasetAccessions []string
 
-		return "", err
+	rows, err := db.Query(query, fileID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	for rows.Next() {
+		var datasetAccession string
+
+		if err := rows.Scan(&datasetAccession); err != nil {
+			log.Errorf("requested file with %s does not exist", sanitizeString(fileID))
+
+			return nil, err
+		}
+
+		datasetAccessions = append(datasetAccessions, datasetAccession)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
-	return datasetName, nil
+	if len(datasetAccessions) == 0 {
+		return nil, sql.ErrNoRows
+	}
+
+	return datasetAccessions, nil
 }
 
 // FileDownload details are used for downloading a file

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -370,7 +370,7 @@ var GetDatasetsContainingFile = func(fileID string) ([]string, error) {
 
 	for count < dbRetryTimes {
 		r, err = DB.getDatasetsContainingFile(fileID)
-		if err != nil {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			count++
 
 			continue
@@ -410,8 +410,6 @@ func (dbs *SQLdb) getDatasetsContainingFile(fileID string) ([]string, error) {
 		var datasetAccession string
 
 		if err := rows.Scan(&datasetAccession); err != nil {
-			log.Errorf("requested file with %s does not exist", sanitizeString(fileID))
-
 			return nil, err
 		}
 

--- a/sda-download/internal/database/database_test.go
+++ b/sda-download/internal/database/database_test.go
@@ -193,7 +193,7 @@ func TestClose(t *testing.T) {
 	assert.Nil(t, r, "Close failed unexpectedly")
 }
 
-func TestCheckFilePermission(t *testing.T) {
+func TestGetDatasetsContainingFile(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 		expected := []string{"dataset1"}
 		query := `
@@ -208,7 +208,7 @@ func TestCheckFilePermission(t *testing.T) {
 
 		x, err := testDb.getDatasetsContainingFile("file1")
 
-		assert.Equal(t, expected, x, "did not get expected permission")
+		assert.Equal(t, expected, x, "did not get expected datasets")
 
 		return err
 	})

--- a/sda-download/internal/database/database_test.go
+++ b/sda-download/internal/database/database_test.go
@@ -195,7 +195,7 @@ func TestClose(t *testing.T) {
 
 func TestCheckFilePermission(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
-		expected := "dataset1"
+		expected := []string{"dataset1"}
 		query := `
 			SELECT datasets.stable_id FROM sda.file_dataset
 			JOIN sda.datasets ON dataset_id = datasets.id
@@ -206,7 +206,7 @@ func TestCheckFilePermission(t *testing.T) {
 			WithArgs("file1").
 			WillReturnRows(sqlmock.NewRows([]string{"dataset_id"}).AddRow("dataset1"))
 
-		x, err := testDb.checkFilePermission("file1")
+		x, err := testDb.getDatasetsContainingFile("file1")
 
 		assert.Equal(t, expected, x, "did not get expected permission")
 

--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the sda-api `dataset/create` API to not reject requests if the requested files belong to different users.
 - Updated [sda api swagger_v1.yml](cmd/api/swagger_v1.yml) to not specify user in the DatasetCreate as it is no longer needed.
-- Updated sda-download to handle file downloads when a file exists in multiple datasets, allows file download if user has a visa for at least one dataset the file is present in
+- Updated sda-download to handle file downloads when a file exists in multiple datasets. Allows file download if user has a visa for at least one dataset the file is present in.
 
 ## [3.1.73] - 2026-06-16
 

--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the sda-api `dataset/create` API to not reject requests if the requested files belong to different users.
 - Updated [sda api swagger_v1.yml](cmd/api/swagger_v1.yml) to not specify user in the DatasetCreate as it is no longer needed.
+- Updated sda-download to handle file downloads when a file exists in multiple datasets, allows file download if user has a visa for at least one dataset the file is present in
 
 ## [3.1.73] - 2026-06-16
 


### PR DESCRIPTION
# Related issue(s) and PR(s)
This PR closes #2498.


# Description
handle file downloads when a file exists in multiple datasets, allows file download if user has a visa for at least one dataset the file is present in

# How to test
- Unit test pass
