### PR TITLE
feat(sda): Added functionality to override the exposed download path for a file within a dataset (with 3.1.76 bump)

### DIFF
--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -38,7 +38,8 @@ VALUES (0, now(), 'Created with version'),
        (21, now(), 'Drop functions set_verified, and set_archived'),
        (22, now(), 'Add file_headers_backup table for key rotation safekeeping'),
        (23, now(), 'Expand files table with storage locations'),
-       (24, now(), 'Add last_event column to files to avoid join on file_event_log');
+       (24, now(), 'Add last_event column to files to avoid join on file_event_log'),
+       (25, now(), 'Add download_path column to file_dataset to allow overriding the file submission_file_path during downloading');
 
 -- Datasets are used to group files, and permissions are set on the dataset
 -- level
@@ -162,6 +163,7 @@ CREATE TABLE file_dataset (
     id                  SERIAL PRIMARY KEY,
     file_id             UUID REFERENCES files(id) NOT NULL,
     dataset_id          INT REFERENCES datasets(id) NOT NULL,
+    download_path       TEXT,
     CONSTRAINT unique_file_dataset UNIQUE(file_id, dataset_id)
 );
 

--- a/postgresql/initdb.d/01_main.sql
+++ b/postgresql/initdb.d/01_main.sql
@@ -164,7 +164,8 @@ CREATE TABLE file_dataset (
     file_id             UUID REFERENCES files(id) NOT NULL,
     dataset_id          INT REFERENCES datasets(id) NOT NULL,
     download_path       TEXT,
-    CONSTRAINT unique_file_dataset UNIQUE(file_id, dataset_id)
+    CONSTRAINT unique_file_dataset UNIQUE(file_id, dataset_id),
+    CONSTRAINT file_dataset_unique_download_path_dataset_idx UNIQUE (dataset_id, download_path)
 );
 
 -- Keeps track of all events for the files, with timestamps and user_ids.

--- a/postgresql/migratedb.d/25_add_download_path_column_to_file_dataset.sql
+++ b/postgresql/migratedb.d/25_add_download_path_column_to_file_dataset.sql
@@ -1,0 +1,21 @@
+
+DO
+$$
+DECLARE
+-- The version we know how to do migration from, at the end of a successful migration
+-- we will no longer be at this version.
+  sourcever INTEGER := 24;
+  changes VARCHAR := 'Add download_path column to file_dataset to allow overriding the file submission_file_path during downloading';
+BEGIN
+  IF (select max(version) from sda.dbschema_version) = sourcever then
+    RAISE NOTICE 'Doing migration from schema version % to %', sourcever, sourcever+1;
+    RAISE NOTICE 'Changes: %', changes;
+    INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
+
+    ALTER TABLE sda.file_dataset ADD COLUMN download_path TEXT;
+
+  ELSE
+    RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;
+  END IF;
+END
+$$

--- a/postgresql/migratedb.d/25_add_download_path_column_to_file_dataset.sql
+++ b/postgresql/migratedb.d/25_add_download_path_column_to_file_dataset.sql
@@ -12,7 +12,9 @@ BEGIN
     RAISE NOTICE 'Changes: %', changes;
     INSERT INTO sda.dbschema_version VALUES(sourcever+1, now(), changes);
 
-    ALTER TABLE sda.file_dataset ADD COLUMN download_path TEXT;
+    ALTER TABLE sda.file_dataset
+      ADD COLUMN download_path TEXT,
+      ADD CONSTRAINT file_dataset_unique_download_path_dataset_idx UNIQUE (dataset_id, download_path);
 
   ELSE
     RAISE NOTICE 'Schema migration from % to % does not apply now, skipping', sourcever, sourcever+1;

