### PR TITLE
fix/sda-download download files by file_dataset.download_path

### DIFF
--- a/sda-download/internal/database/database.go
+++ b/sda-download/internal/database/database.go
@@ -342,7 +342,8 @@ SELECT files.stable_id
 FROM sda.files
  	JOIN sda.file_dataset file_dataset ON file_dataset.file_id = files.id
  	JOIN sda.datasets datasets ON file_dataset.dataset_id = datasets.id
-	WHERE datasets.stable_id = $1 AND files.submission_file_path ~ ('^[^/]*/?' || $2);`
+	WHERE datasets.stable_id = $1 
+	  AND COALESCE(file_dataset.download_path, files.submission_file_path) ~ ('^[^/]*/?' || $2);`
 	// regexp matching in the submission file path in order to disregard the
 	// first slash-separated path element. The first path element is the id of
 	// the uploading user which should not be displayed.

--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed downloading files by the `file_dataset.download_path` in the sda-download(v1) 
+
 ## [3.1.76] - 2026-07-15
 
 ### Added


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #2502 and #2501 .

## Description

[PR ](https://github.com/neicnordic/sensitive-data-archive/pull/2502) added file_dataset download_path, but the sda-download(v1) had issue downloading files with the file_dataset download_path for a dataset.

This PR fixes the `getDatasetFileStableID` used when downloading a file to use file_dataset.download_path if set.
