### PR TITLE
feat(ingest): Utilse db transaction during message handling, and requeue on retryable errors

### DIFF
--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - s3inbox: Allow forwarding of the [HeadObject action](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html) 
 
+### Changed
+
+- ingest:
+  - Use db transactions during cancel and ingest actions and rollback if encounter error.
+  - Requeue messages which could be expected to succeed on a retry.
+  - Add a "error-queue-reason" header when sending messages to the error queue which can not be retried to record reason.
+  - Update unit tests to use mocks of the db, and storage reader, writer instead of docker / temp directory.
+    - Remove redundant unit tests which are covered by other tests, and remove unit tests which should be covered by integration tests.
+  - Use log/slog for logging instead of logrus.
+- Update remaining mocks to implement github.com/stretchr/testify/mock.Mock.
+
 ### Fixed
 
 - Fixed downloading files by the `file_dataset.download_path` in the sda-download(v1) 

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -114,9 +114,17 @@ func setup() error {
 	var buf bytes.Buffer
 	sha256hash := sha256.New()
 	_ = io.MultiWriter(&buf, sha256hash)
+	content := buf.Bytes()
 
-	api.inboxReader = &mocks.MockReader{Data: buf.Bytes()}
-	api.inboxWriter = &mocks.MockWriter{}
+	mockReader := &mocks.MockReader{}
+	mockReader.On("NewFileReader", mock.Anything, mock.Anything).Return(content, nil)
+	mockReader.On("GetFileSize", mock.Anything, mock.Anything).Return(int64(len(content)), nil)
+
+	api.inboxReader = mockReader
+
+	mockWriter := &mocks.MockWriter{}
+	mockWriter.On("RemoveFile", mock.Anything, mock.Anything).Return(nil)
+	api.inboxWriter = mockWriter
 
 	rbac := []byte(
 		`{"policy":[{"role":"admin","path":"/c4gh-keys/*","action":"(GET)|(POST)|(PUT)"},
@@ -174,7 +182,10 @@ func setup() error {
 	mockDB.On("UpdateFileEventLog", fileID, "disabled", "api", "{}", "{}").Return(nil)
 
 	api.db = mockDB
-	api.mq = &mocks.MockBroker{}
+	mockBroker := &mocks.MockBroker{}
+	mockBroker.On("Publish", mock.Anything, mock.Anything).Return(nil)
+	mockBroker.On("Alive").Return(true)
+	api.mq = mockBroker
 
 	return nil
 }

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -77,7 +78,7 @@ func run() error {
 
 	app.Broker, err = rabbitmq.NewRabbitMQBroker(context.Background())
 	if err != nil {
-		return fmt.Errorf("failed to initialize mq broker, due to: %v", err)
+		return fmt.Errorf("failed to initialize mq broker: %v", err)
 	}
 
 	defer func() {
@@ -85,13 +86,13 @@ func run() error {
 			return
 		}
 		if err := app.Broker.Close(); err != nil {
-			log.Errorf("could not close Broker, due to: %v", err)
+			slog.Error("could not close broker", "error", err)
 		}
 	}()
 
 	app.db, err = postgres.NewPostgresSQLDatabase()
 	if err != nil {
-		return fmt.Errorf("failed to initialize sda db due to: %v", err)
+		return fmt.Errorf("failed to initialize sda db: %v", err)
 	}
 	defer app.db.Close()
 	if dbSchemaVersion, err := app.db.SchemaVersion(); err != nil || dbSchemaVersion < 23 {
@@ -103,36 +104,35 @@ func run() error {
 		return errors.New("no C4GH private keys configured")
 	}
 	if err := app.registerC4GHKey(ctx); err != nil {
-		return fmt.Errorf("failed to register c4gh key, due to: %v", err)
+		return fmt.Errorf("failed to register c4gh key: %v", err)
 	}
 	storageLocationBroker, err := locationbroker.NewLocationBroker(app.db)
 	if err != nil {
-		return fmt.Errorf("failed to initialize location broker, due to: %v", err)
+		return fmt.Errorf("failed to initialize location broker: %v", err)
 	}
 	app.ArchiveWriter, err = storage.NewWriter(ctx, "archive", storageLocationBroker)
 	if err != nil {
-		return fmt.Errorf("failed to initialize archive writer, due to: %v", err)
+		return fmt.Errorf("failed to initialize archive writer: %v", err)
 	}
 	app.ArchiveReader, err = storage.NewReader(ctx, "archive")
 	if err != nil {
-		return fmt.Errorf("failed to initialize archive reader, due to: %v", err)
+		return fmt.Errorf("failed to initialize archive reader: %v", err)
 	}
 	app.InboxReader, err = storage.NewReader(ctx, "inbox")
 	if err != nil {
-		return fmt.Errorf("failed to initialize inbox reader, due to: %v", err)
+		return fmt.Errorf("failed to initialize inbox reader: %v", err)
 	}
 
 	backupWriter, err := storage.NewWriter(ctx, "backup", storageLocationBroker)
 	if err != nil && !errors.Is(err, storageerrors.ErrorNoValidWriter) {
-		return fmt.Errorf("failed to initialize backup writer due to: %v", err)
+		return fmt.Errorf("failed to initialize backup writer: %v", err)
 	}
 	if backupWriter != nil {
-		log.Info("backup writer initialized, will clean cancelled files from backup storage")
+		slog.Info("backup writer initialized, will clean cancelled files from backup storage")
 		app.BackupWriter = backupWriter
 	} else {
-		log.Info("no backup writer initialized, will NOT clean cancelled files from backup storage")
+		slog.Info("no backup writer initialized, will NOT clean cancelled files from backup storage")
 	}
-	log.Info("starting ingest service")
 
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
@@ -141,16 +141,17 @@ func run() error {
 	go func() {
 		consumeErr <- app.Broker.Subscribe(ctx, ingestconf.SourceQueue(), app.handleMessage)
 	}()
+	slog.Info("ingest service started")
 
 	select {
 	case sig := <-sigc:
-		log.Infof("recieved signal: %v, shutting down gracefully", sig)
+		slog.Info("received signal, shutting down gracefully", "signal", sig)
 		cancel()
 
 		return nil
 	case err := <-consumeErr:
 		if !errors.Is(err, context.Canceled) {
-			log.Errorf("failed to consume from %s, due to: %v", ingestconf.SourceQueue(), err)
+			slog.Error("consumer failure", "error", err, "source-queue", ingestconf.SourceQueue())
 			cancel()
 
 			return err
@@ -164,32 +165,35 @@ func (app *Ingest) handleMessage(ctx context.Context, message *brokerv2.Message)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-trigger.json", ingestconf.SchemaPath()), message.Body)
-	if err != nil {
-		log.Errorf("could not validate message: %s, due to: %v", message.Key, err)
+	if err := schema.ValidateJSON(fmt.Sprintf("%s/ingestion-trigger.json", ingestconf.SchemaPath()), message.Body); err != nil {
+		slog.Error("could not validate message", "error", err, "message-key", message.Key)
 
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		// send message to error queue and do not requeue
+		return []func(){app.errorQueue(message, "could not validate message")}, nil
 	}
 
 	var ingestionTrigger schema.IngestionTrigger
-	err = json.Unmarshal(message.Body, &ingestionTrigger)
-	if err != nil {
-		log.Errorf("could not unmarshall message, due to: %v", err)
 
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+	if err := json.Unmarshal(message.Body, &ingestionTrigger); err != nil {
+		slog.Error("could not unmarshal message", "error", err, "message-key", message.Key)
+
+		// send message to error queue and do not requeue
+		return []func(){app.errorQueue(message, "could not unmarshal message")}, nil
 	}
-	log.Infof("received work (correlation-id: %s, filepath: %s, user: %s)", message.Key, ingestionTrigger.FilePath, ingestionTrigger.User)
+	slog.Info("received work", "message-key", message.Key, "filepath", ingestionTrigger.FilePath, "user", ingestionTrigger.User)
 
 	var callbacks []func()
+	var err error
 	switch ingestionTrigger.Type {
 	case "cancel":
 		callbacks, err = app.cancelFile(ctx, message.Key, message)
 	case "ingest":
 		callbacks, err = app.ingestFile(ctx, message.Key, ingestionTrigger.FilePath, ingestionTrigger.User, ingestconf.ArchivedQueue(), message)
 	default:
-		log.Warnf("unknown ingest type: %s", ingestionTrigger.Type)
+		slog.Warn("unknown ingest type", "type", ingestionTrigger.Type, "message-key", message.Key, "filepath", ingestionTrigger.FilePath, "user", ingestionTrigger.User)
 
-		return nil, errors.New("unknonw ingest type")
+		// send message to error queue and do not requeue
+		return []func(){app.errorQueue(message, "unknown ingest type")}, nil
 	}
 
 	return callbacks, err
@@ -215,67 +219,69 @@ func (app *Ingest) registerC4GHKey(ctx context.Context) error {
 func (app *Ingest) cancelFile(ctx context.Context, fileID string, message *brokerv2.Message) ([]func(), error) {
 	fileExistsInDataset, err := app.db.IsFileInDataset(ctx, fileID)
 	if err != nil {
+		// requeue message as db error is not expected and should succeed on retries
 		return nil, fmt.Errorf("failed to query db: %v", err)
 	}
 
 	if fileExistsInDataset {
-		log.Warnf("cannot cancel file: %s, as it has been added to a dataset", fileID)
+		slog.Warn("cannot cancel file as it has been added to a dataset", "file-id", fileID)
 
-		return []func(){app.errorQueue(message), app.setErrorEvent("cannot cancel file: already added to a dataset", message)}, nil
+		reason := "cannot cancel file: already added to a dataset"
+		// send message to error queue, set file error event, and do not requeue
+		return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
 	}
 
 	archiveData, err := app.db.GetArchived(ctx, fileID)
 	if err != nil {
+		// requeue message as db error is not expected and should succeed on retries
 		return nil, err
 	}
 
 	if archiveData == nil {
-		log.Warnf("file %s not found in archive, skipping", fileID)
+		slog.Warn("file not found in archive, skipping", "file-id", fileID)
 
 		return nil, nil
 	}
 
 	if archiveData.Location != "" {
 		if err := app.ArchiveWriter.RemoveFile(ctx, archiveData.Location, archiveData.FilePath); err != nil {
-			log.Errorf("failed to remove file with id %s from backup due to %v", fileID, err)
-
-			return nil, nil
+			// Just log error and continue as this should not block updating the db
+			slog.Error("failed to remove file with from archive", "error", err, "file-id", fileID)
 		}
 	}
 
 	if app.BackupWriter != nil && archiveData.BackupFilePath != "" && archiveData.BackupLocation != "" {
 		if err := app.BackupWriter.RemoveFile(ctx, archiveData.BackupLocation, archiveData.BackupFilePath); err != nil {
-			log.Errorf("failed to remove file with id %s from backup due to %v", fileID, err)
-
-			return nil, nil
+			// Just log error and continue as this should not block updating the db
+			slog.Error("failed to remove file from backup", "error", err, "file-id", fileID)
 		}
 	}
 
-	// Ideally this transaction should span the whole message processing, but for now just spans the CancelFile
 	tx, err := app.db.BeginTransaction(ctx)
 	if err != nil {
-		log.Errorf("failed to begin transaction, reason: %v", err)
-
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		slog.Error("failed to begin transaction", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
 	}
-	if err := tx.CancelFile(ctx, fileID, string(message.Body)); err != nil {
-		log.Errorf("failed to cancel file with id: %s, due to %v", fileID, err)
-
+	defer func() {
 		if err := tx.Rollback(); err != nil {
-			log.Errorf("failed to rollback CancelFile transaction, reason: %v", err)
+			slog.Error("failed to rollback transaction", "error", err, "file-id", fileID)
 		}
+	}()
 
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+	if err := tx.CancelFile(ctx, fileID, string(message.Body)); err != nil {
+		slog.Error("failed to cancel file", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
 	}
 
 	if err := tx.Commit(); err != nil {
-		log.Errorf("failed to commit CancelFile transaction, reason: %v", err)
-		_ = tx.Rollback()
-
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		slog.Error("failed to commit transaction", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
 	}
 
-	log.Infof("successfully canceled and cleaned up file: %s", fileID)
+	slog.Info("file cancelled successfully", "file-id", fileID)
 
 	return nil, nil
 }
@@ -283,17 +289,29 @@ func (app *Ingest) cancelFile(ctx context.Context, fileID string, message *broke
 func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archivedQueue string, message *brokerv2.Message) ([]func(), error) {
 	status, err := app.db.GetFileStatus(ctx, fileID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		log.Errorf("could not get file status for file: %s, due to %v", fileID, err)
-
-		return nil, nil
+		slog.Error("could not get file status for file", "error", err, "file-id", fileID)
+		// requeue message as db error(other than sql.ErrNoRows) is not expected and should succeed on retries
+		return nil, err
 	}
 
 	submissionLocation, err := app.db.GetSubmissionLocation(ctx, fileID)
 	if err != nil {
-		log.Errorf("failed to get submission location for file: %s, due to :%v", fileID, err)
-
-		return nil, nil
+		slog.Error("failed to get submission location for file", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
 	}
+
+	tx, err := app.db.BeginTransaction(ctx)
+	if err != nil {
+		slog.Error("failed to begin transaction", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			slog.Error("failed to rollback transaction", "error", err, "file-id", fileID)
+		}
+	}()
 
 	switch status {
 	case "uploaded", "disabled":
@@ -301,94 +319,121 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 	case "":
 		// Catch all for implementations inbox uploading that does not register the file in the DB, e.g. for those not using S3inbox or sftpInbox
 		// Since we dont have the submission location in storage, we need to look through all configured storage locations.
-		var findFileErr, registerErr error
+
 		// message.Key is the broker correlation-id, not the submission path; use the trigger's
 		// filePath and resolve it to the physical inbox path before locating it.
-		submissionLocation, findFileErr = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
-
-		// Ideally this transaction should span the whole message processing, but for now just spans the RegisterFile
-		tx, err := app.db.BeginTransaction(ctx)
+		submissionLocation, err = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
 		if err != nil {
-			log.Errorf("failed to begin transaction, reason: %v", err)
+			slog.Error("failed to find submission location for file", "error", err, "file-id", fileID)
 
-			return nil, nil
-		}
-
-		// Register file even if FindFile didnt succeed with submissionLocation == "", as we will add an error file event log to it in that case
-		// Store the anonymized submission path (filePath), not the correlation-id, so the mapper can resolve it back on cleanup.
-		fileID, registerErr = tx.RegisterFile(ctx, &fileID, submissionLocation, filePath, user)
-		if registerErr != nil {
-			log.Errorf("failed to register file, fileID: %s, reason: (%s)", fileID, registerErr.Error())
-			if err := tx.Rollback(); err != nil {
-				log.Errorf("failed to rollback RegisterFile transaction, reason: %v", err)
+			if errors.Is(err, storageerrors.ErrorFileNotFoundInLocation) {
+				// send message to error queue and do not requeue
+				return []func(){app.errorQueue(message, "failed to find submission location for file")}, nil
 			}
 
-			return nil, nil
-		}
-		if err := tx.Commit(); err != nil {
-			log.Errorf("failed to commit RegisterFile transaction, reason: %v", err)
-			_ = tx.Rollback()
+			return nil, err
 		}
 
-		if findFileErr != nil {
-			log.Errorf("failed to find submission location for file: %s, due to: %v", fileID, findFileErr)
+		// Store the anonymized submission path (filePath), not the correlation-id, so the mapper can resolve it back on cleanup.
+		fileID, err = tx.RegisterFile(ctx, &fileID, submissionLocation, filePath, user)
+		if err != nil {
+			slog.Error("failed to register file", "error", err, "file-id", fileID)
 
-			return []func(){app.errorQueue(message), app.setErrorEvent(findFileErr.Error(), message)}, nil
+			return nil, err
 		}
-
 		// File is now registered; fall through to read + decrypt + archive in a single pass, the same
 		// way a pre-registered "uploaded" file is handled. Returning here would leave a non-s3inbox
 		// upload stuck at "registered", so verify never runs.
 
 	default:
-		log.Warnf("file: %s received ingestion trigger with status: %s", fileID, status)
+		slog.Warn("received ingestion trigger for file with unexpected status", "file-id", fileID, "status", status)
 
-		return nil, fmt.Errorf("cannot ingest file with status: %s", status)
+		// send message to error queue and do not requeue
+		return []func(){app.errorQueue(message, "unexpected file status for ingest trigger")}, nil
+	}
+
+	if submissionLocation == "" {
+		reason := "file submission location not known"
+		slog.Error(reason, "file-id", fileID)
+		// send message to error queue, set file event log, and do not requeue
+		return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
 	}
 
 	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
 	if err != nil {
-		log.Errorf("failed to read file, due to: %v", err)
-
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		switch {
+		case errors.Is(err, storageerrors.ErrorFileNotFoundInLocation):
+			reason := "failed to find file in inbox when expected"
+			slog.Error(reason, "file-id", fileID)
+			// send message to error queue, set file event log, and do not requeue
+			return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
+		case errors.Is(err, storageerrors.ErrorInvalidLocation):
+			reason := "file has invalid submission location"
+			slog.Error(reason, "file-id", fileID, "submission-location", submissionLocation)
+			// send message to error queue, set file event log, and do not requeue
+			return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
+		case errors.Is(err, storageerrors.ErrorNoEndpointConfiguredForLocation):
+			reason := "file has submission location which is not configured"
+			slog.Error(reason, "file-id", fileID, "submission-location", submissionLocation)
+			// send message to error queue, set file event log, and do not requeue
+			return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
+		default:
+			slog.Error("failed to read file", "error", err, "file-id", fileID)
+			// requeue message as inbox error is not expected and should succeed on retries
+			return nil, err
+		}
 	}
-	defer sourceReader.Close()
+	defer func() {
+		_ = sourceReader.Close()
+	}()
 
-	if err := app.db.UpdateFileEventLog(ctx, fileID, "submitted", "ingest", "{}", string(message.Body)); err != nil {
-		log.Errorf("failed to set ingestion status for file from message, file-id: %s, due to: %v", fileID, err)
-
-		return []func(){app.errorQueue(message)}, nil
+	if err := tx.UpdateFileEventLog(ctx, fileID, "submitted", "ingest", "{}", string(message.Body)); err != nil {
+		slog.Error("failed to update file event log", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
 	}
 
-	decryptResult, err := app.decrypt(sourceReader)
+	dr, err := app.decrypt(sourceReader)
 	if err != nil {
-		log.Errorf("failed ingestion during decrypt and archive for file: %s, due to: %v", fileID, err)
-
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		slog.Error("failed ingestion during decrypt and archive", "error", err, "file-id", fileID)
+		// send message to error queue, set file event log, and do not requeue
+		return []func(){app.errorQueue(message, err.Error()), app.setErrorEvent(err.Error(), message)}, nil
 	}
 
-	location, err := app.archive(ctx, decryptResult.keyHash, fileID, decryptResult.header, decryptResult.teedReader)
+	location, err := app.archive(ctx, tx, dr.keyHash, fileID, dr.header, dr.teedReader)
 	if err != nil {
-		log.Errorf("failed to archive file: %s, due to: %v", fileID, err)
-
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		slog.Error("failed to archive file", "error", err, "file-id", fileID)
+		// requeue message as db error is not expected and should succeed on retries
+		return nil, err
 	}
 
-	checksum := fmt.Sprintf("%x", decryptResult.hash.Sum(nil))
+	checksum := fmt.Sprintf("%x", dr.hash.Sum(nil))
 
-	if err := app.finalizeDatabaseRecords(ctx, fileID, location, checksum, message); err != nil {
-		log.Errorf("failed to finalize databse records for file: %s, due to: %v", fileID, err)
-
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+	if err := app.finalizeDatabaseRecords(ctx, tx, fileID, location, checksum, message); err != nil {
+		slog.Error("failed to finalize database records", "error", err, "file-id", fileID)
+		// requeue message as error is not expected and should succeed on retries
+		return nil, err
 	}
 
+	// If commit fails we've already uploaded the file to the archive
+	// but we will still rollback and reconsume the message as that can be done again, and it would just overwrite it
+	if err := tx.Commit(); err != nil {
+		slog.Error("failed to commit transaction for ingest action", "error", err, "file-id", fileID)
+		// requeue message as broker error is not expected and should succeed on retries
+		return nil, err
+	}
+
+	// We need to send message after the commit, since there is a race condition where verify would consume and start processing the message before the commit is actioned.
+	// If notifyArchived fails we can not requeue the message as the db transaction has already been commited. Failure here would require manual intervertion.
 	if err := app.notifyArchived(ctx, fileID, filePath, user, checksum, archivedQueue, message); err != nil {
-		log.Errorf("failed to send to archived message for file: %s, due to: %v", fileID, err)
+		reason := "failed to notify archived"
+		slog.Error(reason, "error", err, "file-id", fileID)
 
-		return []func(){app.errorQueue(message), app.setErrorEvent(err.Error(), message)}, nil
+		// send message to error queue, set file event log, and do not requeue
+		return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
 	}
 
-	log.Infof("file %s ingested sucessfully", fileID)
+	slog.Info("file ingested successfully", "file-id", fileID)
 
 	return nil, nil
 }
@@ -401,7 +446,7 @@ func (app *Ingest) decrypt(source io.ReadCloser) (decryptResult, error) {
 
 	header, err := headers.ReadHeader(headerTee)
 	if err != nil {
-		return decryptResult{}, fmt.Errorf("failed to parse crypt4gh header, due to: %v", err)
+		return decryptResult{}, fmt.Errorf("failed to parse crypt4gh header: %v", err)
 	}
 
 	var validKey *[32]byte
@@ -423,13 +468,12 @@ func (app *Ingest) decrypt(source io.ReadCloser) (decryptResult, error) {
 	return decryptResult{keyHash: keyHash, hash: fileHash, teedReader: teedReader, header: header}, err
 }
 
-func (app *Ingest) archive(ctx context.Context, keyHash, fileID string, rawHeader []byte, reader io.Reader) (string, error) {
-	if err := app.db.SetKeyHash(ctx, keyHash, fileID); err != nil {
+func (app *Ingest) archive(ctx context.Context, tx database.Transaction, keyHash, fileID string, rawHeader []byte, reader io.Reader) (string, error) {
+	if err := tx.SetKeyHash(ctx, keyHash, fileID); err != nil {
 		return "", err
 	}
 
-	// TODO: Remember to clean up previous DB call in case next one errors (eg use transactions)
-	if err := app.db.StoreHeader(ctx, rawHeader, fileID); err != nil {
+	if err := tx.StoreHeader(ctx, rawHeader, fileID); err != nil {
 		return "", err
 	}
 
@@ -441,8 +485,7 @@ func (app *Ingest) archive(ctx context.Context, keyHash, fileID string, rawHeade
 	return location, nil
 }
 
-func (app *Ingest) finalizeDatabaseRecords(ctx context.Context, fileID, location, checksum string, message *brokerv2.Message) error {
-	log.Infof("finalizeDatabaseRecords: fileID=%s checksum=%s", fileID, checksum)
+func (app *Ingest) finalizeDatabaseRecords(ctx context.Context, tx database.Transaction, fileID, location, checksum string, message *brokerv2.Message) error {
 	fileSize, err := app.ArchiveReader.GetFileSize(ctx, location, fileID)
 	if err != nil {
 		return err
@@ -453,21 +496,12 @@ func (app *Ingest) finalizeDatabaseRecords(ctx context.Context, fileID, location
 	fileInfo.Size = fileSize
 	fileInfo.UploadedChecksum = checksum
 
-	status, err := app.db.GetFileStatus(ctx, fileID)
-	if err != nil {
-		return err
+	if err := tx.SetArchived(ctx, location, fileInfo, fileID); err != nil {
+		return fmt.Errorf("failed to mark file as archived, file-id: %s: %v", fileID, err)
 	}
 
-	if err := app.db.SetArchived(ctx, location, fileInfo, fileID); err != nil {
-		return fmt.Errorf("failed to mark file as archived, file-id: %s, due to: %v", fileID, err)
-	}
-
-	if status == "disabled" {
-		return nil
-	}
-
-	if err := app.db.UpdateFileEventLog(ctx, fileID, "archived", "ingest", "{}", string(message.Body)); err != nil {
-		return fmt.Errorf("failed to update file event log, file-id: %s due to: %v", fileID, err)
+	if err := tx.UpdateFileEventLog(ctx, fileID, "archived", "ingest", "{}", string(message.Body)); err != nil {
+		return fmt.Errorf("failed to update file event log, file-id: %s: %v", fileID, err)
 	}
 
 	return nil
@@ -494,7 +528,7 @@ func (app *Ingest) notifyArchived(ctx context.Context, fileID, filePath, user, c
 
 	err = schema.ValidateJSON(fmt.Sprintf("%s/ingestion-verification.json", ingestconf.SchemaPath()), messageBody)
 	if err != nil {
-		log.Errorf("could not validate message: %s, due to: %v", message.Key, err)
+		slog.Error("could not validate message", "error", err, "message-key", message.Key)
 
 		return err
 	}
@@ -510,21 +544,24 @@ func (app *Ingest) setErrorEvent(details string, message *brokerv2.Message) func
 
 		detailsJSON, err := json.Marshal(detailsMap)
 		if err != nil {
-			log.Errorf("failed to marshal details to JSON, due to: %v", err)
+			slog.Error("failed to marshal details to JSON", "error", err)
 			detailsJSON = []byte("{}")
 		}
-		err = app.db.UpdateFileEventLog(context.Background(), message.Key, "error", "ingest", string(detailsJSON), string(message.Body))
-		if err != nil {
-			log.Errorf("error from database when setting error event, due to: %v", err)
+		if err := app.db.UpdateFileEventLog(context.Background(), message.Key, "error", "ingest", string(detailsJSON), string(message.Body)); err != nil {
+			slog.Error("failed to set file event log error event", "error", err)
 		}
 	}
 }
 
-func (app *Ingest) errorQueue(message *brokerv2.Message) func() {
+func (app *Ingest) errorQueue(originMessage *brokerv2.Message, errorQueueReason string) func() {
 	return func() {
-		if err := app.Broker.Publish(context.Background(), "error", *message); err != nil {
-			log.Errorf("failed to publish to error queue: %v", err)
+		if originMessage.Headers == nil {
+			originMessage.Headers = make(map[string]any)
 		}
-		log.Infof("published message: %s to error queue", message.Key)
+		originMessage.Headers["error-queue-reason"] = errorQueueReason
+		if err := app.Broker.Publish(context.Background(), "error", *originMessage); err != nil {
+			slog.Error("failed to publish to error queue", "error", err, "message-key", originMessage.Key, "error-queue-reason", errorQueueReason)
+		}
+		slog.Info("published message to error queue", "message-key", originMessage.Key, "error-queue-reason", errorQueueReason)
 	}
 }

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -3,124 +3,28 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
-
-	"database/sql"
-	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
-	"github.com/neicnordic/sensitive-data-archive/internal/database"
-	"github.com/neicnordic/sensitive-data-archive/internal/database/postgres"
-	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/locationbroker"
-	"github.com/neicnordic/sensitive-data-archive/mocks"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/crypt4gh/streaming"
 	ingestconf "github.com/neicnordic/sensitive-data-archive/cmd/ingest/config"
 	broker "github.com/neicnordic/sensitive-data-archive/internal/broker/v2"
-	"github.com/neicnordic/sensitive-data-archive/internal/config"
-
+	"github.com/neicnordic/sensitive-data-archive/internal/database"
 	"github.com/neicnordic/sensitive-data-archive/internal/helper"
+	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/storageerrors"
+	"github.com/neicnordic/sensitive-data-archive/mocks"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/neicnordic/sensitive-data-archive/internal/schema"
-	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2"
-	"github.com/ory/dockertest/v3"
-	"github.com/ory/dockertest/v3/docker"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
-
-var mqPort int
-var dbPort uint16
-var brokerAPI string
-
-func TestMain(m *testing.M) {
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		m.Run()
-	}
-	_, b, _, _ := runtime.Caller(0)
-	rootDir := path.Join(path.Dir(b), "../../../")
-	ingestconf.SetSchemaPath(path.Join(rootDir, "sda/schemas/isolated/"))
-
-	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
-	pool, err := dockertest.NewPool("")
-	if err != nil {
-		log.Fatalf("Could not construct pool: %s", err)
-	}
-
-	// uses pool to try to connect to Docker
-	err = pool.Client.Ping()
-	if err != nil {
-		log.Fatalf("Could not connect to Docker: %s", err)
-	}
-
-	// pulls an image, creates a container based on it and runs it
-	postgresContainer, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "postgres",
-		Tag:        "15.2-alpine3.17",
-		Env: []string{
-			"POSTGRES_PASSWORD=rootpasswd",
-			"POSTGRES_DB=sda",
-		},
-		Mounts: []string{
-			fmt.Sprintf("%s/postgresql/initdb.d:/docker-entrypoint-initdb.d", rootDir),
-		},
-	}, func(config *docker.HostConfig) {
-		// set AutoRemove to true so that stopped container goes away by itself
-		config.AutoRemove = true
-		config.RestartPolicy = docker.RestartPolicy{
-			Name: "no",
-		}
-	})
-	if err != nil {
-		log.Fatalf("Could not start resource: %s", err)
-	}
-
-	dbHostAndPort := postgresContainer.GetHostPort("5432/tcp")
-	dbPortUint64, _ := strconv.ParseUint(postgresContainer.GetPort("5432/tcp"), 10, 16)
-	dbPort = uint16(dbPortUint64)
-	databaseURL := fmt.Sprintf("postgres://postgres:rootpasswd@%s/sda?sslmode=disable", dbHostAndPort)
-
-	pool.MaxWait = 120 * time.Second
-	if err = pool.Retry(func() error {
-		db, err := sql.Open("postgres", databaseURL)
-		if err != nil {
-			log.Println(err)
-
-			return err
-		}
-
-		query := "SELECT MAX(version) FROM sda.dbschema_version;"
-		var dbVersion int
-
-		return db.QueryRow(query).Scan(&dbVersion)
-	}); err != nil {
-		log.Fatalf("Could not connect to postgres: %s", err)
-	}
-
-	log.Println("starting tests")
-	code := m.Run()
-
-	log.Println("tests completed")
-	if err := pool.Purge(postgresContainer); err != nil {
-		log.Fatalf("Could not purge resource: %s", err)
-	}
-
-	os.Exit(code)
-}
 
 func TestIngestTestSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))
@@ -128,528 +32,301 @@ func TestIngestTestSuite(t *testing.T) {
 
 type TestSuite struct {
 	suite.Suite
-	filePath   string
-	pubKeyList [][32]byte
-	ingest     Ingest
-	tempDir    string
-	UserName   string
-	archiveDir string
-	inboxDir   string
+	ingest   Ingest
+	userName string
 
-	verificationDB *sql.DB
+	mockInboxReader       *mocks.MockReader
+	mockArchiveReader     *mocks.MockReader
+	mockArchiveWriter     *mocks.MockWriter
+	mockBackupWriter      *mocks.MockWriter
+	mockDB                *mocks.MockDatabase
+	mockBroker            *mocks.MockBroker
+	publicKey, privateKey [32]byte
 }
 
 func (ts *TestSuite) SetupSuite() {
 	var err error
-	viper.Set("log.level", "debug")
-	ts.tempDir = ts.T().TempDir()
-	keyFile1 := fmt.Sprintf("%s/c4gh1.key", ts.tempDir)
-	keyFile2 := fmt.Sprintf("%s/c4gh2.key", ts.tempDir)
-
-	publicKey, err := helper.CreatePrivateKeyFile(keyFile1, "test")
+	ts.publicKey, ts.privateKey, err = keys.GenerateKeyPair()
 	if err != nil {
-		ts.FailNow("Failed to create c4gh key")
-	}
-	// Add only the first public key to the list
-	ts.pubKeyList = append(ts.pubKeyList, publicKey)
-
-	_, err = helper.CreatePrivateKeyFile(keyFile2, "test")
-	if err != nil {
-		ts.FailNow("Failed to create c4gh key")
+		ts.FailNow("failed to create private c4gh key")
 	}
 
-	viper.Set("c4gh.privateKeys", []config.C4GHprivateKeyConf{
-		{FilePath: keyFile1, Passphrase: "test"},
-		{FilePath: keyFile2, Passphrase: "test"},
-	})
-	viper.Set("archive.type", "posix")
-	viper.Set("archive.location", "/tmp/")
-	viper.Set("broker.host", "localhost")
-	viper.Set("broker.port", mqPort)
-	viper.Set("broker.user", "guest")
-	viper.Set("broker.password", "guest")
-	viper.Set("broker.queue", "ingest")
-	viper.Set("broker.routingkey", "verify")
-	viper.Set("broker.vhost", "sda")
-	viper.Set("schema.path", "../../schemas/isolated/")
-
-	ts.ingest.db, err = postgres.NewPostgresSQLDatabase(
-		postgres.Host("127.0.0.1"),
-		postgres.Port(dbPort),
-		postgres.User("postgres"),
-		postgres.Password("rootpasswd"),
-		postgres.DatabaseName("sda"),
-		postgres.Schema("sda"),
-		postgres.CACert(""),
-		postgres.SslMode("disable"),
-		postgres.ClientCert(""),
-		postgres.ClientKey(""),
-	)
-	if err != nil {
-		ts.FailNow("failed to connect to database", err)
+	ts.ingest.ArchiveKeyList = []*[32]byte{
+		&ts.privateKey,
 	}
 
-	ts.verificationDB, err = sql.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%d user=postgres password=rootpasswd dbname=sda sslmode=disable search_path=sda", dbPort))
-	if err != nil {
-		ts.FailNow(fmt.Sprintf("failed to connect to database: %v", err))
-	}
+	ingestconf.SetSchemaPath("../../schemas/isolated/")
 
-	ts.ingest.Broker = &mocks.MockBroker{}
-	if err != nil {
-		ts.FailNowf("failed to setup rabbitMQ connection: %s", err.Error())
-	}
-	ts.ingest.ArchiveKeyList, err = config.GetC4GHprivateKeys()
-	if err != nil {
-		ts.FailNow("no private keys configured")
-	}
-
-	if err := ts.ingest.db.AddKeyHash(context.Background(), hex.EncodeToString(publicKey[:]), "the test key"); err != nil {
-		ts.FailNow("failed to register the public key")
-	}
-
-	ts.UserName = "test-ingest"
-}
-
-func (ts *TestSuite) TearDownSuite() {
-	if ts.verificationDB != nil {
-		ts.NoError(ts.verificationDB.Close())
-	}
-	if ts.ingest.db != nil {
-		ts.NoError(ts.ingest.db.Close())
-	}
+	ts.userName = "test-ingest"
 }
 
 func (ts *TestSuite) SetupTest() {
-	ts.archiveDir = ts.T().TempDir()
-	ts.inboxDir = ts.T().TempDir()
+	ts.mockInboxReader = &mocks.MockReader{}
+	ts.mockArchiveReader = &mocks.MockReader{}
+	ts.mockArchiveWriter = &mocks.MockWriter{}
+	ts.mockBackupWriter = &mocks.MockWriter{}
+	ts.mockDB = &mocks.MockDatabase{}
+	ts.mockBroker = &mocks.MockBroker{}
 
-	// Ensure a folder with the user name exists
-	err := os.Mkdir(path.Join(ts.inboxDir, ts.UserName), 0750)
+	ts.ingest.InboxReader = ts.mockInboxReader
+	ts.ingest.ArchiveReader = ts.mockArchiveReader
+	ts.ingest.ArchiveWriter = ts.mockArchiveWriter
+	ts.ingest.BackupWriter = ts.mockBackupWriter
+	ts.ingest.db = ts.mockDB
+	ts.ingest.Broker = ts.mockBroker
+}
+
+func (ts *TestSuite) encryptBytes(in []byte) ([]byte, []byte) {
+	contentBuf := &bytes.Buffer{}
+
+	sha256hash := sha256.New()
+	mr := io.MultiWriter(contentBuf, sha256hash)
+
+	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(mr, ts.privateKey, [][32]byte{ts.publicKey}, nil)
 	if err != nil {
-		ts.FailNow("failed to create user folder in inbox directory")
+		ts.FailNow("failed to create crypt4gh writer")
+	}
+	defer func() {
+		_ = crypt4GHWriter.Close()
+	}()
+	if _, err := io.Copy(crypt4GHWriter, bytes.NewReader(in)); err != nil {
+		ts.FailNow("failed to write to crypt4gh writer")
 	}
 
-	f, err := os.CreateTemp(path.Join(ts.inboxDir, ts.UserName), "")
-	if err != nil {
-		ts.FailNow("failed to create test file")
-	}
-	defer f.Close()
-
-	_, err = io.Copy(f, io.LimitReader(rand.Reader, 10*1024*1024))
-	if err != nil {
-		ts.FailNow("failed to write data to test file")
-	}
-
-	outFileName := f.Name() + ".c4gh"
-	outFile, err := os.Create(outFileName) // #nosec G703 -- file controlled by unit test
-	if err != nil {
-		ts.FailNow("failed to create encrypted test file")
-	}
-	defer outFile.Close()
-
-	_, privateKey, err := keys.GenerateKeyPair()
-	if err != nil {
-		ts.FailNow("failed to create private c4gh key")
-	}
-
-	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(outFile, privateKey, ts.pubKeyList, nil)
-	if err != nil {
-		ts.FailNow("failed to create c4gh writer")
-	}
-
-	_, err = io.Copy(crypt4GHWriter, io.LimitReader(rand.Reader, 10*1024*1024))
-	if err != nil {
-		ts.FailNow("failed to write data to encrypted test file")
-	}
-	crypt4GHWriter.Close()
-
-	ts.filePath = filepath.Base(outFileName)
-
-	if err := os.WriteFile(filepath.Join(ts.tempDir, "config.yaml"), []byte(fmt.Sprintf(`
-storage:
-  inbox:
-    posix:
-      - path: %s
-  archive:
-    posix:
-      - path: %s
-`, ts.inboxDir, ts.archiveDir)), 0600); err != nil {
-		ts.FailNow(err.Error())
-	}
-
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.SetConfigType("yaml")
-	viper.SetConfigFile(filepath.Join(ts.tempDir, "config.yaml"))
-	if err := viper.ReadInConfig(); err != nil {
-		ts.FailNow(err.Error())
-	}
-
-	lb, err := locationbroker.NewLocationBroker(ts.ingest.db)
-	ts.NoError(err)
-	ts.ingest.ArchiveWriter, err = storage.NewWriter(context.Background(), "archive", lb)
-	if err != nil {
-		ts.FailNow("failed to setup archive writer")
-	}
-	ts.ingest.ArchiveReader, err = storage.NewReader(context.Background(), "archive")
-	if err != nil {
-		ts.FailNow("failed to setup archive reader")
-	}
-	ts.ingest.InboxReader, err = storage.NewReader(context.Background(), "inbox")
-	if err != nil {
-		ts.FailNow("failed to setup inbox reader")
-	}
-
-	viper.Set("c4gh.privateKeys", []config.C4GHprivateKeyConf{
-		{FilePath: filepath.Join(ts.tempDir, "c4gh1.key"), Passphrase: "test"},
-		{FilePath: filepath.Join(ts.tempDir, "c4gh2.key"), Passphrase: "test"},
-	})
+	return contentBuf.Bytes(), sha256hash.Sum(nil)
 }
 
 func (ts *TestSuite) TestCancelFile_BaseCase() {
+	fileID := uuid.NewString()
 	userName := "test-cancel"
-	file1 := fmt.Sprintf("/%v/TestCancelMessage.c4gh", userName)
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, "/inbox", file1, userName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
+	filePath := fmt.Sprintf("/%v/TestCancelMessage.c4gh", userName)
 
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", userName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
+	ts.mockDB.On("IsFileInDataset", fileID).Return(false, nil)
+	ts.mockDB.On("GetArchived", fileID).Return(&database.ArchiveData{
+		FilePath:       filePath,
+		Location:       "archive_unit_test_location",
+		FileSize:       1,
+		BackupFilePath: fileID,
+		BackupLocation: "backup_unit_test_location",
+	}, nil)
+	ts.mockArchiveWriter.On("RemoveFile", "archive_unit_test_location", filePath).Return(nil)
+	ts.mockBackupWriter.On("RemoveFile", "backup_unit_test_location", fileID).Return(nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Commit").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockDB.On("CancelFile", fileID, mock.Anything).Return(nil)
 
-	assert.NoError(ts.T(), ts.ingest.db.SetArchived(context.Background(), ts.archiveDir, &database.FileInfo{
-		ArchivedChecksum:  "123",
-		Size:              500,
-		Path:              fileID,
-		DecryptedChecksum: "321",
-		DecryptedSize:     550,
-		UploadedChecksum:  "abc",
-	}, fileID))
-
-	ts.NoError(os.WriteFile(filepath.Join(ts.archiveDir, fileID), []byte("unit testing file"), 0600))
-
-	message := createMessage("cancel", file1, userName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
+	message := createMessage("cancel", filePath, userName, fileID)
+	_, err := ts.ingest.handleMessage(context.Background(), message)
 	assert.Equal(ts.T(), err, nil)
+	ts.mockArchiveWriter.AssertNumberOfCalls(ts.T(), "RemoveFile", 1)
+	ts.mockBackupWriter.AssertNumberOfCalls(ts.T(), "RemoveFile", 1)
+	ts.mockDB.AssertNumberOfCalls(ts.T(), "CancelFile", 1)
 }
 
 func (ts *TestSuite) TestCancelFile_NotArchived() {
+	fileID := uuid.NewString()
 	userName := "test-cancel"
-	file1 := fmt.Sprintf("/%v/TestCancelMessage.c4gh", userName)
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, "/inbox", file1, userName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
+	filePath := fmt.Sprintf("/%v/TestCancelMessage.c4gh", userName)
 
-	ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", userName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
+	ts.mockDB.On("IsFileInDataset", fileID).Return(false, nil)
+	ts.mockDB.On("GetArchived", fileID).Return(nil, nil)
 
-	message := createMessage("cancel", file1, userName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
+	message := createMessage("cancel", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
 	assert.NoError(ts.T(), err, "unexpected error when canceling file")
 }
 
-func (ts *TestSuite) TestCancelFile_WrongCorrelationID() {
-	userName := "test-cancel"
-	file1 := fmt.Sprintf("/%v/TestCancelMessage_wrongCorrelationID.c4gh", userName)
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, "/inbox", file1, userName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
-
-	ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", userName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	message := createMessage("cancel", file1, userName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.Equal(ts.T(), nil, err)
-}
-
 func (ts *TestSuite) TestIngestFile_BaseCase() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
+	fileID := uuid.NewString()
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
 
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
+	encryptedContent, encryptedChecksum := ts.encryptBytes([]byte("test file content"))
 
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
+	ts.mockDB.On("GetFileStatus", fileID).Return("uploaded", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("submission_unit_test_location", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Commit").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return(encryptedContent, nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "submitted", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockDB.On("SetKeyHash", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("StoreHeader", mock.Anything, fileID).Return(nil)
+	ts.mockArchiveWriter.On("WriteFile", fileID).Return("archive_unit_test_location", nil)
+	ts.mockArchiveReader.On("GetFileSize", "archive_unit_test_location", fileID).Return(int64(1), nil)
+	ts.mockDB.On("SetArchived", "archive_unit_test_location", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "archived", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockBroker.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
 	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
+	ts.mockArchiveWriter.AssertNumberOfCalls(ts.T(), "WriteFile", 1)
+	ts.mockDB.AssertCalled(ts.T(), "SetArchived", "archive_unit_test_location", database.FileInfo{
+		Size:             1,
+		Path:             fileID,
+		UploadedChecksum: fmt.Sprintf("%x", encryptedChecksum),
+	}, fileID)
+	ts.mockDB.AssertNumberOfCalls(ts.T(), "UpdateFileEventLog", 2)
+	ts.mockBroker.AssertNumberOfCalls(ts.T(), "Publish", 1)
 }
 
+// Non-s3inbox flow (e.g. FEGA-Norway via TSD): nothing pre-registers the file, so ingest's
+// catch-all (status "") is the first registration point. It must register AND archive in one
+// pass; an early return after RegisterFile would park the file at "registered" and verify would
+// never run. Guards the v3.1.72 catch-all regression.
 func (ts *TestSuite) TestIngestFile_NotRegistered_FallsThroughToArchive() {
-	// Non-s3inbox flow (e.g. FEGA-Norway via TSD): nothing pre-registers the file, so ingest's
-	// catch-all (status "") is the first registration point. It must register AND archive in one
-	// pass; an early return after RegisterFile would park the file at "registered" and verify would
-	// never run. Guards the v3.1.72 catch-all regression.
-	correlationID := uuid.New().String()
-	message := createMessage("ingest", ts.filePath, ts.UserName, correlationID)
-	_, err := ts.ingest.handleMessage(context.Background(), message)
+	fileID := uuid.NewString()
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+
+	encryptedContent, encryptedChecksum := ts.encryptBytes([]byte("test file content"))
+
+	ts.mockDB.On("GetFileStatus", fileID).Return("", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Commit").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockInboxReader.On("FindFile", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return("submission_unit_test_location", nil)
+	ts.mockDB.On("RegisterFile", &fileID, "submission_unit_test_location", filePath, userName).Return(fileID, nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return(encryptedContent, nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "submitted", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockDB.On("SetKeyHash", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("StoreHeader", mock.Anything, fileID).Return(nil)
+	ts.mockArchiveWriter.On("WriteFile", fileID).Return("archive_unit_test_location", nil)
+	ts.mockArchiveReader.On("GetFileSize", "archive_unit_test_location", fileID).Return(int64(1), nil)
+	ts.mockDB.On("SetArchived", "archive_unit_test_location", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "archived", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockBroker.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
 	assert.NoError(ts.T(), err, "unexpected error ingesting a non-registered file")
 
-	fileID, err := ts.ingest.db.GetFileIDByUserPathAndStatus(context.Background(), ts.UserName, ts.filePath, "archived")
-	assert.NoError(ts.T(), err, "non-registered file should reach 'archived' in one pass, not park at 'registered'")
-	assert.Equal(ts.T(), correlationID, fileID, "catch-all must register the file under the message correlation-id, finalize looks the file up by it")
+	ts.mockInboxReader.AssertNumberOfCalls(ts.T(), "FindFile", 1)
+	ts.mockDB.AssertNumberOfCalls(ts.T(), "RegisterFile", 1)
+	ts.mockArchiveWriter.AssertNumberOfCalls(ts.T(), "WriteFile", 1)
+	ts.mockDB.AssertCalled(ts.T(), "SetArchived", "archive_unit_test_location", database.FileInfo{
+		Size:             1,
+		Path:             fileID,
+		UploadedChecksum: fmt.Sprintf("%x", encryptedChecksum),
+	}, fileID)
+	ts.mockDB.AssertNumberOfCalls(ts.T(), "UpdateFileEventLog", 2)
+	ts.mockBroker.AssertNumberOfCalls(ts.T(), "Publish", 1)
+}
+
+func (ts *TestSuite) TestIngestFile_NotRegistered_NotFoundInInbox() {
+	fileID := uuid.NewString()
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+
+	ts.mockDB.On("GetFileStatus", fileID).Return("", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockInboxReader.On("FindFile", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return("", storageerrors.ErrorFileNotFoundInLocation)
+	ts.mockBroker.On("Publish", "error", mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
+	assert.Equal(ts.T(), nil, err)
+
+	ts.mockBroker.AssertCalled(ts.T(), "Publish", "error", mock.Anything)
 }
 
 func (ts *TestSuite) TestIngestFile_NoSubmissionLocation() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, "/inbox", ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
+	fileID := uuid.NewString()
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
 
-	ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
+	ts.mockDB.On("GetFileStatus", fileID).Return("uploaded", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "error", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockBroker.On("Publish", "error", mock.Anything).Return(nil)
 
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.Equal(ts.T(), nil, err)
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
+	assert.NoError(ts.T(), err)
+
+	ts.mockDB.AssertCalled(ts.T(), "UpdateFileEventLog", fileID, "error", "ingest", mock.Anything, mock.Anything)
+	ts.mockBroker.AssertCalled(ts.T(), "Publish", "error", mock.Anything)
 }
 
 func (ts *TestSuite) TestIngestFile_AlreadyIngested() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
+	fileID := uuid.NewString()
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
 
-	if err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}"); err != nil {
-		ts.Fail("failed to update file event log")
+	ts.mockDB.On("GetFileStatus", fileID).Return("verified", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockBroker.On("Publish", "error", mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
 	}
-
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.Error(ts.T(), err)
-}
-
-func (ts *TestSuite) TestIngestFile_UnknownInboxType() {
-	message := createMessage("ingest", ts.filePath, ts.UserName, uuid.New().String())
-	_, err := ts.ingest.handleMessage(context.Background(), message)
-	assert.Equal(ts.T(), nil, err)
-}
-
-func (ts *TestSuite) TestIngestFile_IngestDisabledFile() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
-
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "disabled", "ingest", "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-}
-
-func (ts *TestSuite) TestIngestFile_IngestDisabledFileNewChecksum() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	// first ingestion with original inbox reader
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "disabled", "ingest", "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	// generate new encrypted file in memory
-	_, privateKey, err := keys.GenerateKeyPair()
-	assert.NoError(ts.T(), err, "failed to generate c4gh key pair")
-
-	var buf bytes.Buffer
-	sha256hash := sha256.New()
-	mr := io.MultiWriter(&buf, sha256hash)
-	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(mr, privateKey, ts.pubKeyList, nil)
-	assert.NoError(ts.T(), err, "failed to create c4gh writer")
-	_, err = io.Copy(crypt4GHWriter, io.LimitReader(rand.Reader, 10*1024*1024))
-	assert.NoError(ts.T(), err, "failed to write data to encrypted test file")
-	crypt4GHWriter.Close()
-
-	// swap inbox reader to serve the new file from memory
-	originalReader := ts.ingest.InboxReader
-	ts.ingest.InboxReader = &mocks.MockReader{Data: buf.Bytes()}
-	defer func() { ts.ingest.InboxReader = originalReader }()
-
-	// reingestion should work
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	// DB should have the new checksum
-	var dbChecksum string
-	const q = "SELECT checksum from sda.checksums WHERE source = 'UPLOADED' and file_id = $1;"
-	err = ts.verificationDB.QueryRow(q, fileID).Scan(&dbChecksum)
-	assert.NoError(ts.T(), err, "failed to get checksum from database")
-	assert.Equal(ts.T(), hex.EncodeToString(sha256hash.Sum(nil)), dbChecksum)
-}
-
-func (ts *TestSuite) TestIngestFile_IngestVerifiedFile() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
-
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	sha256hash := sha256.New()
-	fi := new(database.FileInfo)
-	fi.ArchivedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
-	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
-	fi.DecryptedSize = 10 * 1024 * 1024
-	fi.Size = (10 * 1024 * 1024) + 456
-	if err := ts.ingest.db.SetVerified(context.Background(), fi, fileID); err != nil {
-		ts.Fail("failed to mark file as verified")
-	}
-
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.Error(ts.T(), err)
-}
-
-func (ts *TestSuite) TestIngestFile_IngestVerifiedDisabledFile() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
-
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	sha256hash := sha256.New()
-	fi := new(database.FileInfo)
-	fi.ArchivedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
-	fi.DecryptedChecksum = hex.EncodeToString(sha256hash.Sum(nil))
-	fi.DecryptedSize = 10 * 1024 * 1024
-	fi.Size = (10 * 1024 * 1024) + 456
-	err = ts.ingest.db.SetVerified(context.Background(), fi, fileID)
-	assert.NoError(ts.T(), err, "failed to mark file as verified")
-
-	if err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "disabled", "ingest", "{}", "{}"); err != nil {
-		ts.Fail("failed to update file event log")
-	}
-
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-}
-
-func (ts *TestSuite) TestIngestFile_IngestVerifiedCancelledFileNewChecksum() {
-	fileID, err := ts.ingest.db.RegisterFile(context.Background(), nil, ts.inboxDir, ts.filePath, ts.UserName)
-	assert.NoError(ts.T(), err, "failed to register file in database")
-
-	if err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "uploaded", ts.UserName, "{}", "{}"); err != nil {
-		ts.Fail("failed to update file event log")
-	}
-
-	message := createMessage("ingest", ts.filePath, ts.UserName, fileID)
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	var firstDbChecksum string
-	const q1 = "SELECT checksum from sda.checksums WHERE source = 'UPLOADED' and file_id = $1;"
-	if err := ts.verificationDB.QueryRow(q1, fileID).Scan(&firstDbChecksum); err != nil {
-		ts.FailNow("failed to get checksum from database")
-	}
-
-	verifiedSha256 := sha256.New()
-	fi := new(database.FileInfo)
-	fi.ArchivedChecksum = hex.EncodeToString(verifiedSha256.Sum(nil))
-	fi.DecryptedChecksum = hex.EncodeToString(verifiedSha256.Sum(nil))
-	fi.DecryptedSize = 10 * 1024 * 1024
-	fi.Size = (10 * 1024 * 1024) + 456
-	err = ts.ingest.db.SetVerified(context.Background(), fi, fileID)
-	assert.NoError(ts.T(), err, "failed to mark file as verified")
-
-	err = ts.ingest.db.UpdateFileEventLog(context.Background(), fileID, "disabled", "ingest", "{}", "{}")
-	assert.NoError(ts.T(), err, "failed to update file event log")
-
-	// overwrite the encrypted file to generate new checksum
-	f, err := os.CreateTemp(ts.inboxDir, "")
-	if err != nil {
-		ts.FailNow("failed to create test file")
-	}
-	defer f.Close()
-
-	_, err = io.Copy(f, io.LimitReader(rand.Reader, 10*1024*1024))
-	if err != nil {
-		ts.FailNow("failed to write data to test file")
-	}
-
-	_, privateKey, err := keys.GenerateKeyPair()
-	if err != nil {
-		ts.FailNow("failed to create private c4gh key")
-	}
-
-	outFile, err := os.Create(path.Join(ts.inboxDir, ts.UserName, ts.filePath))
-	if err != nil {
-		ts.FailNowf("failed to create encrypted test file: %s", err.Error())
-	}
-	defer outFile.Close()
-
-	sha256hash := sha256.New()
-	mr := io.MultiWriter(outFile, sha256hash)
-
-	crypt4GHWriter, err := streaming.NewCrypt4GHWriter(mr, privateKey, ts.pubKeyList, nil)
-	if err != nil {
-		ts.FailNowf("failed to create c4gh writer: %s", err.Error())
-	}
-
-	_, err = io.Copy(crypt4GHWriter, io.LimitReader(rand.Reader, 10*1024*1024))
-	if err != nil {
-		ts.FailNow("failed to write data to encrypted test file")
-	}
-	crypt4GHWriter.Close()
-
-	// assert.Equal(ts.T(), "ack", ts.ingest.ingestFile(context.Background(), fileID, message))
-	_, err = ts.ingest.handleMessage(context.Background(), message)
-	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
-
-	// DB should have the new checksum
-	var dbChecksum string
-	const q = "SELECT checksum from sda.checksums WHERE source = 'UPLOADED' and file_id = $1;"
-	if err := ts.verificationDB.QueryRow(q, fileID).Scan(&dbChecksum); err != nil {
-		ts.FailNow("failed to get checksum from database")
-	}
-
-	assert.Equal(ts.T(), dbChecksum, hex.EncodeToString(sha256hash.Sum(nil)))
-
-	assert.NotEqual(ts.T(), dbChecksum, firstDbChecksum)
+	assert.NoError(ts.T(), err)
+	ts.mockBroker.AssertCalled(ts.T(), "Publish", "error", mock.Anything)
 }
 
 func (ts *TestSuite) TestIngestFile_MissingFile() {
-	basepath := filepath.Dir(ts.filePath)
 	fileID := uuid.NewString()
-	message := createMessage("ingest", fmt.Sprintf("%s/missing.file.c4gh", basepath), ts.UserName, fileID)
-	_, err := ts.ingest.handleMessage(context.Background(), message)
-	assert.Equal(ts.T(), err, nil)
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+
+	ts.mockDB.On("GetFileStatus", fileID).Return("uploaded", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("submission_unit_test_location", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return(nil, storageerrors.ErrorFileNotFoundInLocation)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "error", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockBroker.On("Publish", "error", mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
+	assert.NoError(ts.T(), err, "unexpected error ingesting a missing file")
+
+	ts.mockDB.AssertCalled(ts.T(), "UpdateFileEventLog", fileID, "error", "ingest", mock.Anything, mock.Anything)
+	ts.mockBroker.AssertCalled(ts.T(), "Publish", "error", mock.Anything)
 }
 
-func (ts *TestSuite) TestRegisterC4ghKey_NewDeployment() {
-	_, err := ts.verificationDB.Exec("TRUNCATE sda.encryption_keys CASCADE;")
-	assert.NoError(ts.T(), err)
+func (ts *TestSuite) TestIngestFile_DatabaseError() {
+	fileID := uuid.NewString()
+	userName := "test-ingest"
+	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
 
-	privateKeys, err := config.GetC4GHprivateKeys()
-	assert.NoError(ts.T(), err)
-	assert.Equal(ts.T(), 2, len(privateKeys))
+	ts.mockDB.On("GetFileStatus", fileID).Return("", errors.New("some error"))
 
-	assert.NoError(ts.T(), ts.ingest.registerC4GHKey(context.Background()))
-
-	kh, err := ts.ingest.db.ListKeyHashes(context.Background())
-	assert.NoError(ts.T(), err)
-	assert.Equal(ts.T(), 2, len(kh))
-}
-
-func (ts *TestSuite) TestRegisterC4ghKey_ExistingEntry() {
-	privateKeys, err := config.GetC4GHprivateKeys()
-	assert.NoError(ts.T(), err)
-	assert.Equal(ts.T(), 2, len(privateKeys))
-
-	assert.NoError(ts.T(), ts.ingest.registerC4GHKey(context.Background()))
-
-	kh, err := ts.ingest.db.ListKeyHashes(context.Background())
-	assert.NoError(ts.T(), err)
-	assert.Equal(ts.T(), 1, len(kh))
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
+	assert.Error(ts.T(), err, "expected error when ingest has db issue")
 }
 
 func createMessage(triggerType, filePath, userID, messageKey string) *broker.Message {

--- a/sda/mocks/broker_mock.go
+++ b/sda/mocks/broker_mock.go
@@ -4,22 +4,33 @@ import (
 	"context"
 
 	broker "github.com/neicnordic/sensitive-data-archive/internal/broker/v2" //nolint: revive
+	"github.com/stretchr/testify/mock"
 )
 
-type MockBroker struct{}
-
-func (m *MockBroker) Subscribe(ctx context.Context, sourceQueue string, handleFunc func(ctx context.Context, msg *broker.Message) ([]func(), error)) error {
-	return nil
+type MockBroker struct {
+	mock.Mock
 }
 
-func (m *MockBroker) Publish(ctx context.Context, destinationQueue string, message broker.Message) error {
-	return nil
+func (m *MockBroker) Subscribe(_ context.Context, sourceQueue string, _ func(ctx context.Context, msg *broker.Message) ([]func(), error)) error {
+	args := m.Called(sourceQueue)
+
+	return args.Error(0)
+}
+
+func (m *MockBroker) Publish(_ context.Context, destinationQueue string, message broker.Message) error {
+	args := m.Called(destinationQueue, message)
+
+	return args.Error(0)
 }
 
 func (m *MockBroker) Close() error {
-	return nil
+	args := m.Called()
+
+	return args.Error(0)
 }
 
 func (m *MockBroker) Alive() bool {
-	return true
+	args := m.Called()
+
+	return args.Bool(0)
 }

--- a/sda/mocks/database_mock.go
+++ b/sda/mocks/database_mock.go
@@ -11,6 +11,18 @@ type MockDatabase struct {
 	mock.Mock
 }
 
+func (m *MockDatabase) Commit() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+func (m *MockDatabase) Rollback() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
 func (m *MockDatabase) UpdateUserInfo(_ context.Context, userID, name, email string, groups []string) error {
 	args := m.Called(userID, name, email, groups)
 
@@ -131,11 +143,19 @@ func (m *MockDatabase) DeprecateKeyHash(_ context.Context, keyHash string) error
 }
 
 func (m *MockDatabase) BeginTransaction(_ context.Context) (database.Transaction, error) {
-	panic("function not expected to be called in unit tests")
+	args := m.Called()
+
+	if err := args.Error(0); err != nil {
+		return nil, err
+	}
+
+	return m, nil
 }
 
 func (m *MockDatabase) Close() error {
-	panic("function not expected to be called in unit tests")
+	args := m.Called()
+
+	return args.Error(0)
 }
 
 func (m *MockDatabase) SchemaVersion() (int, error) {
@@ -187,7 +207,7 @@ func (m *MockDatabase) RotateHeaderKey(_ context.Context, header []byte, keyHash
 }
 
 func (m *MockDatabase) SetArchived(_ context.Context, location string, file *database.FileInfo, fileID string) error {
-	args := m.Called(location, file, fileID)
+	args := m.Called(location, *file, fileID)
 
 	return args.Error(0)
 }
@@ -223,15 +243,20 @@ func (m *MockDatabase) BackupHeader(_ context.Context, fileID string, header []b
 }
 
 func (m *MockDatabase) SetVerified(_ context.Context, file *database.FileInfo, fileID string) error {
-	args := m.Called(file, fileID)
+	args := m.Called(*file, fileID)
 
 	return args.Error(0)
 }
 
 func (m *MockDatabase) GetArchived(_ context.Context, fileID string) (*database.ArchiveData, error) {
 	args := m.Called(fileID)
+	ad, err := args.Get(0), args.Error(1)
 
-	return args.Get(0).(*database.ArchiveData), args.Error(1)
+	if ad != nil {
+		return ad.(*database.ArchiveData), err
+	}
+
+	return nil, err
 }
 
 func (m *MockDatabase) CheckAccessionIDExists(_ context.Context, accessionID, fileID string) (string, error) {
@@ -272,8 +297,12 @@ func (m *MockDatabase) UpdateDatasetEvent(_ context.Context, datasetID, status, 
 
 func (m *MockDatabase) GetFileInfo(_ context.Context, id string) (*database.FileInfo, error) {
 	args := m.Called(id)
+	fi, err := args.Get(0), args.Error(1)
+	if fi != nil {
+		return fi.(*database.FileInfo), err
+	}
 
-	return args.Get(0).(*database.FileInfo), args.Error(1)
+	return nil, err
 }
 
 func (m *MockDatabase) GetSubmissionLocation(_ context.Context, fileID string) (string, error) {
@@ -290,14 +319,22 @@ func (m *MockDatabase) GetHeaderByAccessionID(_ context.Context, accessionID str
 
 func (m *MockDatabase) GetMappingData(_ context.Context, accessionID string) (*database.MappingData, error) {
 	args := m.Called(accessionID)
+	md, err := args.Get(0), args.Error(1)
+	if md != nil {
+		return md.(*database.MappingData), err
+	}
 
-	return args.Get(0).(*database.MappingData), args.Error(1)
+	return nil, err
 }
 
 func (m *MockDatabase) GetSyncData(_ context.Context, accessionID string) (*database.SyncData, error) {
 	args := m.Called(accessionID)
+	sd, err := args.Get(0), args.Error(1)
+	if sd != nil {
+		return sd.(*database.SyncData), err
+	}
 
-	return args.Get(0).(*database.SyncData), args.Error(1)
+	return nil, err
 }
 
 func (m *MockDatabase) GetFileIDInInbox(_ context.Context, submissionUser, filePath string) (string, error) {

--- a/sda/mocks/reader_mock.go
+++ b/sda/mocks/reader_mock.go
@@ -3,24 +3,51 @@ package mocks
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
+
+	"github.com/stretchr/testify/mock"
 )
 
 type MockReader struct {
-	Data []byte
+	mock.Mock
 }
 
-func (r *MockReader) NewFileReader(_ context.Context, _, _ string) (io.ReadCloser, error) {
-	return io.NopCloser(bytes.NewReader(r.Data)), nil
+type readSeekCloser struct {
+	*bytes.Reader
 }
-func (r *MockReader) NewFileReadSeeker(_ context.Context, _, _ string) (io.ReadSeekCloser, error) {
-	return nil, errors.New("not implemented")
+
+func (readSeekCloser) Close() error { return nil }
+
+func (r *MockReader) NewFileReader(_ context.Context, location, filePath string) (io.ReadCloser, error) {
+	args := r.Called(location, filePath)
+	content, err := args.Get(0), args.Error(1)
+	if content != nil {
+		return readSeekCloser{bytes.NewReader(content.([]byte))}, err
+	}
+
+	return nil, err
 }
-func (r *MockReader) FindFile(_ context.Context, _ string) (string, error) {
-	return "archive", nil
+func (r *MockReader) NewFileReadSeeker(_ context.Context, location, filePath string) (io.ReadSeekCloser, error) {
+	args := r.Called(location, filePath)
+	content, err := args.Get(0), args.Error(1)
+	if content != nil {
+		return readSeekCloser{bytes.NewReader(content.([]byte))}, err
+	}
+
+	return nil, err
 }
-func (r *MockReader) GetFileSize(_ context.Context, _, _ string) (int64, error) {
-	return int64(len(r.Data)), nil
+func (r *MockReader) FindFile(_ context.Context, filePath string) (string, error) {
+	args := r.Called(filePath)
+
+	return args.String(0), args.Error(1)
 }
-func (r *MockReader) Ping(_ context.Context) error { return nil }
+func (r *MockReader) GetFileSize(_ context.Context, location, filePath string) (int64, error) {
+	args := r.Called(location, filePath)
+
+	return args.Get(0).(int64), args.Error(1)
+}
+func (r *MockReader) Ping(_ context.Context) error {
+	args := r.Called()
+
+	return args.Error(0)
+}

--- a/sda/mocks/writer_mock.go
+++ b/sda/mocks/writer_mock.go
@@ -3,14 +3,22 @@ package mocks
 import (
 	"context"
 	"io"
+
+	"github.com/stretchr/testify/mock"
 )
 
-type MockWriter struct{}
+type MockWriter struct {
+	mock.Mock
+}
 
 func (m *MockWriter) RemoveFile(_ context.Context, location, filePath string) error {
-	return nil
+	args := m.Called(location, filePath)
+
+	return args.Error(0)
 }
 
 func (m *MockWriter) WriteFile(_ context.Context, filePath string, _ io.Reader) (location string, err error) {
-	return "archive", nil
+	args := m.Called(filePath)
+
+	return args.String(0), args.Error(1)
 }


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2518 .


## Description
- Use db transactions during cancel and ingest actions and rollback if encounter error
- Requeue messages which could be expected to succeed on a retry
- Add a "error-queue-reason" header when sending messages to the error queue which can not be retried to record reason
- Update unit tests to use mocks of the db, and storage reader, writer instead of docker / temp directory
  - Remove redundant unit tests which are covered by other test, and remove unit tests which should be covered by integration tests.
- Use log/slog for logging instead of logrus

- Update remaining mocks to implement github.com/stretchr/testify/mock.Mock

## How to test
- Unit tests pass