--- a/sda-download/api/s3/s3_test.go
+++ b/sda-download/api/s3/s3_test.go
@@ -92,7 +92,7 @@ func (ts *S3TestSuite) TestListByPrefix() {
 
 	query := `
 SELECT files.stable_id AS id,
-	reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
+	reverse\(split_part\(reverse\(COALESCE\(file_dataset.download_path, files.submission_file_path\)::text\), '/'::text, 1\)\) AS display_file_name,
 	files.submission_user AS user_id,
 	COALESCE\(file_dataset.download_path, files.submission_file_path\) AS file_path,
 	files.decrypted_file_size,
@@ -157,7 +157,7 @@ func (ts *S3TestSuite) TestListObjects() {
 
 	query := `
 SELECT files.stable_id AS id,
-	reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
+	reverse\(split_part\(reverse\(COALESCE\(file_dataset.download_path, files.submission_file_path\)::text\), '/'::text, 1\)\) AS display_file_name,
 	files.submission_user AS user_id,
 	COALESCE\(file_dataset.download_path, files.submission_file_path\) AS file_path,
 	files.decrypted_file_size,

--- a/sda-download/api/s3/s3_test.go
+++ b/sda-download/api/s3/s3_test.go
@@ -94,7 +94,7 @@ func (ts *S3TestSuite) TestListByPrefix() {
 SELECT files.stable_id AS id,
 	reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
 	files.submission_user AS user_id,
-	files.submission_file_path AS file_path,
+	COALESCE\(file_dataset.download_path, files.submission_file_path\) AS file_path,
 	files.decrypted_file_size,
 	sha_unenc.checksum AS decrypted_file_checksum,
 	sha_unenc.type AS decrypted_file_checksum_type
@@ -159,7 +159,7 @@ func (ts *S3TestSuite) TestListObjects() {
 SELECT files.stable_id AS id,
 	reverse\(split_part\(reverse\(files.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
 	files.submission_user AS user_id,
-	files.submission_file_path AS file_path,
+	COALESCE\(file_dataset.download_path, files.submission_file_path\) AS file_path,
 	files.decrypted_file_size,
 	sha_unenc.checksum AS decrypted_file_checksum,
 	sha_unenc.type AS decrypted_file_checksum_type

--- a/sda-download/cmd/main.go
+++ b/sda-download/cmd/main.go
@@ -32,8 +32,8 @@ func init() {
 	if err != nil {
 		log.Panicf("database connection failed, reason: %v", err)
 	}
-	if db.Version < 23 {
-		log.Panic("database schema v23 is required")
+	if db.Version < 25 {
+		log.Panic("database schema v25 is required")
 	}
 	database.DB = db
 

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -190,7 +190,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 SELECT files.stable_id AS id,
 	reverse(split_part(reverse(files.submission_file_path::text), '/'::text, 1)) AS display_file_name,
 	files.submission_user AS user_id,
-	files.submission_file_path AS file_path,
+	COALESCE(file_dataset.download_path, files.submission_file_path) AS file_path,
 	files.decrypted_file_size,
 	sha_unenc.checksum AS decrypted_file_checksum,
 	sha_unenc.type AS decrypted_file_checksum_type

--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -188,7 +188,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 
 	const query = `
 SELECT files.stable_id AS id,
-	reverse(split_part(reverse(files.submission_file_path::text), '/'::text, 1)) AS display_file_name,
+	reverse(split_part(reverse(COALESCE(file_dataset.download_path, files.submission_file_path)::text), '/'::text, 1)) AS display_file_name,
 	files.submission_user AS user_id,
 	COALESCE(file_dataset.download_path, files.submission_file_path) AS file_path,
 	files.decrypted_file_size,

--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.76] - 2026-07-15
+
+### Added
+
+- Added functionality to override the exposed download path for a file within a dataset
+  - The file download path for a file in a dataset is set during the dataset creation(ie when a file is added to a dataset)
+  - The download and download-v2 services will default to the submission file path if file download path is not set for a dataset
+  - Updated [sda api swagger_v1.yml](cmd/api/swagger_v1.yml) DatasetCreate to allow caller to override the file download path in a dataset by the file accession
+  - Updated [dataset-mapping schema](schemas/isolated/dataset-mapping.json) to allow propagation of the file download path per file accession
+  - Added [new column to file_dataset table and bumped schema version to 25](../postgresql/migratedb.d/25_add_download_path_column_to_file_dataset.sql)
+
 ## [3.1.75] - 2026-07-08
 
 ### Added

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -30,8 +30,9 @@ import (
 )
 
 type dataset struct {
-	AccessionIDs []string `json:"accession_ids"`
-	DatasetID    string   `json:"dataset_id"`
+	AccessionIDs      []string          `json:"accession_ids"`
+	DatasetID         string            `json:"dataset_id"`
+	FileDownloadPaths map[string]string `json:"file_download_paths,omitempty"`
 }
 
 type API struct {

--- a/sda/cmd/api/handlers.go
+++ b/sda/cmd/api/handlers.go
@@ -658,7 +658,12 @@ func (api *API) createDataset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate that the files to have overridden download paths are added to the dataset in the same request
-	for accessionToSetDownloadPath := range dataset.FileDownloadPaths {
+	for accessionToSetDownloadPath, downloadPath := range dataset.FileDownloadPaths {
+		if downloadPath == "" {
+			writeJSON(w, http.StatusBadRequest, "download path for a file can not be empty")
+
+			return
+		}
 		found := false
 		for _, accessionToAddToDataset := range dataset.AccessionIDs {
 			if accessionToSetDownloadPath == accessionToAddToDataset {

--- a/sda/cmd/api/handlers.go
+++ b/sda/cmd/api/handlers.go
@@ -110,22 +110,26 @@ func (api *API) loggingMiddleware(next http.Handler) http.Handler {
 func (api *API) readinessResponse(w http.ResponseWriter, r *http.Request) {
 	if !api.mq.Alive() {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("unable to reach rabbitmq"))
+		_, _ = w.Write([]byte("unable to reach rabbitmq"))
+
+		return
 	}
 
 	if err := api.db.Ping(context.Background()); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("unable to reach database"))
+		_, _ = w.Write([]byte("unable to reach database"))
+
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	_ = json.NewEncoder(w).Encode(v)
 }
 
 // parseLimitParam parses and validates the optional "limit" query parameter.
@@ -202,7 +206,7 @@ func (api *API) getFiles(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(rsp)
+	_ = json.NewEncoder(w).Encode(rsp)
 }
 
 func (api *API) updateFileEvent(w http.ResponseWriter, r *http.Request) {
@@ -289,7 +293,7 @@ func (api *API) getFileEvents(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string][]database.FileStatus{"events": statusHistory})
+	_ = json.NewEncoder(w).Encode(map[string][]database.FileStatus{"events": statusHistory})
 }
 
 /*
@@ -653,6 +657,24 @@ func (api *API) createDataset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate that the files to have overridden download paths are added to the dataset in the same request
+	for accessionToSetDownloadPath := range dataset.FileDownloadPaths {
+		found := false
+		for _, accessionToAddToDataset := range dataset.AccessionIDs {
+			if accessionToSetDownloadPath == accessionToAddToDataset {
+				found = true
+
+				break
+			}
+		}
+		if !found {
+			slog.Error("attempted to set file download path for a file not being added to the dataset")
+			writeJSON(w, http.StatusBadRequest, "attempted to set file download path for a file not being added to the dataset")
+
+			return
+		}
+	}
+
 	// Check that the files the accession ids are linked to belong to the user of the dataset
 	for _, accessionID := range dataset.AccessionIDs {
 		md, err := api.db.GetMappingData(r.Context(), accessionID)
@@ -665,13 +687,16 @@ func (api *API) createDataset(w http.ResponseWriter, r *http.Request) {
 		if md == nil {
 			slog.Info("rejecting create dataset request including non-existing id", "accession_id", accessionID)
 			writeJSON(w, http.StatusBadRequest, fmt.Sprintf("no file exists with accession: %s", accessionID))
+
+			return
 		}
 	}
 
 	mapping := schema.DatasetMapping{
-		Type:         "mapping",
-		AccessionIDs: dataset.AccessionIDs,
-		DatasetID:    dataset.DatasetID,
+		Type:              "mapping",
+		AccessionIDs:      dataset.AccessionIDs,
+		DatasetID:         dataset.DatasetID,
+		FileDownloadPaths: dataset.FileDownloadPaths,
 	}
 	marshaledMsg, _ := json.Marshal(&mapping)
 	if err := schema.ValidateJSON(fmt.Sprintf("%s/dataset-mapping.json", apiconfig.SchemaPath()), marshaledMsg); err != nil {
@@ -866,7 +891,7 @@ func (api *API) listActiveUsers(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string][]string{"users": users})
+	_ = json.NewEncoder(w).Encode(map[string][]string{"users": users})
 }
 
 func (api *API) listUserFiles(w http.ResponseWriter, r *http.Request) {
@@ -914,7 +939,7 @@ func (api *API) listUserFiles(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(rsp)
+	_ = json.NewEncoder(w).Encode(rsp)
 }
 
 // addC4ghHash handles the addition of a hashed public key to the database.
@@ -998,7 +1023,7 @@ func (api *API) listC4ghHashes(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(rsp)
+	_ = json.NewEncoder(w).Encode(rsp)
 }
 
 func (api *API) deprecateC4ghHash(w http.ResponseWriter, r *http.Request) {
@@ -1033,7 +1058,7 @@ func (api *API) listAllDatasets(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(rsp)
+	_ = json.NewEncoder(w).Encode(rsp)
 }
 
 func (api *API) listUserDatasets(w http.ResponseWriter, r *http.Request) {
@@ -1058,7 +1083,7 @@ func (api *API) listUserDatasets(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(rsp)
+	_ = json.NewEncoder(w).Encode(rsp)
 }
 
 func (api *API) listDatasets(w http.ResponseWriter, r *http.Request) {
@@ -1090,7 +1115,7 @@ func (api *API) listDatasets(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(rsp)
+	_ = json.NewEncoder(w).Encode(rsp)
 }
 
 func (api *API) verifyFile(w http.ResponseWriter, r *http.Request) {

--- a/sda/cmd/api/swagger_v1.yml
+++ b/sda/cmd/api/swagger_v1.yml
@@ -526,6 +526,11 @@ components:
         dataset_id:
           type: string
           example: zz-dataset-123456-asdfgh
+        file_download_paths:
+          type: object
+          additionalProperties:
+            type: string
+          example: {"zz-file-123456-asdfgh": "dataset1/files/zz-file-123456-asdfgh_file.c4gh", "zz-file-123456-qwerty": "dataset1/files/zz-file-123456-qwerty_file.c4gh"}
     DatasetInfo:
       type: object
       properties:

--- a/sda/cmd/download/database/database.go
+++ b/sda/cmd/download/database/database.go
@@ -35,7 +35,7 @@ const (
 // paginatedFileBase is the shared SELECT+JOIN+LATERAL block for keyset-paginated
 // dataset file queries. Each variant appends its own WHERE filter and LIMIT clause.
 const paginatedFileBase = `
-		SELECT f.stable_id, f.submission_file_path, f.archive_file_size,
+		SELECT f.stable_id, COALESCE(fd.download_path, f.submission_file_path), f.archive_file_size,
 		       f.decrypted_file_size, cs.checksums
 		FROM sda.files f
 		INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
@@ -90,7 +90,7 @@ var queries = map[string]string{
 		SELECT
 			f.stable_id,
 			d.stable_id as dataset_id,
-			f.submission_file_path,
+			COALESCE(fd.download_path, f.submission_file_path),
 			f.archive_file_path,
 			f.archive_location,
 			f.archive_file_size,
@@ -109,7 +109,7 @@ var queries = map[string]string{
 		SELECT
 			f.stable_id,
 			d.stable_id as dataset_id,
-			f.submission_file_path,
+			COALESCE(fd.download_path, f.submission_file_path),
 			f.archive_file_path,
 			f.archive_location,
 			f.archive_file_size,
@@ -122,7 +122,7 @@ var queries = map[string]string{
 		INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
 		INNER JOIN sda.datasets d ON fd.dataset_id = d.id
 		LEFT JOIN sda.checksums c ON f.id = c.file_id AND c.source = 'UNENCRYPTED'
-		WHERE d.stable_id = $1 AND f.submission_file_path = $2`,
+		WHERE d.stable_id = $1 AND COALESCE(fd.download_path, f.submission_file_path) = $2`,
 
 	// checkFilePermission verifies user has access to the file's dataset
 	// by checking if the dataset stable_id is in the user's visas
@@ -153,23 +153,23 @@ var queries = map[string]string{
 	// Keyset-paginated file queries compose from paginatedFileBase (defined below).
 
 	// getDatasetFilesPage returns paginated files in a dataset (no path filter).
-	// Keyset cursor on (submission_file_path, stable_id). $2='' means first page.
+	// Keyset cursor on (COALESCE(fd.download_path, f.submission_file_path), stable_id). $2='' means first page.
 	getDatasetFilesPageQuery: paginatedFileBase + `
-		  AND ($2 = '' OR (f.submission_file_path, f.stable_id) > ($2, $3))
-		ORDER BY f.submission_file_path, f.stable_id
+		  AND ($2 = '' OR (COALESCE(fd.download_path, f.submission_file_path), f.stable_id) > ($2, $3))
+		ORDER BY COALESCE(fd.download_path, f.submission_file_path), f.stable_id
 		LIMIT $4`,
 
 	// getDatasetFilesPageByPath returns a file by exact path (at most 1 result).
 	getDatasetFilesPageByPathQuery: paginatedFileBase + `
-		  AND f.submission_file_path = $2
+		  AND COALESCE(fd.download_path, f.submission_file_path) = $2
 		LIMIT $3`,
 
 	// getDatasetFilesPageByPrefix returns paginated files matching a path prefix.
-	// Keyset cursor on (submission_file_path, stable_id). $3='' means first page.
+	// Keyset cursor on (COALESCE(fd.download_path, f.submission_file_path), stable_id). $3='' means first page.
 	getDatasetFilesPageByPrefixQuery: paginatedFileBase + `
-		  AND f.submission_file_path LIKE $2 ESCAPE '\'
-		  AND ($3 = '' OR (f.submission_file_path, f.stable_id) > ($3, $4))
-		ORDER BY f.submission_file_path, f.stable_id
+		  AND COALESCE(fd.download_path, f.submission_file_path) LIKE $2 ESCAPE '\'
+		  AND ($3 = '' OR (COALESCE(fd.download_path, f.submission_file_path), f.stable_id) > ($3, $4))
+		ORDER BY COALESCE(fd.download_path, f.submission_file_path), f.stable_id
 		LIMIT $5`,
 }
 
@@ -184,7 +184,7 @@ type FileListOptions struct {
 	FilePath   string // exact match (mutually exclusive with PathPrefix)
 	PathPrefix string // prefix match
 	Limit      int    // pageSize + 1 (fetch one extra to detect next page)
-	CursorPath string // last-seen submission_file_path ("" for first page)
+	CursorPath string // last-seen submission_file_path(or file_dataset.download_path is populated) ("" for first page)
 	CursorID   string // tie-breaker: last-seen stable_id ("" for first page)
 }
 

--- a/sda/cmd/download/database/database.go
+++ b/sda/cmd/download/database/database.go
@@ -51,126 +51,117 @@ const paginatedFileBase = `
 // These are prepared at startup to verify correctness and improve performance.
 var queries = map[string]string{
 	// getAllDatasets returns all datasets (for allow-all-data mode)
-	getAllDatasetsQuery: `
-		SELECT DISTINCT d.stable_id, d.title, d.description, d.created_at
-		FROM sda.datasets d
-		ORDER BY d.created_at DESC`,
+	getAllDatasetsQuery: `SELECT DISTINCT d.stable_id, d.title, d.description, d.created_at
+FROM sda.datasets d
+ORDER BY d.created_at DESC`,
 
 	// getDatasetIDsByUser returns dataset stable_ids where the user is the submission_user
 	// This follows the data ownership model used by the API service
-	getDatasetIDsByUserQuery: `
-		SELECT DISTINCT d.stable_id
-		FROM sda.datasets d
-		INNER JOIN sda.file_dataset fd ON d.id = fd.dataset_id
-		INNER JOIN sda.files f ON fd.file_id = f.id
-		WHERE f.submission_user = $1 AND f.stable_id IS NOT NULL`,
+	getDatasetIDsByUserQuery: `SELECT DISTINCT d.stable_id
+FROM sda.datasets d
+INNER JOIN sda.file_dataset fd ON d.id = fd.dataset_id
+INNER JOIN sda.files f ON fd.file_id = f.id
+WHERE f.submission_user = $1 AND f.stable_id IS NOT NULL`,
 
 	// getUserDatasets returns datasets where the stable_id matches any of the allowed dataset IDs
-	getUserDatasetsQuery: `
-		SELECT DISTINCT d.stable_id, d.title, d.description, d.created_at
-		FROM sda.datasets d
-		WHERE d.stable_id = ANY($1)
-		ORDER BY d.created_at DESC`,
+	getUserDatasetsQuery: `SELECT DISTINCT d.stable_id, d.title, d.description, d.created_at
+FROM sda.datasets d
+WHERE d.stable_id = ANY($1)
+ORDER BY d.created_at DESC`,
 
-	getDatasetInfoQuery: `
-		SELECT
-			d.stable_id,
-			d.title,
-			d.description,
-			d.created_at,
-			COUNT(f.id) as file_count,
-			COALESCE(SUM(f.decrypted_file_size), 0) as total_size
-		FROM sda.datasets d
-		LEFT JOIN sda.file_dataset fd ON d.id = fd.dataset_id
-		LEFT JOIN sda.files f ON fd.file_id = f.id
-		WHERE d.stable_id = $1
-		GROUP BY d.id, d.stable_id, d.title, d.description, d.created_at`,
+	getDatasetInfoQuery: `SELECT
+	d.stable_id,
+	d.title,
+	d.description,
+	d.created_at,
+	COUNT(f.id) as file_count,
+	COALESCE(SUM(f.decrypted_file_size), 0) as total_size
+FROM sda.datasets d
+LEFT JOIN sda.file_dataset fd ON d.id = fd.dataset_id
+LEFT JOIN sda.files f ON fd.file_id = f.id
+WHERE d.stable_id = $1
+GROUP BY d.id, d.stable_id, d.title, d.description, d.created_at`,
 
-	getFileByIDQuery: `
-		SELECT
-			f.stable_id,
-			d.stable_id as dataset_id,
-			COALESCE(fd.download_path, f.submission_file_path),
-			f.archive_file_path,
-			f.archive_location,
-			f.archive_file_size,
-			f.decrypted_file_size,
-			c.checksum as decrypted_checksum,
-			c.type as decrypted_checksum_type,
-			f.header,
-			f.created_at
-		FROM sda.files f
-		INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
-		INNER JOIN sda.datasets d ON fd.dataset_id = d.id
-		LEFT JOIN sda.checksums c ON f.id = c.file_id AND c.source = 'UNENCRYPTED'
-		WHERE f.stable_id = $1`,
+	getFileByIDQuery: `SELECT
+	f.stable_id,
+	d.stable_id as dataset_id,
+	COALESCE(fd.download_path, f.submission_file_path),
+	f.archive_file_path,
+	f.archive_location,
+	f.archive_file_size,
+	f.decrypted_file_size,
+	c.checksum as decrypted_checksum,
+	c.type as decrypted_checksum_type,
+	f.header,
+	f.created_at
+FROM sda.files f
+INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
+INNER JOIN sda.datasets d ON fd.dataset_id = d.id
+LEFT JOIN sda.checksums c ON f.id = c.file_id AND c.source = 'UNENCRYPTED'
+WHERE f.stable_id = $1`,
 
-	getFileByPathQuery: `
-		SELECT
-			f.stable_id,
-			d.stable_id as dataset_id,
-			COALESCE(fd.download_path, f.submission_file_path),
-			f.archive_file_path,
-			f.archive_location,
-			f.archive_file_size,
-			f.decrypted_file_size,
-			c.checksum as decrypted_checksum,
-			c.type as decrypted_checksum_type,
-			f.header,
-			f.created_at
-		FROM sda.files f
-		INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
-		INNER JOIN sda.datasets d ON fd.dataset_id = d.id
-		LEFT JOIN sda.checksums c ON f.id = c.file_id AND c.source = 'UNENCRYPTED'
-		WHERE d.stable_id = $1 AND COALESCE(fd.download_path, f.submission_file_path) = $2`,
+	getFileByPathQuery: `SELECT
+	f.stable_id,
+	d.stable_id as dataset_id,
+	COALESCE(fd.download_path, f.submission_file_path),
+	f.archive_file_path,
+	f.archive_location,
+	f.archive_file_size,
+	f.decrypted_file_size,
+	c.checksum as decrypted_checksum,
+	c.type as decrypted_checksum_type,
+	f.header,
+	f.created_at
+FROM sda.files f
+INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
+INNER JOIN sda.datasets d ON fd.dataset_id = d.id
+LEFT JOIN sda.checksums c ON f.id = c.file_id AND c.source = 'UNENCRYPTED'
+WHERE d.stable_id = $1 AND COALESCE(fd.download_path, f.submission_file_path) = $2`,
 
 	// checkFilePermission verifies user has access to the file's dataset
 	// by checking if the dataset stable_id is in the user's visas
-	checkFilePermissionQuery: `
-		SELECT EXISTS(
-			SELECT 1
-			FROM sda.files f
-			INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
-			INNER JOIN sda.datasets d ON fd.dataset_id = d.id
-			WHERE f.stable_id = $1 AND d.stable_id = ANY($2)
-		)`,
+	checkFilePermissionQuery: `SELECT EXISTS(
+	SELECT 1
+	FROM sda.files f
+	INNER JOIN sda.file_dataset fd ON f.id = fd.file_id
+	INNER JOIN sda.datasets d ON fd.dataset_id = d.id
+	WHERE f.stable_id = $1 AND d.stable_id = ANY($2)
+)`,
 
 	// checkDatasetExists checks if a dataset with the given stable_id exists
-	checkDatasetExistsQuery: `
-		SELECT EXISTS(
-			SELECT 1
-			FROM sda.datasets d
-			WHERE d.stable_id = $1
-		)`,
+	checkDatasetExistsQuery: `SELECT EXISTS(
+	SELECT 1
+	FROM sda.datasets d
+	WHERE d.stable_id = $1
+)`,
 
 	// getFileChecksums returns checksums for a file filtered by source (e.g., "ARCHIVED", "UNENCRYPTED").
-	getFileChecksumsQuery: `
-		SELECT c.checksum, c.type
-		FROM sda.checksums c
-		INNER JOIN sda.files f ON c.file_id = f.id
-		WHERE f.stable_id = $1 AND c.source = $2`,
+	getFileChecksumsQuery: `SELECT c.checksum, c.type
+FROM sda.checksums c
+INNER JOIN sda.files f ON c.file_id = f.id
+WHERE f.stable_id = $1 AND c.source = $2`,
 
 	// Keyset-paginated file queries compose from paginatedFileBase (defined below).
 
 	// getDatasetFilesPage returns paginated files in a dataset (no path filter).
 	// Keyset cursor on (COALESCE(fd.download_path, f.submission_file_path), stable_id). $2='' means first page.
 	getDatasetFilesPageQuery: paginatedFileBase + `
-		  AND ($2 = '' OR (COALESCE(fd.download_path, f.submission_file_path), f.stable_id) > ($2, $3))
-		ORDER BY COALESCE(fd.download_path, f.submission_file_path), f.stable_id
-		LIMIT $4`,
+  AND ($2 = '' OR (COALESCE(fd.download_path, f.submission_file_path), f.stable_id) > ($2, $3))
+ORDER BY COALESCE(fd.download_path, f.submission_file_path), f.stable_id
+LIMIT $4`,
 
 	// getDatasetFilesPageByPath returns a file by exact path (at most 1 result).
 	getDatasetFilesPageByPathQuery: paginatedFileBase + `
-		  AND COALESCE(fd.download_path, f.submission_file_path) = $2
-		LIMIT $3`,
+  AND COALESCE(fd.download_path, f.submission_file_path) = $2
+LIMIT $3`,
 
 	// getDatasetFilesPageByPrefix returns paginated files matching a path prefix.
 	// Keyset cursor on (COALESCE(fd.download_path, f.submission_file_path), stable_id). $3='' means first page.
 	getDatasetFilesPageByPrefixQuery: paginatedFileBase + `
-		  AND COALESCE(fd.download_path, f.submission_file_path) LIKE $2 ESCAPE '\'
-		  AND ($3 = '' OR (COALESCE(fd.download_path, f.submission_file_path), f.stable_id) > ($3, $4))
-		ORDER BY COALESCE(fd.download_path, f.submission_file_path), f.stable_id
-		LIMIT $5`,
+  AND COALESCE(fd.download_path, f.submission_file_path) LIKE $2 ESCAPE '\'
+  AND ($3 = '' OR (COALESCE(fd.download_path, f.submission_file_path), f.stable_id) > ($3, $4))
+ORDER BY COALESCE(fd.download_path, f.submission_file_path), f.stable_id
+LIMIT $5`,
 }
 
 // Checksum represents a file checksum with its algorithm type.

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -207,7 +207,7 @@ func handleMessage(ctx context.Context, delivered amqp.Delivery) {
 				log.Errorf("failed to map file: %s to dataset-id: %s, reason: %v", fileMappingData.FileID, mappings.DatasetID, err)
 
 				// Nack message so the server gets notified that something is wrong and requeue the message
-				if err := delivered.Nack(false, true); err != nil {
+				if err := delivered.Nack(false, false); err != nil {
 					log.Errorf("failed to Nack message, reason: (%v)", err)
 				}
 

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -54,8 +54,8 @@ func run() error {
 		return fmt.Errorf("failed to initialize sda db, due to: %v", err)
 	}
 	defer db.Close()
-	if dbSchemaVersion, err := db.SchemaVersion(); err != nil || dbSchemaVersion < 23 {
-		return errors.Join(errors.New("database schema v23 is required"), err)
+	if dbSchemaVersion, err := db.SchemaVersion(); err != nil || dbSchemaVersion < 25 {
+		return errors.Join(errors.New("database schema v25 is required"), err)
 	}
 
 	mqBroker, err = broker.NewMQ(conf.Broker)
@@ -174,7 +174,15 @@ func handleMessage(ctx context.Context, delivered amqp.Delivery) {
 	case "mapping":
 		log.Debug("mapping type operation, mapping files to dataset")
 		for _, aID := range mappings.AccessionIDs {
-			log.Debugf("Mapped file to dataset (correlation-id: %s, dataset-id: %s, accession-id: %s)", delivered.CorrelationId, mappings.DatasetID, aID)
+			var fileDownloadPath *string
+
+			if mappings.FileDownloadPaths != nil {
+				if v, ok := mappings.FileDownloadPaths[aID]; ok && v != "" {
+					fileDownloadPath = &v
+				}
+			}
+
+			log.Debugf("Mapping file to dataset (correlation-id: %s, dataset-id: %s, accession-id: %s, file-download-path overridden: %t)", delivered.CorrelationId, mappings.DatasetID, aID, fileDownloadPath != nil)
 			fileMappingData, err := tx.GetMappingData(ctx, aID)
 			if err != nil {
 				log.Errorf("failed to get file info for file with accession-id: %s, can not map file to dataset: %s, due to: %v", aID, mappings.DatasetID, err)
@@ -195,7 +203,7 @@ func handleMessage(ctx context.Context, delivered amqp.Delivery) {
 
 				return
 			}
-			if err := tx.MapFileToDataset(ctx, mappings.DatasetID, fileMappingData.FileID); err != nil {
+			if err := tx.MapFileToDataset(ctx, mappings.DatasetID, fileMappingData.FileID, fileDownloadPath); err != nil {
 				log.Errorf("failed to map file: %s to dataset-id: %s, reason: %v", fileMappingData.FileID, mappings.DatasetID, err)
 
 				// Nack message so the server gets notified that something is wrong and requeue the message

--- a/sda/cmd/sync/sync_test.go
+++ b/sda/cmd/sync/sync_test.go
@@ -175,7 +175,7 @@ func (s *SyncTest) TestBuildSyncDatasetJSON() {
 	err = db.SetVerified(context.Background(), fileInfo, fileID)
 	assert.NoError(s.T(), err, "failed to mark file as Verified")
 
-	assert.NoError(s.T(), db.MapFileToDataset(context.Background(), "cd532362-e06e-4461-8490-b9ce64b8d9e7", fileID), "failed to map file to dataset")
+	assert.NoError(s.T(), db.MapFileToDataset(context.Background(), "cd532362-e06e-4461-8490-b9ce64b8d9e7", fileID, nil), "failed to map file to dataset")
 
 	m := []byte(`{"type":"mapping", "dataset_id": "cd532362-e06e-4461-8490-b9ce64b8d9e7", "accession_ids": ["ed6af454-d910-49e3-8cda-488a6f246e67"]}`)
 	jsonData, err := buildSyncDatasetJSON(context.Background(), m)

--- a/sda/internal/database/database.go
+++ b/sda/internal/database/database.go
@@ -89,8 +89,8 @@ type functions interface {
 	// GetAccessionID returns the stable id of a file identified by its file_id
 	GetAccessionID(ctx context.Context, fileID string) (string, error)
 
-	// MapFileToDataset maps a file to a dataset in the database
-	MapFileToDataset(ctx context.Context, datasetID, fileID string) error
+	// MapFileToDataset maps a file to a dataset in the database, provide a fileDownloadPathOverride to override the file submission path as the exposed download path
+	MapFileToDataset(ctx context.Context, datasetID, fileID string, fileDownloadPathOverride *string) error
 
 	// GetInboxPath retrieves the submission_fie_path for a file with a given accessionID
 	GetInboxPath(ctx context.Context, accessionID string) (string, error)

--- a/sda/internal/database/postgres/db_functions_test.go
+++ b/sda/internal/database/postgres/db_functions_test.go
@@ -1548,7 +1548,7 @@ func (ts *DatabaseTests) TestMapFileToDataset_WithDownloadPath() {
 	var rowsWithoutDownloadPath bool
 	err := ts.verificationDB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.file_dataset WHERE download_path IS NULL)").Scan(&rowsWithoutDownloadPath)
 	if err != nil {
-		ts.FailNow("failed to get submission file size from DB", err)
+		ts.FailNow("failed to get query verification db to check if download path is null", err)
 	}
 
 	assert.Equal(ts.T(), false, rowsWithoutDownloadPath)

--- a/sda/internal/database/postgres/db_functions_test.go
+++ b/sda/internal/database/postgres/db_functions_test.go
@@ -496,14 +496,14 @@ func (ts *DatabaseTests) TestMapFilesToDataset() {
 
 	for di, fIDs := range diSet {
 		for _, fileID := range fIDs {
-			err := ts.db.MapFileToDataset(context.Background(), di, fileID)
+			err := ts.db.MapFileToDataset(context.Background(), di, fileID, nil)
 			assert.NoError(ts.T(), err, "failed to map file to dataset")
 		}
 	}
 
 	// Append files to an existing dataset
 	for _, fileID := range fileIDs[9:11] {
-		err := ts.db.MapFileToDataset(context.Background(), "dataset1", fileID)
+		err := ts.db.MapFileToDataset(context.Background(), "dataset1", fileID, nil)
 		assert.NoError(ts.T(), err, "failed to append file to dataset")
 	}
 
@@ -550,7 +550,7 @@ func (ts *DatabaseTests) TestUpdateDatasetEvent() {
 
 	for di, fIDs := range diSet {
 		for _, fileID := range fIDs {
-			assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), di, fileID), "failed to map file to dataset")
+			assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), di, fileID, nil), "failed to map file to dataset")
 		}
 	}
 
@@ -624,7 +624,7 @@ func (ts *DatabaseTests) TestCheckIfDatasetExists() {
 
 	for di, fIDs := range diSet {
 		for _, fileIDs := range fIDs {
-			assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), di, fileIDs), "failed to map file to dataset")
+			assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), di, fileIDs, nil), "failed to map file to dataset")
 		}
 	}
 
@@ -826,15 +826,15 @@ func (ts *DatabaseTests) TestListActiveUsers() {
 		}
 	}
 
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-A_00"]))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-A_01"]))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-A_02"]))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-A_00"], nil))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-A_01"], nil))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-A_02"], nil))
 
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_00"]))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_01"]))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_02"]))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_03"]))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_04"]))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_00"], nil))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_01"], nil))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_02"], nil))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_03"], nil))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "test-dataset-01", accessionToFileID["accession_User-C_04"], nil))
 
 	userList, err := ts.db.ListActiveUsers(context.Background())
 	assert.NoError(ts.T(), err, "failed to list users from DB")
@@ -881,7 +881,7 @@ func (ts *DatabaseTests) TestGetDatasetStatus() {
 			ts.FailNowf("got (%s) when setting stable ID: %s, %s", err.Error(), accessionID, fileID)
 		}
 
-		if err := ts.db.MapFileToDataset(context.Background(), dID, fileID); err != nil {
+		if err := ts.db.MapFileToDataset(context.Background(), dID, fileID, nil); err != nil {
 			ts.FailNow("failed to map files to dataset")
 		}
 	}
@@ -1076,7 +1076,7 @@ func (ts *DatabaseTests) TestListDatasets() {
 		default:
 			continue
 		}
-		if err := ts.db.MapFileToDataset(context.Background(), dID, fileID); err != nil {
+		if err := ts.db.MapFileToDataset(context.Background(), dID, fileID, nil); err != nil {
 			ts.FailNow("failed to map files to dataset")
 		}
 	}
@@ -1147,13 +1147,13 @@ func (ts *DatabaseTests) TestListUserDatasets() {
 		}
 
 		if i >= 3 {
-			if err := ts.db.MapFileToDataset(context.Background(), "test-user-dataset-02", fileID); err != nil {
+			if err := ts.db.MapFileToDataset(context.Background(), "test-user-dataset-02", fileID, nil); err != nil {
 				ts.FailNow("failed to map files to dataset")
 			}
 
 			continue
 		}
-		if err := ts.db.MapFileToDataset(context.Background(), "test-user-dataset-01", fileID); err != nil {
+		if err := ts.db.MapFileToDataset(context.Background(), "test-user-dataset-01", fileID, nil); err != nil {
 			ts.FailNow("failed to map files to dataset")
 		}
 	}
@@ -1178,7 +1178,7 @@ func (ts *DatabaseTests) TestListUserDatasets() {
 		ts.FailNowf("got (%s) when setting stable ID: %s, %s", err.Error(), "accessionID", fileID)
 	}
 
-	if err := ts.db.MapFileToDataset(context.Background(), "test-wrong-user-dataset", fileID); err != nil {
+	if err := ts.db.MapFileToDataset(context.Background(), "test-wrong-user-dataset", fileID, nil); err != nil {
 		ts.FailNow("failed to map files to dataset")
 	}
 	if err := ts.db.UpdateDatasetEvent(context.Background(), "test-wrong-user-dataset", "registered", "{\"type\": \"mapping\"}"); err != nil {
@@ -1441,7 +1441,7 @@ func (ts *DatabaseTests) TestGetDatasetFiles() {
 		if err != nil {
 			ts.FailNowf("got (%s) when setting stable ID: %s, %s", err.Error(), accessionID, fileID)
 		}
-		assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), dID, fileID))
+		assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), dID, fileID, nil))
 	}
 
 	files, err := ts.db.GetDatasetFiles(context.Background(), dID)
@@ -1492,7 +1492,7 @@ func (ts *DatabaseTests) TestGetDatasetFileIDs() {
 		if err != nil {
 			ts.FailNowf("got (%s) when setting stable ID: %s, %s", err.Error(), accessionID, fileID)
 		}
-		assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), dID, fileID))
+		assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), dID, fileID, nil))
 	}
 
 	files, err := ts.db.GetDatasetFileIDs(context.Background(), dID)
@@ -1500,6 +1500,58 @@ func (ts *DatabaseTests) TestGetDatasetFileIDs() {
 	assert.Equal(ts.T(), 3, len(files))
 
 	assert.ElementsMatch(ts.T(), createdFileIDs, files)
+}
+
+func (ts *DatabaseTests) TestMapFileToDataset_WithDownloadPath() {
+	testCases := 3
+	dID := "test-get-dataset-fileids-01"
+
+	for i := 0; i < testCases; i++ {
+		filePath := fmt.Sprintf("/%v/TestGetDatasetFileIDs-00%d.c4gh", "User-Q", i)
+		fileID, err := ts.db.RegisterFile(context.Background(), nil, "/inbox", filePath, "User-Q")
+		if err != nil {
+			ts.FailNow("Failed to register file")
+		}
+		if err = ts.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", "User-Q", "{}", "{}"); err != nil {
+			ts.FailNow("Failed to update file event log")
+		}
+
+		fileInfo := &database.FileInfo{
+			Size:              1234,
+			Path:              filePath,
+			ArchivedChecksum:  fmt.Sprintf("%x", sha256.New().Sum(nil)),
+			DecryptedChecksum: fmt.Sprintf("%x", sha256.New().Sum(nil)),
+			DecryptedSize:     999,
+			UploadedChecksum:  fmt.Sprintf("%x", sha256.New().Sum(nil)),
+		}
+
+		err = ts.db.SetArchived(context.Background(), "/archive", fileInfo, fileID)
+		if err != nil {
+			ts.FailNow("failed to mark file as Archived")
+		}
+
+		err = ts.db.SetVerified(context.Background(), fileInfo, fileID)
+		if err != nil {
+			ts.FailNow("failed to mark file as Verified")
+		}
+
+		accessionID := fmt.Sprintf("accession_ids_%s_0%d", "User-Q", i)
+		err = ts.db.SetAccessionID(context.Background(), accessionID, fileID)
+		if err != nil {
+			ts.FailNowf("got (%s) when setting stable ID: %s, %s", err.Error(), accessionID, fileID)
+		}
+		downloadPath := fmt.Sprintf("download_path/%d", i)
+
+		assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), dID, fileID, &downloadPath))
+	}
+
+	var rowsWithoutDownloadPath bool
+	err := ts.verificationDB.QueryRow("SELECT EXISTS(SELECT 1 FROM sda.file_dataset WHERE download_path IS NULL)").Scan(&rowsWithoutDownloadPath)
+	if err != nil {
+		ts.FailNow("failed to get submission file size from DB", err)
+	}
+
+	assert.Equal(ts.T(), false, rowsWithoutDownloadPath)
 }
 
 func (ts *DatabaseTests) TestGetSubmissionPathAndLocation() {
@@ -1705,7 +1757,7 @@ func (ts *DatabaseTests) TestGetSizeAndObjectCountOfLocation() {
 			if len(test.filesToDataset) > 0 {
 				for fileID, accessionID := range test.filesToDataset {
 					assert.NoError(t, ts.db.SetAccessionID(context.Background(), accessionID, fileID))
-					assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "unit-test-dataset-id", fileID))
+					assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "unit-test-dataset-id", fileID, nil))
 				}
 			}
 
@@ -1766,7 +1818,7 @@ func (ts *DatabaseTests) TestIsFileInDataset_Yes() {
 	}, fileID))
 
 	assert.NoError(ts.T(), ts.db.SetAccessionID(context.Background(), "accessionID-1", fileID))
-	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "unit-test-dataset-id", fileID))
+	assert.NoError(ts.T(), ts.db.MapFileToDataset(context.Background(), "unit-test-dataset-id", fileID, nil))
 
 	inDataset, err := ts.db.IsFileInDataset(context.Background(), fileID)
 	assert.NoError(ts.T(), err)

--- a/sda/internal/database/postgres/method_add_key_hash.go
+++ b/sda/internal/database/postgres/method_add_key_hash.go
@@ -9,10 +9,8 @@ import (
 const addKeyHashQuery = "addKeyHash"
 
 func init() {
-	queries[addKeyHashQuery] = `
-INSERT INTO sda.encryption_keys(key_hash, description) 
-VALUES($1, $2) ON CONFLICT DO NOTHING;
-`
+	queries[addKeyHashQuery] = `INSERT INTO sda.encryption_keys(key_hash, description) 
+VALUES($1, $2) ON CONFLICT DO NOTHING;`
 }
 
 func (db *pgDb) addKeyHash(ctx context.Context, tx *sql.Tx, keyHash, keyDescription string) error {

--- a/sda/internal/database/postgres/method_backup_header.go
+++ b/sda/internal/database/postgres/method_backup_header.go
@@ -11,14 +11,12 @@ import (
 const backupHeaderQuery = "backupHeader"
 
 func init() {
-	queries[backupHeaderQuery] = `
-INSERT INTO sda.file_headers_backup (file_id, header, key_hash, backup_at)
+	queries[backupHeaderQuery] = `INSERT INTO sda.file_headers_backup (file_id, header, key_hash, backup_at)
 VALUES ($1, $2, $3, NOW())
 ON CONFLICT (file_id) DO UPDATE
 SET header = EXCLUDED.header,
 	key_hash = EXCLUDED.key_hash,
-	backup_at = EXCLUDED.backup_at;
-`
+	backup_at = EXCLUDED.backup_at;`
 }
 
 func (db *pgDb) backupHeader(ctx context.Context, tx *sql.Tx, fileID string, header []byte, keyHash string) error {

--- a/sda/internal/database/postgres/method_cancel_file.go
+++ b/sda/internal/database/postgres/method_cancel_file.go
@@ -12,15 +12,11 @@ const (
 )
 
 func init() {
-	queries[cancelFileUnSetArchivedQuery] = `
-UPDATE sda.files 
+	queries[cancelFileUnSetArchivedQuery] = `UPDATE sda.files 
 SET archive_location = NULL, archive_file_path = '', archive_file_size = NULL, decrypted_file_size = NULL, stable_id = NULL
-WHERE id = $1;
-`
-	queries[cancelFileDeleteChecksumsQuery] = `
-DELETE FROM sda.checksums 
-WHERE file_id = $1
-`
+WHERE id = $1;`
+	queries[cancelFileDeleteChecksumsQuery] = `DELETE FROM sda.checksums 
+WHERE file_id = $1`
 }
 
 func (db *pgDb) cancelFile(ctx context.Context, tx *sql.Tx, fileID string, message string) error {

--- a/sda/internal/database/postgres/method_check_accession_id_exists.go
+++ b/sda/internal/database/postgres/method_check_accession_id_exists.go
@@ -9,17 +9,14 @@ const checkAccessionIDExistsSameIDQuery = "checkAccessionIDExistsSameID"
 const checkAccessionIDExistsQuery = "checkAccessionIDExists"
 
 func init() {
-	queries[checkAccessionIDExistsSameIDQuery] = `
-SELECT COUNT(id) 
+	queries[checkAccessionIDExistsSameIDQuery] = `SELECT COUNT(id) 
 FROM sda.files 
 WHERE stable_id = $1 
-AND id = $2;
-`
-	queries[checkAccessionIDExistsQuery] = `
-SELECT COUNT(id) 
+AND id = $2;`
+
+	queries[checkAccessionIDExistsQuery] = `SELECT COUNT(id) 
 FROM sda.files 
-WHERE stable_id = $1;
-`
+WHERE stable_id = $1;`
 }
 
 func (db *pgDb) checkAccessionIDExists(ctx context.Context, tx *sql.Tx, accessionID, fileID string) (string, error) {

--- a/sda/internal/database/postgres/method_check_if_dataset_exists.go
+++ b/sda/internal/database/postgres/method_check_if_dataset_exists.go
@@ -8,12 +8,10 @@ import (
 const checkIfDatasetExistsQuery = "checkIfDatasetExists"
 
 func init() {
-	queries[checkIfDatasetExistsQuery] = `
-SELECT EXISTS(
+	queries[checkIfDatasetExistsQuery] = `SELECT EXISTS(
 	SELECT id from sda.datasets 
 	WHERE stable_id = $1
-);
-`
+);`
 }
 
 func (db *pgDb) checkIfDatasetExists(ctx context.Context, tx *sql.Tx, datasetID string) (bool, error) {

--- a/sda/internal/database/postgres/method_deprecate_key_hash.go
+++ b/sda/internal/database/postgres/method_deprecate_key_hash.go
@@ -9,12 +9,10 @@ import (
 const deprecateKeyHashQuery = "deprecateKeyHash"
 
 func init() {
-	queries[deprecateKeyHashQuery] = `
-UPDATE sda.encryption_keys 
+	queries[deprecateKeyHashQuery] = `UPDATE sda.encryption_keys 
 SET deprecated_at = NOW() 
 WHERE key_hash = $1 
-AND deprecated_at IS NULL;
-`
+AND deprecated_at IS NULL;`
 }
 
 func (db *pgDb) deprecateKeyHash(ctx context.Context, tx *sql.Tx, keyHash string) error {

--- a/sda/internal/database/postgres/method_get_accession_id.go
+++ b/sda/internal/database/postgres/method_get_accession_id.go
@@ -8,11 +8,9 @@ import (
 const getAccessionIDQuery = "getAccessionID"
 
 func init() {
-	queries[getAccessionIDQuery] = `
-SELECT stable_id 
+	queries[getAccessionIDQuery] = `SELECT stable_id 
 FROM sda.files 
-WHERE id = $1;
-`
+WHERE id = $1;`
 }
 
 func (db *pgDb) getAccessionID(ctx context.Context, tx *sql.Tx, fileID string) (string, error) {

--- a/sda/internal/database/postgres/method_get_archive_location.go
+++ b/sda/internal/database/postgres/method_get_archive_location.go
@@ -9,11 +9,9 @@ import (
 const getArchiveLocationQuery = "getArchiveLocation"
 
 func init() {
-	queries[getArchiveLocationQuery] = `
-SELECT archive_location 
+	queries[getArchiveLocationQuery] = `SELECT archive_location 
 FROM sda.files 
-WHERE id = $1;
-`
+WHERE id = $1;`
 }
 
 func (db *pgDb) getArchiveLocation(ctx context.Context, tx *sql.Tx, fileID string) (string, error) {

--- a/sda/internal/database/postgres/method_get_archive_path_and_location.go
+++ b/sda/internal/database/postgres/method_get_archive_path_and_location.go
@@ -8,11 +8,9 @@ import (
 const getArchivePathAndLocationQuery = "getArchivePathAndLocation"
 
 func init() {
-	queries[getArchivePathAndLocationQuery] = `
-SELECT archive_file_path, archive_location 
+	queries[getArchivePathAndLocationQuery] = `SELECT archive_file_path, archive_location 
 FROM sda.files 
-WHERE stable_id = $1;
-`
+WHERE stable_id = $1;`
 }
 
 func (db *pgDb) getArchivePathAndLocation(ctx context.Context, tx *sql.Tx, accessionID string) (string, string, error) {

--- a/sda/internal/database/postgres/method_get_archived.go
+++ b/sda/internal/database/postgres/method_get_archived.go
@@ -11,11 +11,9 @@ import (
 const getArchivedQuery = "getArchived"
 
 func init() {
-	queries[getArchivedQuery] = `
-SELECT archive_file_path, archive_file_size, archive_location, backup_path, backup_location 
+	queries[getArchivedQuery] = `SELECT archive_file_path, archive_file_size, archive_location, backup_path, backup_location 
 FROM sda.files 
-WHERE id = $1;
-`
+WHERE id = $1;`
 }
 
 func (db *pgDb) getArchived(ctx context.Context, tx *sql.Tx, fileID string) (*database.ArchiveData, error) {

--- a/sda/internal/database/postgres/method_get_dataset_file_ids.go
+++ b/sda/internal/database/postgres/method_get_dataset_file_ids.go
@@ -8,12 +8,10 @@ import (
 const getDatasetFileIDsQuery = "getDatasetFileIDs"
 
 func init() {
-	queries[getDatasetFileIDsQuery] = `
-SELECT fd.file_id 
+	queries[getDatasetFileIDsQuery] = `SELECT fd.file_id 
 FROM sda.datasets AS d 
 INNER JOIN sda.file_dataset AS fd ON d.id = fd.dataset_id 
-WHERE d.stable_id = $1;
-`
+WHERE d.stable_id = $1;`
 }
 
 func (db *pgDb) getDatasetFileIDs(ctx context.Context, tx *sql.Tx, datasetID string) ([]string, error) {

--- a/sda/internal/database/postgres/method_get_dataset_files.go
+++ b/sda/internal/database/postgres/method_get_dataset_files.go
@@ -8,8 +8,7 @@ import (
 const getDatasetFilesQuery = "getDatasetFiles"
 
 func init() {
-	queries[getDatasetFilesQuery] = `
-SELECT stable_id 
+	queries[getDatasetFilesQuery] = `SELECT stable_id 
 FROM sda.files 
 WHERE id IN (
 	SELECT file_id 
@@ -19,8 +18,7 @@ WHERE id IN (
 		FROM sda.datasets 
 		WHERE stable_id = $1
 		)
-	);
-`
+	);`
 }
 
 func (db *pgDb) getDatasetFiles(ctx context.Context, tx *sql.Tx, datasetID string) ([]string, error) {

--- a/sda/internal/database/postgres/method_get_dataset_status.go
+++ b/sda/internal/database/postgres/method_get_dataset_status.go
@@ -8,12 +8,10 @@ import (
 const getDatasetStatusQuery = "getDatasetStatus"
 
 func init() {
-	queries[getDatasetStatusQuery] = `
-SELECT event 
+	queries[getDatasetStatusQuery] = `SELECT event 
 FROM sda.dataset_event_log 
 WHERE dataset_id = $1 
-ORDER BY id DESC LIMIT 1;
-`
+ORDER BY id DESC LIMIT 1;`
 }
 func (db *pgDb) getDatasetStatus(ctx context.Context, tx *sql.Tx, datasetID string) (string, error) {
 	stmt, err := db.getPreparedStmt(tx, getDatasetStatusQuery)

--- a/sda/internal/database/postgres/method_get_decrypted_checksum.go
+++ b/sda/internal/database/postgres/method_get_decrypted_checksum.go
@@ -8,12 +8,10 @@ import (
 const getDecryptedChecksumQuery = "getDecryptedChecksum"
 
 func init() {
-	queries[getDecryptedChecksumQuery] = `
-SELECT checksum 
+	queries[getDecryptedChecksumQuery] = `SELECT checksum 
 FROM sda.checksums 
 WHERE file_id = $1 
-AND source = 'UNENCRYPTED';
-`
+AND source = 'UNENCRYPTED';`
 }
 
 func (db *pgDb) getDecryptedChecksum(ctx context.Context, tx *sql.Tx, id string) (string, error) {

--- a/sda/internal/database/postgres/method_get_file_details_from_uuid.go
+++ b/sda/internal/database/postgres/method_get_file_details_from_uuid.go
@@ -10,12 +10,10 @@ import (
 const getFileDetailsQuery = "getFileDetails"
 
 func init() {
-	queries[getFileDetailsQuery] = `
-SELECT f.submission_user, f.submission_file_path
+	queries[getFileDetailsQuery] = `SELECT f.submission_user, f.submission_file_path
 FROM sda.files f
 JOIN sda.file_event_log fel on f.id = fel.file_id
-WHERE f.id = $1 and fel.event = $2;
-`
+WHERE f.id = $1 and fel.event = $2;`
 }
 
 func (db *pgDb) getFileDetails(ctx context.Context, tx *sql.Tx, fileID, event string) (*database.FileDetails, error) {

--- a/sda/internal/database/postgres/method_get_file_id_by_user_path_and_status.go
+++ b/sda/internal/database/postgres/method_get_file_id_by_user_path_and_status.go
@@ -8,8 +8,7 @@ import (
 const getFileIDByUserPathAndStatusQuery = "getFileIDByUserPathAndStatus"
 
 func init() {
-	queries[getFileIDByUserPathAndStatusQuery] = `
-SELECT id_and_event.id
+	queries[getFileIDByUserPathAndStatusQuery] = `SELECT id_and_event.id
 FROM (
     SELECT DISTINCT ON (f.id) f.id, fel.event FROM sda.files AS f
         LEFT JOIN sda.file_event_log AS fel ON fel.file_id = f.id
@@ -18,8 +17,7 @@ FROM (
       AND f.stable_id IS NULL
     ORDER BY f.id, fel.started_at DESC LIMIT 1
     ) AS id_and_event
-WHERE id_and_event.event = $3;
-`
+WHERE id_and_event.event = $3;`
 }
 
 func (db *pgDb) getFileIDByUserPathAndStatus(ctx context.Context, tx *sql.Tx, submissionUser, filePath, status string) (string, error) {

--- a/sda/internal/database/postgres/method_get_file_id_in_inbox.go
+++ b/sda/internal/database/postgres/method_get_file_id_in_inbox.go
@@ -9,8 +9,7 @@ import (
 const getFileIDInInboxQuery = "getFileIDInInbox"
 
 func init() {
-	queries[getFileIDInInboxQuery] = `
-SELECT id_and_event.id
+	queries[getFileIDInInboxQuery] = `SELECT id_and_event.id
 FROM (
     SELECT DISTINCT ON (f.id) f.id, fel.event FROM sda.files AS f
         LEFT JOIN sda.file_event_log AS fel ON fel.file_id = f.id

--- a/sda/internal/database/postgres/method_get_file_info.go
+++ b/sda/internal/database/postgres/method_get_file_info.go
@@ -11,14 +11,15 @@ const getFileInfoQuery = "getFileInfo"
 const getFileInfoChecksumQuery = "getFileInfoChecksum"
 
 func init() {
-	queries[getFileInfoQuery] = `
-SELECT archive_file_path, archive_file_size from sda.files where id = $1;
-`
-	queries[getFileInfoChecksumQuery] = `
-SELECT MAX(checksum) FILTER(where source = 'ARCHIVED') as Archived,
-MAX(checksum) FILTER(where source = 'UNENCRYPTED') as Unencrypted,
-MAX(checksum) FILTER(where source = 'UPLOADED') as Uploaded from sda.checksums where file_id = $1;
-`
+	queries[getFileInfoQuery] = `SELECT archive_file_path, archive_file_size 
+FROM sda.files 
+WHERE id = $1;`
+
+	queries[getFileInfoChecksumQuery] = `SELECT MAX(checksum) FILTER(WHERE source = 'ARCHIVED') AS Archived,
+MAX(checksum) FILTER(WHERE source = 'UNENCRYPTED') AS Unencrypted,
+MAX(checksum) FILTER(WHERE source = 'UPLOADED') AS Uploaded 
+FROM sda.checksums 
+WHERE file_id = $1;`
 }
 
 func (db *pgDb) getFileInfo(ctx context.Context, tx *sql.Tx, id string) (*database.FileInfo, error) {

--- a/sda/internal/database/postgres/method_get_file_status.go
+++ b/sda/internal/database/postgres/method_get_file_status.go
@@ -8,12 +8,10 @@ import (
 const getFileStatusQuery = "getFileStatus"
 
 func init() {
-	queries[getFileStatusQuery] = `
-SELECT event 
+	queries[getFileStatusQuery] = `SELECT event 
 FROM sda.file_event_log 
 WHERE file_id = $1 
-ORDER BY id DESC LIMIT 1;
-`
+ORDER BY id DESC LIMIT 1;`
 }
 
 func (db *pgDb) getFileStatus(ctx context.Context, tx *sql.Tx, fileID string) (string, error) {

--- a/sda/internal/database/postgres/method_get_file_status_history.go
+++ b/sda/internal/database/postgres/method_get_file_status_history.go
@@ -10,11 +10,9 @@ import (
 const getFileStatusHistoryQuery = "getFileStatusHistory"
 
 func init() {
-	queries[getFileStatusHistoryQuery] = `
-SELECT event, user_id, details, message, started_at
+	queries[getFileStatusHistoryQuery] = `SELECT event, user_id, details, message, started_at
 FROM sda.file_event_log 
-WHERE file_id = $1 
-`
+WHERE file_id = $1`
 }
 
 func (db *pgDb) getFileStatusHistory(ctx context.Context, tx *sql.Tx, fileID string) ([]database.FileStatus, error) {

--- a/sda/internal/database/postgres/method_get_header.go
+++ b/sda/internal/database/postgres/method_get_header.go
@@ -9,11 +9,9 @@ import (
 const getHeaderQuery = "getHeader"
 
 func init() {
-	queries[getHeaderQuery] = `
-SELECT header 
+	queries[getHeaderQuery] = `SELECT header 
 FROM sda.files 
-WHERE id = $1;
-`
+WHERE id = $1;`
 }
 
 func (db *pgDb) getHeader(ctx context.Context, tx *sql.Tx, fileID string) ([]byte, error) {

--- a/sda/internal/database/postgres/method_get_header_for_stable_id.go
+++ b/sda/internal/database/postgres/method_get_header_for_stable_id.go
@@ -9,11 +9,9 @@ import (
 const getHeaderByAccessionIDQuery = "getHeaderByAccessionID"
 
 func init() {
-	queries[getHeaderByAccessionIDQuery] = `
-SELECT header 
+	queries[getHeaderByAccessionIDQuery] = `SELECT header 
 FROM sda.files 
-WHERE stable_id = $1;
-`
+WHERE stable_id = $1;`
 }
 
 func (db *pgDb) getHeaderByAccessionID(ctx context.Context, tx *sql.Tx, accessionID string) ([]byte, error) {

--- a/sda/internal/database/postgres/method_get_inbox_path.go
+++ b/sda/internal/database/postgres/method_get_inbox_path.go
@@ -8,11 +8,9 @@ import (
 const getInboxPathQuery = "getInboxPath"
 
 func init() {
-	queries[getInboxPathQuery] = `
-SELECT submission_file_path 
+	queries[getInboxPathQuery] = `SELECT submission_file_path 
 FROM sda.files 
-WHERE stable_id = $1;
-`
+WHERE stable_id = $1;`
 }
 
 func (db *pgDb) getInboxPath(ctx context.Context, tx *sql.Tx, accessionID string) (string, error) {

--- a/sda/internal/database/postgres/method_get_key_hash.go
+++ b/sda/internal/database/postgres/method_get_key_hash.go
@@ -8,11 +8,9 @@ import (
 const getKeyHashQuery = "getKeyHash"
 
 func init() {
-	queries[getKeyHashQuery] = `
-SELECT key_hash 
+	queries[getKeyHashQuery] = `SELECT key_hash 
 FROM sda.files 
-WHERE id = $1;
-`
+WHERE id = $1;`
 }
 
 func (db *pgDb) getKeyHash(ctx context.Context, tx *sql.Tx, fileID string) (string, error) {

--- a/sda/internal/database/postgres/method_get_mapping_data.go
+++ b/sda/internal/database/postgres/method_get_mapping_data.go
@@ -11,11 +11,9 @@ import (
 const getMappingDataQuery = "getMappingData"
 
 func init() {
-	queries[getMappingDataQuery] = `
-SELECT id, submission_user, submission_file_path, submission_location 
+	queries[getMappingDataQuery] = `SELECT id, submission_user, submission_file_path, submission_location 
 FROM sda.files 
-WHERE stable_id = $1;
-`
+WHERE stable_id = $1;`
 }
 
 func (db *pgDb) getMappingData(ctx context.Context, tx *sql.Tx, accessionID string) (*database.MappingData, error) {

--- a/sda/internal/database/postgres/method_get_re_verification_data.go
+++ b/sda/internal/database/postgres/method_get_re_verification_data.go
@@ -11,12 +11,10 @@ import (
 const getReVerificationDataQuery = "getReVerificationData"
 
 func init() {
-	queries[getReVerificationDataQuery] = `
-SELECT f.id, f.archive_file_path, f.submission_file_path, f.submission_user, cs.type, cs.checksum 
+	queries[getReVerificationDataQuery] = `SELECT f.id, f.archive_file_path, f.submission_file_path, f.submission_user, cs.type, cs.checksum 
 FROM sda.files AS f 
 INNER JOIN sda.checksums AS cs ON f.id = cs.file_id
-WHERE f.stable_id = $1 AND cs.source = 'ARCHIVED';
-`
+WHERE f.stable_id = $1 AND cs.source = 'ARCHIVED';`
 }
 func (db *pgDb) getReVerificationData(ctx context.Context, tx *sql.Tx, accessionID string) (*database.ReVerificationData, error) {
 	stmt, err := db.getPreparedStmt(tx, getReVerificationDataQuery)

--- a/sda/internal/database/postgres/method_get_re_verification_data_from_file_id.go
+++ b/sda/internal/database/postgres/method_get_re_verification_data_from_file_id.go
@@ -11,12 +11,10 @@ import (
 const getReVerificationDataFromFileIDQuery = "getReVerificationDataFromFileID"
 
 func init() {
-	queries[getReVerificationDataFromFileIDQuery] = `
-SELECT f.id, f.archive_file_path, f.submission_file_path, f.submission_user, cs.type, cs.checksum 
+	queries[getReVerificationDataFromFileIDQuery] = `SELECT f.id, f.archive_file_path, f.submission_file_path, f.submission_user, cs.type, cs.checksum 
 FROM sda.files AS f 
 INNER JOIN sda.checksums AS cs ON f.id = cs.file_id
-WHERE f.id = $1 AND cs.source = 'ARCHIVED';
-`
+WHERE f.id = $1 AND cs.source = 'ARCHIVED';`
 }
 
 func (db *pgDb) getReVerificationDataFromFileID(ctx context.Context, tx *sql.Tx, fileID string) (*database.ReVerificationData, error) {

--- a/sda/internal/database/postgres/method_get_size_and_object_count_of_location.go
+++ b/sda/internal/database/postgres/method_get_size_and_object_count_of_location.go
@@ -9,8 +9,7 @@ import (
 const getSizeAndObjectCountOfLocationQuery = "getSizeAndObjectCountOfLocation"
 
 func init() {
-	queries[getSizeAndObjectCountOfLocationQuery] = `
-SELECT SUM(CASE WHEN f.submission_location = $1 AND f.file_in_dataset IS NOT TRUE THEN f.submission_file_size ELSE f.archive_file_size END ) AS size, COUNT(*)
+	queries[getSizeAndObjectCountOfLocationQuery] = `SELECT SUM(CASE WHEN f.submission_location = $1 AND f.file_in_dataset IS NOT TRUE THEN f.submission_file_size ELSE f.archive_file_size END ) AS size, COUNT(*)
 FROM (
 SELECT f.submission_file_size, f.archive_file_size, f.submission_location, f.archive_location, f.backup_location,
       (EXISTS (SELECT 1
@@ -19,8 +18,7 @@ SELECT f.submission_file_size, f.archive_file_size, f.submission_location, f.arc
       ) AS file_in_dataset
   FROM sda.files AS f
 ) as f
-WHERE (f.submission_location = $1 AND f.file_in_dataset IS NOT TRUE) OR f.archive_location = $1 OR f.backup_location = $1;
-`
+WHERE (f.submission_location = $1 AND f.file_in_dataset IS NOT TRUE) OR f.archive_location = $1 OR f.backup_location = $1;`
 }
 
 func (db *pgDb) getSizeAndObjectCountOfLocation(ctx context.Context, tx *sql.Tx, location string) (uint64, uint64, error) {

--- a/sda/internal/database/postgres/method_get_submission_location.go
+++ b/sda/internal/database/postgres/method_get_submission_location.go
@@ -9,11 +9,9 @@ import (
 const getSubmissionLocationQuery = "getSubmissionLocation"
 
 func init() {
-	queries[getSubmissionLocationQuery] = `
-SELECT submission_location 
+	queries[getSubmissionLocationQuery] = `SELECT submission_location 
 FROM sda.files 
-WHERE id = $1;
-`
+WHERE id = $1;`
 }
 
 func (db *pgDb) getSubmissionLocation(ctx context.Context, tx *sql.Tx, fileID string) (string, error) {

--- a/sda/internal/database/postgres/method_get_sync_data.go
+++ b/sda/internal/database/postgres/method_get_sync_data.go
@@ -10,12 +10,10 @@ import (
 const getSyncDataQuery = "getSyncData"
 
 func init() {
-	queries[getSyncDataQuery] = `
-SELECT f.submission_user, f.submission_file_path, cs.checksum
+	queries[getSyncDataQuery] = `SELECT f.submission_user, f.submission_file_path, cs.checksum
 FROM sda.files AS f
 INNER JOIN sda.checksums AS cs ON f.id = cs.file_id
-WHERE f.stable_id = $1 AND cs.source = 'UNENCRYPTED';
-`
+WHERE f.stable_id = $1 AND cs.source = 'UNENCRYPTED';`
 }
 
 func (db *pgDb) getSyncData(ctx context.Context, tx *sql.Tx, accessionID string) (*database.SyncData, error) {

--- a/sda/internal/database/postgres/method_get_uploaded_submission_file_path_and_location.go
+++ b/sda/internal/database/postgres/method_get_uploaded_submission_file_path_and_location.go
@@ -8,8 +8,7 @@ import (
 const getUploadedSubmissionFilePathAndLocationQuery = "getUploadedSubmissionFilePathAndLocation"
 
 func init() {
-	queries[getUploadedSubmissionFilePathAndLocationQuery] = `
-SELECT submission_file_path, submission_location
+	queries[getUploadedSubmissionFilePathAndLocationQuery] = `SELECT submission_file_path, submission_location
 FROM sda.files
 WHERE
   submission_user = $1
@@ -23,8 +22,7 @@ WHERE
 	    ORDER BY started_at DESC limit 1
 	  ) AS subquery
 	  WHERE event = 'uploaded' OR event = 'disabled'
-    );
-`
+    );`
 }
 
 func (db *pgDb) getUploadedSubmissionFilePathAndLocation(ctx context.Context, tx *sql.Tx, submissionUser, fileID string) (string, string, error) {

--- a/sda/internal/database/postgres/method_get_user_files.go
+++ b/sda/internal/database/postgres/method_get_user_files.go
@@ -14,16 +14,14 @@ import (
 const getUserFilesQuery = "getUserFiles"
 
 func init() {
-	queries[getUserFilesQuery] = `
-SELECT f.id, f.submission_file_path, f.stable_id, COALESCE(f.last_event, '') as event, f.created_at, f.submission_file_size
+	queries[getUserFilesQuery] = `SELECT f.id, f.submission_file_path, f.stable_id, COALESCE(f.last_event, '') as event, f.created_at, f.submission_file_size
 FROM sda.files AS f
 	LEFT JOIN sda.file_dataset AS fd ON fd.file_id = f.id
  WHERE f.submission_user = $1 
     AND ($2::TEXT IS NULL OR substr(f.submission_file_path, 1, $3) = $2::TEXT)
 	AND fd.file_id IS NULL AND COALESCE(f.last_event, '') != 'disabled'
 	AND ($4::UUID IS NULL OR f.id > $4::UUID)
-ORDER BY f.id ASC LIMIT $5;
-`
+ORDER BY f.id ASC LIMIT $5;`
 }
 
 func (db *pgDb) getUserFiles(ctx context.Context, tx *sql.Tx, userID, pathPrefix string, allData bool, limit int, cursor string) ([]*database.SubmissionFileInfo, string, error) {

--- a/sda/internal/database/postgres/method_is_file_in_dataset.go
+++ b/sda/internal/database/postgres/method_is_file_in_dataset.go
@@ -8,9 +8,7 @@ import (
 const isFileInDatasetQuery = "isFileInDataset"
 
 func init() {
-	queries[isFileInDatasetQuery] = `
-SELECT EXISTS(SELECT 1 FROM sda.file_dataset WHERE file_id = $1);
-`
+	queries[isFileInDatasetQuery] = `SELECT EXISTS(SELECT 1 FROM sda.file_dataset WHERE file_id = $1);`
 }
 
 func (db *pgDb) isFileInDataset(ctx context.Context, tx *sql.Tx, fileID string) (bool, error) {

--- a/sda/internal/database/postgres/method_list_active_users.go
+++ b/sda/internal/database/postgres/method_list_active_users.go
@@ -8,15 +8,13 @@ import (
 const listActiveUsersQuery = "listActiveUsers"
 
 func init() {
-	queries[listActiveUsersQuery] = `
-SELECT DISTINCT submission_user 
+	queries[listActiveUsersQuery] = `SELECT DISTINCT submission_user 
 FROM sda.files f 
 WHERE NOT EXISTS (
 	SELECT 1 
 	FROM sda.file_dataset d 
 	WHERE f.id = d.file_id
-) ORDER BY submission_user ASC;
-`
+) ORDER BY submission_user ASC;`
 }
 
 func (db *pgDb) listActiveUsers(ctx context.Context, tx *sql.Tx) ([]string, error) {

--- a/sda/internal/database/postgres/method_list_datasets.go
+++ b/sda/internal/database/postgres/method_list_datasets.go
@@ -10,15 +10,13 @@ import (
 const listDatasetsQuery = "listDatasets"
 
 func init() {
-	queries[listDatasetsQuery] = `
-SELECT dataset_id, event, event_date 
+	queries[listDatasetsQuery] = `SELECT dataset_id, event, event_date 
 FROM sda.dataset_event_log 
 WHERE (dataset_id, event_date) IN (
 	SELECT dataset_id, max(event_date) 
 	FROM sda.dataset_event_log 
 	GROUP BY dataset_id
-	);
-`
+	);`
 }
 func (db *pgDb) listDatasets(ctx context.Context, tx *sql.Tx) ([]*database.DatasetInfo, error) {
 	stmt, err := db.getPreparedStmt(tx, listDatasetsQuery)

--- a/sda/internal/database/postgres/method_list_user_datasets.go
+++ b/sda/internal/database/postgres/method_list_user_datasets.go
@@ -10,8 +10,7 @@ import (
 const listUserDatasetsQuery = "listUserDatasets"
 
 func init() {
-	queries[listUserDatasetsQuery] = `
-SELECT dataset_id, event, event_date 
+	queries[listUserDatasetsQuery] = `SELECT dataset_id, event, event_date 
 FROM sda.dataset_event_log 
 WHERE (dataset_id, event_date) IN (
 	SELECT dataset_id,max(event_date) FROM sda.dataset_event_log WHERE
@@ -25,8 +24,7 @@ WHERE (dataset_id, event_date) IN (
 		)
 	)
 	GROUP BY dataset_id
-);
-`
+);`
 }
 
 func (db *pgDb) listUserDatasets(ctx context.Context, tx *sql.Tx, submissionUser string) ([]*database.DatasetInfo, error) {

--- a/sda/internal/database/postgres/method_map_file_to_dataset.go
+++ b/sda/internal/database/postgres/method_map_file_to_dataset.go
@@ -11,7 +11,7 @@ const mapFileToDatasetInsertDatasetQuery = "mapFileToDatasetInsertDataset"
 func init() {
 	queries[mapFileToDatasetQuery] = `
 INSERT INTO sda.file_dataset (file_id, dataset_id, download_path)
-VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
+VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT unique_file_dataset DO NOTHING;
 `
 
 	// Here we do the UPDATE SET stable_id = EXCLUDED.stable_id to make the RETURNING id return the id

--- a/sda/internal/database/postgres/method_map_file_to_dataset.go
+++ b/sda/internal/database/postgres/method_map_file_to_dataset.go
@@ -10,8 +10,8 @@ const mapFileToDatasetInsertDatasetQuery = "mapFileToDatasetInsertDataset"
 
 func init() {
 	queries[mapFileToDatasetQuery] = `
-INSERT INTO sda.file_dataset (file_id, dataset_id)
-VALUES ($1, $2) ON CONFLICT DO NOTHING;
+INSERT INTO sda.file_dataset (file_id, dataset_id, download_path)
+VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;
 `
 
 	// Here we do the UPDATE SET stable_id = EXCLUDED.stable_id to make the RETURNING id return the id
@@ -26,7 +26,7 @@ RETURNING id;
 `
 }
 
-func (db *pgDb) mapFileToDataset(ctx context.Context, tx *sql.Tx, datasetID, fileID string) error {
+func (db *pgDb) mapFileToDataset(ctx context.Context, tx *sql.Tx, datasetID, fileID string, downloadPath *string) error {
 	stmt, err := db.getPreparedStmt(tx, mapFileToDatasetQuery)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (db *pgDb) mapFileToDataset(ctx context.Context, tx *sql.Tx, datasetID, fil
 		return err
 	}
 
-	if _, err := stmt.ExecContext(ctx, fileID, dbDatasetID); err != nil {
+	if _, err := stmt.ExecContext(ctx, fileID, dbDatasetID, downloadPath); err != nil {
 		return err
 	}
 

--- a/sda/internal/database/postgres/method_map_file_to_dataset.go
+++ b/sda/internal/database/postgres/method_map_file_to_dataset.go
@@ -9,21 +9,17 @@ const mapFileToDatasetQuery = "mapFileToDataset"
 const mapFileToDatasetInsertDatasetQuery = "mapFileToDatasetInsertDataset"
 
 func init() {
-	queries[mapFileToDatasetQuery] = `
-INSERT INTO sda.file_dataset (file_id, dataset_id, download_path)
-VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT unique_file_dataset DO NOTHING;
-`
+	queries[mapFileToDatasetQuery] = `INSERT INTO sda.file_dataset (file_id, dataset_id, download_path)
+VALUES ($1, $2, $3) ON CONFLICT ON CONSTRAINT unique_file_dataset DO NOTHING;`
 
 	// Here we do the UPDATE SET stable_id = EXCLUDED.stable_id to make the RETURNING id return the id
 	// with a ON CONFLICT DO NOTHING, the RETURNING id will not return the ID
 	// This is to reduce the need for an additional SELECT query after the insert
-	queries[mapFileToDatasetInsertDatasetQuery] = `
-INSERT INTO sda.datasets (stable_id) 
+	queries[mapFileToDatasetInsertDatasetQuery] = `INSERT INTO sda.datasets (stable_id) 
 VALUES ($1) 
 ON CONFLICT (stable_id) DO 
 	UPDATE SET stable_id = EXCLUDED.stable_id
-RETURNING id;
-`
+RETURNING id;`
 }
 
 func (db *pgDb) mapFileToDataset(ctx context.Context, tx *sql.Tx, datasetID, fileID string, downloadPath *string) error {

--- a/sda/internal/database/postgres/method_register_file.go
+++ b/sda/internal/database/postgres/method_register_file.go
@@ -8,16 +8,14 @@ import (
 const registerFileQuery = "registerFile"
 
 func init() {
-	queries[registerFileQuery] = `
-INSERT INTO sda.files(id, submission_location, submission_file_path, submission_user, encryption_method)
+	queries[registerFileQuery] = `INSERT INTO sda.files(id, submission_location, submission_file_path, submission_user, encryption_method)
 VALUES(COALESCE(CAST(NULLIF($1, '') AS UUID), gen_random_uuid()), $2, $3, $4, 'CRYPT4GH' )
     ON CONFLICT ON CONSTRAINT unique_ingested
     DO UPDATE SET submission_location = EXCLUDED.submission_location,
            submission_file_path = EXCLUDED.submission_file_path,
            submission_user = EXCLUDED.submission_user,
            encryption_method = EXCLUDED.encryption_method
-	RETURNING id;
-`
+	RETURNING id;`
 }
 
 func (db *pgDb) registerFile(ctx context.Context, tx *sql.Tx, fileID *string, inboxLocation, uploadPath, uploadUser string) (string, error) {

--- a/sda/internal/database/postgres/method_rotate_header_key.go
+++ b/sda/internal/database/postgres/method_rotate_header_key.go
@@ -10,11 +10,9 @@ import (
 const rotateHeaderKeyQuery = "rotateHeaderKey"
 
 func init() {
-	queries[rotateHeaderKeyQuery] = `
-UPDATE sda.files 
+	queries[rotateHeaderKeyQuery] = `UPDATE sda.files 
 SET header = $1, key_hash = $2 
-WHERE id = $3;
-`
+WHERE id = $3;`
 }
 
 func (db *pgDb) rotateHeaderKey(ctx context.Context, tx *sql.Tx, header []byte, keyHash, fileID string) error {

--- a/sda/internal/database/postgres/method_set_accession_id.go
+++ b/sda/internal/database/postgres/method_set_accession_id.go
@@ -9,11 +9,9 @@ import (
 const setAccessionIDQuery = "setAccessionID"
 
 func init() {
-	queries[setAccessionIDQuery] = `
-UPDATE sda.files 
+	queries[setAccessionIDQuery] = `UPDATE sda.files 
 SET stable_id = $1 
-WHERE id = $2;
-`
+WHERE id = $2;`
 }
 
 func (db *pgDb) setAccessionID(ctx context.Context, tx *sql.Tx, accessionID, fileID string) error {

--- a/sda/internal/database/postgres/method_set_archived.go
+++ b/sda/internal/database/postgres/method_set_archived.go
@@ -14,16 +14,13 @@ const (
 )
 
 func init() {
-	queries[setArchivedQuery] = `
-UPDATE sda.files 
+	queries[setArchivedQuery] = `UPDATE sda.files 
 SET archive_location = $1, archive_file_path = $2, archive_file_size = $3 
-WHERE id = $4;
-`
-	queries[setArchivedAddCheckSumQuery] = `
-INSERT INTO sda.checksums(file_id, checksum, type, source)
+WHERE id = $4;`
+
+	queries[setArchivedAddCheckSumQuery] = `INSERT INTO sda.checksums(file_id, checksum, type, source)
 VALUES($1, $2, upper($3)::sda.checksum_algorithm, upper('UPLOADED')::sda.checksum_source)
-ON CONFLICT ON CONSTRAINT unique_checksum DO UPDATE SET checksum = EXCLUDED.checksum;
-`
+ON CONFLICT ON CONSTRAINT unique_checksum DO UPDATE SET checksum = EXCLUDED.checksum;`
 }
 
 func (db *pgDb) setArchived(ctx context.Context, tx *sql.Tx, location string, file *database.FileInfo, fileID string) error {

--- a/sda/internal/database/postgres/method_set_backed_up.go
+++ b/sda/internal/database/postgres/method_set_backed_up.go
@@ -9,11 +9,9 @@ import (
 const setBackedUpQuery = "setBackedUp"
 
 func init() {
-	queries[setBackedUpQuery] = `
-UPDATE sda.files 
+	queries[setBackedUpQuery] = `UPDATE sda.files 
 SET backup_location = $1, backup_path = $2 
-WHERE id = $3;
-`
+WHERE id = $3;`
 }
 
 func (db *pgDb) setBackedUp(ctx context.Context, tx *sql.Tx, location, path, fileID string) error {

--- a/sda/internal/database/postgres/method_set_key_hash.go
+++ b/sda/internal/database/postgres/method_set_key_hash.go
@@ -9,11 +9,9 @@ import (
 const setKeyHashQuery = "setKeyHash"
 
 func init() {
-	queries[setKeyHashQuery] = `
-UPDATE sda.files 
+	queries[setKeyHashQuery] = `UPDATE sda.files 
 SET key_hash = $1 
-WHERE id = $2;
-`
+WHERE id = $2;`
 }
 func (db *pgDb) setKeyHash(ctx context.Context, tx *sql.Tx, keyHash, fileID string) error {
 	stmt, err := db.getPreparedStmt(tx, setKeyHashQuery)

--- a/sda/internal/database/postgres/method_set_submission_file_size.go
+++ b/sda/internal/database/postgres/method_set_submission_file_size.go
@@ -8,11 +8,9 @@ import (
 const setSubmissionFileSizeQuery = "setSubmissionFileSize"
 
 func init() {
-	queries[setSubmissionFileSizeQuery] = `
-UPDATE sda.files 
+	queries[setSubmissionFileSizeQuery] = `UPDATE sda.files 
 SET submission_file_size = $1 
-WHERE id = $2;
-`
+WHERE id = $2;`
 }
 
 func (db *pgDb) setSubmissionFileSize(ctx context.Context, tx *sql.Tx, fileID string, submissionFileSize int64) error {

--- a/sda/internal/database/postgres/method_set_verified.go
+++ b/sda/internal/database/postgres/method_set_verified.go
@@ -15,21 +15,15 @@ const (
 )
 
 func init() {
-	queries[setVerifiedQuery] = `
-UPDATE sda.files SET decrypted_file_size = $1 WHERE id = $2;
-`
-	queries[setVerifiedAddArchiveChecksumQuery] = `
-INSERT INTO sda.checksums(file_id, checksum, type, source)
+	queries[setVerifiedQuery] = `UPDATE sda.files SET decrypted_file_size = $1 WHERE id = $2;`
+
+	queries[setVerifiedAddArchiveChecksumQuery] = `INSERT INTO sda.checksums(file_id, checksum, type, source)
 VALUES($1, $2, upper($3)::sda.checksum_algorithm, upper('ARCHIVED')::sda.checksum_source)
-ON CONFLICT ON CONSTRAINT unique_checksum DO UPDATE SET checksum = EXCLUDED.checksum;
+ON CONFLICT ON CONSTRAINT unique_checksum DO UPDATE SET checksum = EXCLUDED.checksum;`
 
-`
-	queries[setVerifiedAddUnencryptedChecksumQuery] = `
-INSERT INTO sda.checksums(file_id, checksum, type, source)
+	queries[setVerifiedAddUnencryptedChecksumQuery] = `INSERT INTO sda.checksums(file_id, checksum, type, source)
 VALUES($1, $2, upper($3)::sda.checksum_algorithm, upper('UNENCRYPTED')::sda.checksum_source)
-ON CONFLICT ON CONSTRAINT unique_checksum DO UPDATE SET checksum = EXCLUDED.checksum;
-
-`
+ON CONFLICT ON CONSTRAINT unique_checksum DO UPDATE SET checksum = EXCLUDED.checksum;`
 }
 
 func (db *pgDb) setVerified(ctx context.Context, tx *sql.Tx, file *database.FileInfo, fileID string) error {

--- a/sda/internal/database/postgres/method_store_header.go
+++ b/sda/internal/database/postgres/method_store_header.go
@@ -10,11 +10,9 @@ import (
 const storeHeaderQuery = "storeHeader"
 
 func init() {
-	queries[storeHeaderQuery] = `
-UPDATE sda.files 
+	queries[storeHeaderQuery] = `UPDATE sda.files 
 SET header = $1 
-WHERE id = $2;
-`
+WHERE id = $2;`
 }
 
 func (db *pgDb) storeHeader(ctx context.Context, tx *sql.Tx, header []byte, id string) error {

--- a/sda/internal/database/postgres/method_update_dataset_event.go
+++ b/sda/internal/database/postgres/method_update_dataset_event.go
@@ -9,10 +9,8 @@ import (
 const updateDatasetEventQuery = "updateDatasetEvent"
 
 func init() {
-	queries[updateDatasetEventQuery] = `
-INSERT INTO sda.dataset_event_log(dataset_id, event, message) 
-VALUES($1, $2, $3);
-`
+	queries[updateDatasetEventQuery] = `INSERT INTO sda.dataset_event_log(dataset_id, event, message) 
+VALUES($1, $2, $3);`
 }
 func (db *pgDb) updateDatasetEvent(ctx context.Context, tx *sql.Tx, datasetID, status, message string) error {
 	stmt, err := db.getPreparedStmt(tx, updateDatasetEventQuery)

--- a/sda/internal/database/postgres/method_update_file_event_log.go
+++ b/sda/internal/database/postgres/method_update_file_event_log.go
@@ -11,10 +11,8 @@ import (
 const updateFileEventLogQuery = "updateFileEventLog"
 
 func init() {
-	queries[updateFileEventLogQuery] = `
-INSERT INTO sda.file_event_log(file_id, event, user_id, details, message)
-VALUES($1, $2, $3, $4, $5);
-`
+	queries[updateFileEventLogQuery] = `INSERT INTO sda.file_event_log(file_id, event, user_id, details, message)
+VALUES($1, $2, $3, $4, $5);`
 }
 func (db *pgDb) updateFileEventLog(ctx context.Context, tx *sql.Tx, fileUUID, event, user, details, message string) error {
 	stmt, err := db.getPreparedStmt(tx, updateFileEventLogQuery)

--- a/sda/internal/database/postgres/method_update_user_info.go
+++ b/sda/internal/database/postgres/method_update_user_info.go
@@ -11,13 +11,11 @@ import (
 const updateUserInfoQuery = "updateUserInfo"
 
 func init() {
-	queries[updateUserInfoQuery] = `
-INSERT INTO sda.userinfo(id, name, email, groups) VALUES($1, $2, $3, $4)
+	queries[updateUserInfoQuery] = `INSERT INTO sda.userinfo(id, name, email, groups) VALUES($1, $2, $3, $4)
 ON CONFLICT (id)
-DO UPDATE SET name = excluded.name, email = excluded.email, groups = excluded.groups;
-
-`
+DO UPDATE SET name = excluded.name, email = excluded.email, groups = excluded.groups;`
 }
+
 func (db *pgDb) updateUserInfo(ctx context.Context, tx *sql.Tx, userID, name, email string, groups []string) error {
 	stmt, err := db.getPreparedStmt(tx, updateUserInfoQuery)
 	if err != nil {

--- a/sda/internal/database/postgres/postgres.go
+++ b/sda/internal/database/postgres/postgres.go
@@ -215,8 +215,8 @@ func (db *pgDb) GetAccessionID(ctx context.Context, fileID string) (string, erro
 	return db.getAccessionID(ctx, nil, fileID)
 }
 
-func (db *pgDb) MapFileToDataset(ctx context.Context, datasetID, fileID string) error {
-	return db.mapFileToDataset(ctx, nil, datasetID, fileID)
+func (db *pgDb) MapFileToDataset(ctx context.Context, datasetID, fileID string, downloadPath *string) error {
+	return db.mapFileToDataset(ctx, nil, datasetID, fileID, downloadPath)
 }
 
 func (db *pgDb) GetInboxPath(ctx context.Context, accessionID string) (string, error) {

--- a/sda/internal/database/postgres/postgres.go
+++ b/sda/internal/database/postgres/postgres.go
@@ -23,10 +23,8 @@ const getSchemaVersionQuery = "getSchemaVersion"
 var queries = make(map[string]string)
 
 func init() {
-	queries[getSchemaVersionQuery] = `
-SELECT MAX(version) 
-FROM sda.dbschema_version;
-`
+	queries[getSchemaVersionQuery] = `SELECT MAX(version) 
+FROM sda.dbschema_version;`
 }
 
 func NewPostgresSQLDatabase(options ...func(config *dbConfig)) (database.Database, error) {

--- a/sda/internal/database/postgres/tx.go
+++ b/sda/internal/database/postgres/tx.go
@@ -98,8 +98,8 @@ func (tx *pgTx) GetAccessionID(ctx context.Context, fileID string) (string, erro
 	return tx.getAccessionID(ctx, tx.tx, fileID)
 }
 
-func (tx *pgTx) MapFileToDataset(ctx context.Context, datasetID, fileID string) error {
-	return tx.mapFileToDataset(ctx, tx.tx, datasetID, fileID)
+func (tx *pgTx) MapFileToDataset(ctx context.Context, datasetID, fileID string, downloadPath *string) error {
+	return tx.mapFileToDataset(ctx, tx.tx, datasetID, fileID, downloadPath)
 }
 
 func (tx *pgTx) GetInboxPath(ctx context.Context, accessionID string) (string, error) {

--- a/sda/internal/schema/schema.go
+++ b/sda/internal/schema/schema.go
@@ -85,9 +85,10 @@ type DatasetDeprecate struct {
 }
 
 type DatasetMapping struct {
-	Type         string   `json:"type"`
-	DatasetID    string   `json:"dataset_id"`
-	AccessionIDs []string `json:"accession_ids"`
+	Type              string            `json:"type"`
+	DatasetID         string            `json:"dataset_id"`
+	AccessionIDs      []string          `json:"accession_ids"`
+	FileDownloadPaths map[string]string `json:"file_download_paths,omitempty"`
 }
 
 type DatasetRelease struct {

--- a/sda/internal/storage/v2/locationbroker/location_broker_test.go
+++ b/sda/internal/storage/v2/locationbroker/location_broker_test.go
@@ -62,7 +62,7 @@ func (m *mockDatabase) GetFileStatus(_ context.Context, _ string) (string, error
 	panic("function not expected to be called in unit tests")
 }
 
-func (m *mockDatabase) GetFileStatusHistory(ctx context.Context, fileID string) ([]database.FileStatus, error) {
+func (m *mockDatabase) GetFileStatusHistory(_ context.Context, _ string) ([]database.FileStatus, error) {
 	panic("function not expected to be called in unit tests")
 }
 
@@ -94,7 +94,7 @@ func (m *mockDatabase) GetAccessionID(_ context.Context, _ string) (string, erro
 	panic("function not expected to be called in unit tests")
 }
 
-func (m *mockDatabase) MapFileToDataset(_ context.Context, _, _ string) error {
+func (m *mockDatabase) MapFileToDataset(_ context.Context, _, _ string, _ *string) error {
 	panic("function not expected to be called in unit tests")
 }
 

--- a/sda/internal/storage/v2/posix/writer/writer_test.go
+++ b/sda/internal/storage/v2/posix/writer/writer_test.go
@@ -429,7 +429,7 @@ func (m *notImplementedDatabase) GetAccessionID(_ context.Context, _ string) (st
 	panic("function not expected to be called in unit tests")
 }
 
-func (m *notImplementedDatabase) MapFileToDataset(_ context.Context, _, _ string) error {
+func (m *notImplementedDatabase) MapFileToDataset(_ context.Context, _, _ string, _ *string) error {
 	panic("function not expected to be called in unit tests")
 }
 

--- a/sda/internal/storage/v2/s3/writer/writer_test.go
+++ b/sda/internal/storage/v2/s3/writer/writer_test.go
@@ -444,7 +444,7 @@ func (m *notImplementedDatabase) GetAccessionID(_ context.Context, _ string) (st
 	panic("function not expected to be called in unit tests")
 }
 
-func (m *notImplementedDatabase) MapFileToDataset(_ context.Context, _, _ string) error {
+func (m *notImplementedDatabase) MapFileToDataset(_ context.Context, _, _ string, _ *string) error {
 	panic("function not expected to be called in unit tests")
 }
 

--- a/sda/mocks/database_mock.go
+++ b/sda/mocks/database_mock.go
@@ -252,8 +252,8 @@ func (m *MockDatabase) GetAccessionID(_ context.Context, fileID string) (string,
 	return args.Get(0).(string), args.Error(1)
 }
 
-func (m *MockDatabase) MapFileToDataset(_ context.Context, datasetID, fileID string) error {
-	args := m.Called(datasetID, fileID)
+func (m *MockDatabase) MapFileToDataset(_ context.Context, datasetID, fileID string, downloadPath *string) error {
+	args := m.Called(datasetID, fileID, downloadPath)
 
 	return args.Error(0)
 }

--- a/sda/schemas/isolated/dataset-mapping.json
+++ b/sda/schemas/isolated/dataset-mapping.json
@@ -31,8 +31,8 @@
         "accession_ids": {
             "$id": "#/properties/accession_ids",
             "type": "array",
-            "title": "The file stable ids in that dataset",
-            "description": "The file stable ids in that dataset",
+            "title": "The file accession ids to be added to the dataset",
+            "description": "The file accession ids to be added to the dataset",
             "examples": [
                 [
                     "anyidentifier"
@@ -42,6 +42,21 @@
             "items": {
                 "type": "string",
                 "pattern": "^\\S+$"
+            }
+        },
+        "file_download_paths": {
+            "$id": "#/properties/file_download_paths",
+            "type": "object",
+            "title": "The download path that files should be exposed with for this dataset",
+            "description": "The download path that files should be exposed with for this dataset, provided per file by file accession. If not provided for a file the download path will default to the submission path",
+            "examples": [
+                {
+                    "any_identifier": "download_path",
+                    "any_identifier_2": "download_path_2"
+                }
+            ],
+            "additionalProperties": {
+                "type": "string"
             }
         }
     }

--- a/sda/schemas/isolated/dataset-mapping.json
+++ b/sda/schemas/isolated/dataset-mapping.json
@@ -55,8 +55,14 @@
                     "any_identifier_2": "download_path_2"
                 }
             ],
+            "propertyNames": {
+                "type": "string",
+                "pattern": "^\\S+$"
+            },
             "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\S+$"
             }
         }
     }


### PR DESCRIPTION
# Related issue(s) and PR(s)
This PR closes #2501 .

# Description
Added functionality to override the exposed download path for a file within a dataset

- The file download path for a file in a dataset is set during the dataset creation(ie when a file is added to a dataset)
- The download and download-v2 services will default to the submission file path if file download path is not set for a dataset
- Updated [sda api swagger_v1.yml](cmd/api/swagger_v1.yml) DatasetCreate to allow caller to override the file download path in a dataset by the file accession
- Updated [dataset-mapping schema](schemas/isolated/dataset-mapping.json) to allow propagation of the file download path per file accession
- Added [new column to file_dataset table and bumped schema version to 25](../postgresql/migratedb.d/25_add_download_path_column_to_file_dataset.sql)

And bumping sda version -> 3.1.76 for release of change


## How to test
- Unit tests pass
