### PR TITLE
[sda-admin] Optional filtering for listing files

### DIFF
--- a/sda-admin/README.md
+++ b/sda-admin/README.md
@@ -33,6 +33,25 @@ available, `sda-admin` prints the current page and prompts for `Enter` or
 `Space` before fetching the next page. Users do not need to pass a cursor
 manually.
 
+### Filtering by status
+
+Use `-status` to only show files with a given `fileStatus` (e.g. `uploaded`):
+```sh
+sda-admin file list -user test-user@example.org -status uploaded
+```
+
+### Filtering by inbox path prefix
+
+Use `-path-prefix` to only show files whose inbox path starts with the given prefix:
+```sh
+sda-admin file list -user test-user@example.org -path-prefix some/path
+```
+
+Both options are optional and can be combined:
+```sh
+sda-admin file list -user test-user@example.org -status uploaded -path-prefix some/path
+```
+
 
 ## Ingest a file
 

--- a/sda-admin/file/file.go
+++ b/sda-admin/file/file.go
@@ -34,7 +34,9 @@ type RequestBodyUpdateReason struct {
 
 // List fetches and prints all files for username, auto-paginating.
 //
-// If status is given, only files whith this specific status printed.
+// If pathPrefix is given, only files with this specific prefix printed.
+//
+// If status is given, only files with this specific status are printed.
 // Filtering happens client-side after each page is fetched.
 //
 // When stdout is a TTY (interactive session), each page is printed as it
@@ -44,12 +46,17 @@ type RequestBodyUpdateReason struct {
 // When stdout is not a TTY (e.g. piped to jq or another program), all pages
 // are collected and emitted as a single JSON array so that consumers always
 // receive valid JSON.
-func List(apiURI, token, username, status string) error {
+func List(apiURI, token, username, status, pathPrefix string) error {
 	parsedURL, err := url.Parse(apiURI)
 	if err != nil {
 		return err
 	}
 	parsedURL.Path = path.Join(parsedURL.Path, "users", username, "files")
+	if pathPrefix != "" {
+		q := parsedURL.Query()
+		q.Set("path_prefix", pathPrefix)
+		parsedURL.RawQuery = q.Encode()
+	}
 
 	isTTY := term.IsTerminal(int(os.Stdout.Fd())) //nolint:gosec
 

--- a/sda-admin/file/file.go
+++ b/sda-admin/file/file.go
@@ -34,6 +34,9 @@ type RequestBodyUpdateReason struct {
 
 // List fetches and prints all files for username, auto-paginating.
 //
+// If status is given, only files whith this specific status printed.
+// Filtering happens client-side after each page is fetched.
+//
 // When stdout is a TTY (interactive session), each page is printed as it
 // arrives and the user is prompted to press Enter or Space for the next page,
 // or Ctrl+C to abort.
@@ -41,7 +44,7 @@ type RequestBodyUpdateReason struct {
 // When stdout is not a TTY (e.g. piped to jq or another program), all pages
 // are collected and emitted as a single JSON array so that consumers always
 // receive valid JSON.
-func List(apiURI, token, username string) error {
+func List(apiURI, token, username, status string) error {
 	parsedURL, err := url.Parse(apiURI)
 	if err != nil {
 		return err
@@ -67,7 +70,7 @@ func List(apiURI, token, username string) error {
 
 		cursor = headers.Get("X-Next-Cursor")
 
-		allItems, err = handleListPage(body, cursor, isTTY, allItems)
+		allItems, err = handleListPage(body, cursor, isTTY, allItems, status)
 		if err != nil {
 			return err
 		}
@@ -90,9 +93,22 @@ func List(apiURI, token, username string) error {
 	return nil
 }
 
-func handleListPage(body []byte, cursor string, isTTY bool, allItems []json.RawMessage) ([]json.RawMessage, error) {
+func handleListPage(body []byte, cursor string, isTTY bool, allItems []json.RawMessage, status string) ([]json.RawMessage, error) {
+	var page []json.RawMessage
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if status != "" {
+		page = filterByStatus(page, status)
+	}
+
 	if isTTY {
-		_, _ = fmt.Print(string(pretty.Pretty(body)))
+		out, err := json.Marshal(page)
+		if err != nil {
+			return nil, err
+		}
+		_, _ = fmt.Print(string(pretty.Pretty(out)))
 		if cursor == "" {
 			return allItems, nil
 		}
@@ -105,12 +121,27 @@ func handleListPage(body []byte, cursor string, isTTY bool, allItems []json.RawM
 		return allItems, nil
 	}
 
-	var page []json.RawMessage
-	if err := json.Unmarshal(body, &page); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
+	return append(allItems, page...), nil
+}
+
+type fileStatusOnly struct {
+	Status string `json:"fileStatus"`
+}
+
+// filterByStatus keeps only the items whose fileStatus matches status.
+func filterByStatus(items []json.RawMessage, status string) []json.RawMessage {
+	filtered := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		var f fileStatusOnly
+		if err := json.Unmarshal(item, &f); err != nil {
+			continue
+		}
+		if f.Status == status {
+			filtered = append(filtered, item)
+		}
 	}
 
-	return append(allItems, page...), nil
+	return filtered
 }
 
 // waitForContinue is a variable so it can be replaced in tests.

--- a/sda-admin/file/file_test.go
+++ b/sda-admin/file/file_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +44,7 @@ func TestList(t *testing.T) {
 	defer func() { helpers.GetPagedResponseBody = originalFunc }()
 	helpers.GetPagedResponseBody = mockHelpers.GetPagedResponseBody
 
-	err := List("http://example.com", "test-token", "testuser")
+	err := List("http://example.com", "test-token", "testuser", "")
 	assert.NoError(t, err)
 	mockHelpers.AssertExpectations(t)
 }
@@ -312,9 +313,37 @@ func TestListMultiPage(t *testing.T) {
 	mockHelpers.On("GetPagedResponseBody", page2URL.String(), "test-token").
 		Return([]byte(`["file2"]`), http.Header{}, nil)
 
-	err := List("http://example.com", "test-token", "testuser")
+	err := List("http://example.com", "test-token", "testuser", "")
 	assert.NoError(t, err)
 	mockHelpers.AssertExpectations(t)
+}
+
+func TestListWithStatusFilter(t *testing.T) {
+	mockHelpers := new(MockHelpers)
+	mockHelpers.On("GetPagedResponseBody", "http://example.com/users/testuser/files", "test-token").
+		Return([]byte(`[{"fileID":"1","fileStatus":"uploaded"},{"fileID":"2","fileStatus":"ready"}]`), http.Header{}, nil)
+
+	originalFunc := helpers.GetPagedResponseBody
+	defer func() { helpers.GetPagedResponseBody = originalFunc }()
+	helpers.GetPagedResponseBody = mockHelpers.GetPagedResponseBody
+
+	err := List("http://example.com", "test-token", "testuser", "uploaded")
+	assert.NoError(t, err)
+	mockHelpers.AssertExpectations(t)
+}
+
+func TestFilterByStatus(t *testing.T) {
+	items := []json.RawMessage{
+		json.RawMessage(`{"fileID":"1","fileStatus":"uploaded"}`),
+		json.RawMessage(`{"fileID":"2","fileStatus":"ready"}`),
+		json.RawMessage(`{"fileID":"3","fileStatus":"uploaded"}`),
+	}
+
+	filtered := filterByStatus(items, "uploaded")
+
+	assert.Len(t, filtered, 2)
+	assert.JSONEq(t, `{"fileID":"1","fileStatus":"uploaded"}`, string(filtered[0]))
+	assert.JSONEq(t, `{"fileID":"3","fileStatus":"uploaded"}`, string(filtered[1]))
 }
 
 func TestWaitForUserContinue_NonTTYAutoContinues(t *testing.T) {

--- a/sda-admin/file/file_test.go
+++ b/sda-admin/file/file_test.go
@@ -44,7 +44,7 @@ func TestList(t *testing.T) {
 	defer func() { helpers.GetPagedResponseBody = originalFunc }()
 	helpers.GetPagedResponseBody = mockHelpers.GetPagedResponseBody
 
-	err := List("http://example.com", "test-token", "testuser", "")
+	err := List("http://example.com", "test-token", "testuser", "", "")
 	assert.NoError(t, err)
 	mockHelpers.AssertExpectations(t)
 }
@@ -313,7 +313,7 @@ func TestListMultiPage(t *testing.T) {
 	mockHelpers.On("GetPagedResponseBody", page2URL.String(), "test-token").
 		Return([]byte(`["file2"]`), http.Header{}, nil)
 
-	err := List("http://example.com", "test-token", "testuser", "")
+	err := List("http://example.com", "test-token", "testuser", "", "")
 	assert.NoError(t, err)
 	mockHelpers.AssertExpectations(t)
 }
@@ -327,7 +327,21 @@ func TestListWithStatusFilter(t *testing.T) {
 	defer func() { helpers.GetPagedResponseBody = originalFunc }()
 	helpers.GetPagedResponseBody = mockHelpers.GetPagedResponseBody
 
-	err := List("http://example.com", "test-token", "testuser", "uploaded")
+	err := List("http://example.com", "test-token", "testuser", "uploaded", "")
+	assert.NoError(t, err)
+	mockHelpers.AssertExpectations(t)
+}
+
+func TestListWithPathPrefix(t *testing.T) {
+	mockHelpers := new(MockHelpers)
+	mockHelpers.On("GetPagedResponseBody", "http://example.com/users/testuser/files?path_prefix=some%2Fpath", "test-token").
+		Return([]byte(`["file1"]`), http.Header{}, nil)
+
+	originalFunc := helpers.GetPagedResponseBody
+	defer func() { helpers.GetPagedResponseBody = originalFunc }()
+	helpers.GetPagedResponseBody = mockHelpers.GetPagedResponseBody
+
+	err := List("http://example.com", "test-token", "testuser", "", "some/path")
 	assert.NoError(t, err)
 	mockHelpers.AssertExpectations(t)
 }

--- a/sda-admin/main.go
+++ b/sda-admin/main.go
@@ -26,8 +26,8 @@ const usage = `usage: sda-admin [-uri URI] [-token TOKEN] <command> [options]
 Commands:
   user list                     List all users.
   file list -user USERNAME      List all files for a specified user.
-  file list -user USERNAME [-status STATUS]
-                                List all files for a specified user and filtered by status.
+  file list -user USERNAME [-status STATUS] [-path-prefix PREFIX]
+                                List all files for a specified user, optionally filtered by status and/or inbox path prefix.
   file ingest -filepath FILEPATH -user USERNAME
                                 Trigger ingestion of a given file.
   file set-accession -filepath FILEPATH -user USERNAME -accession-id accessionID
@@ -62,8 +62,8 @@ var userListUsage = `Usage: sda-admin user list
   List all users in the system with ongoing submissions.`
 
 var fileUsage = `List all files for a user:
-  Usage: sda-admin file list -user USERNAME [-status STATUS]
-	List all files for a specified user, optionally filtered by status.
+  Usage: sda-admin file list -user USERNAME [-status STATUS] [-path-prefix PREFIX]
+	List all files for a specified user, optionally filtered by status and/or inbox path prefix.
 
 Ingest a file:
   Usage: sda-admin file ingest -filepath FILEPATH -user USERNAME
@@ -80,18 +80,20 @@ Rotate key for a file:
 Options:
   -user USERNAME       Specify the username associated with the file.
   -status STATUS       Optional, for list. Only list files with this status.
+  -path-prefix PREFIX  Optional, for list. Only list files whose inbox path starts with this prefix.
   -filepath FILEPATH   Specify the path of the file to ingest.
   -accession-id ID     Specify the accession ID to assign to the file.
   -file-id FILEUUID    Specify the file ID of the file to rotate key.
 
 Use 'sda-admin help file <command>' for information on a specific command.`
 
-var fileListUsage = `Usage: sda-admin file list -user USERNAME [-status STATUS]
+var fileListUsage = `Usage: sda-admin file list -user USERNAME [-status STATUS] [-path-prefix PREFIX]
   List all files for a specified user.
 
 Options:
   -user USERNAME 	Specify the username associated with the files.
-  -status STATUS 	Optional. Only list files with this status.`
+  -status STATUS 	Optional. Only list files with this status.
+  -path-prefix PREFIX 	Optional. Only list files whose inbox path starts with this prefix.`
 
 var fileIngestUsage = `Usage with file path and user: sda-admin file ingest -filepath FILEPATH -user USERNAME
 Usage with file ID: sda-admin file ingest -fileid FILEUUID
@@ -356,8 +358,10 @@ func handleFileListCommand() error {
 	listFilesCmd := flag.NewFlagSet("list", flag.ExitOnError)
 	var username string
 	var status string
+	var pathPrefix string
 	listFilesCmd.StringVar(&username, "user", "", "Filter files by username")
 	listFilesCmd.StringVar(&status, "status", "", "Filter files by status")
+	listFilesCmd.StringVar(&pathPrefix, "path-prefix", "", "Filter files by inbox path prefix")
 
 	if err := listFilesCmd.Parse(flag.Args()[2:]); err != nil {
 		return fmt.Errorf("error: failed to parse command line arguments, reason: %v", err)
@@ -368,7 +372,7 @@ func handleFileListCommand() error {
 		return fmt.Errorf("error: the -user flag is required.\n%s", fileListUsage)
 	}
 
-	if err := file.List(apiURI, token, username, status); err != nil {
+	if err := file.List(apiURI, token, username, status, pathPrefix); err != nil {
 		if errors.Is(err, file.ErrAborted) {
 			return file.ErrAborted
 		}

--- a/sda-admin/main.go
+++ b/sda-admin/main.go
@@ -26,6 +26,8 @@ const usage = `usage: sda-admin [-uri URI] [-token TOKEN] <command> [options]
 Commands:
   user list                     List all users.
   file list -user USERNAME      List all files for a specified user.
+  file list -user USERNAME [-status STATUS]
+                                List all files for a specified user and filtered by status.
   file ingest -filepath FILEPATH -user USERNAME
                                 Trigger ingestion of a given file.
   file set-accession -filepath FILEPATH -user USERNAME -accession-id accessionID
@@ -60,8 +62,8 @@ var userListUsage = `Usage: sda-admin user list
   List all users in the system with ongoing submissions.`
 
 var fileUsage = `List all files for a user:
-  Usage: sda-admin file list -user USERNAME
-	List all files for a specified user.
+  Usage: sda-admin file list -user USERNAME [-status STATUS]
+	List all files for a specified user, optionally filtered by status.
 
 Ingest a file:
   Usage: sda-admin file ingest -filepath FILEPATH -user USERNAME
@@ -77,17 +79,19 @@ Rotate key for a file:
 
 Options:
   -user USERNAME       Specify the username associated with the file.
+  -status STATUS       Optional, for list. Only list files with this status.
   -filepath FILEPATH   Specify the path of the file to ingest.
   -accession-id ID     Specify the accession ID to assign to the file.
   -file-id FILEUUID    Specify the file ID of the file to rotate key.
 
 Use 'sda-admin help file <command>' for information on a specific command.`
 
-var fileListUsage = `Usage: sda-admin file list -user USERNAME
+var fileListUsage = `Usage: sda-admin file list -user USERNAME [-status STATUS]
   List all files for a specified user.
 
 Options:
-  -user USERNAME 	Specify the username associated with the files.`
+  -user USERNAME 	Specify the username associated with the files.
+  -status STATUS 	Optional. Only list files with this status.`
 
 var fileIngestUsage = `Usage with file path and user: sda-admin file ingest -filepath FILEPATH -user USERNAME
 Usage with file ID: sda-admin file ingest -fileid FILEUUID
@@ -351,7 +355,9 @@ func handleUserCommand() error {
 func handleFileListCommand() error {
 	listFilesCmd := flag.NewFlagSet("list", flag.ExitOnError)
 	var username string
+	var status string
 	listFilesCmd.StringVar(&username, "user", "", "Filter files by username")
+	listFilesCmd.StringVar(&status, "status", "", "Filter files by status")
 
 	if err := listFilesCmd.Parse(flag.Args()[2:]); err != nil {
 		return fmt.Errorf("error: failed to parse command line arguments, reason: %v", err)
@@ -362,7 +368,7 @@ func handleFileListCommand() error {
 		return fmt.Errorf("error: the -user flag is required.\n%s", fileListUsage)
 	}
 
-	if err := file.List(apiURI, token, username); err != nil {
+	if err := file.List(apiURI, token, username, status); err != nil {
 		if errors.Is(err, file.ErrAborted) {
 			return file.ErrAborted
 		}


### PR DESCRIPTION
## Description
With this PR two optional parameters have been added for the `file list` command.
- The admin can filter the files of the user by using path prefix. With this feature the admin can check files which are belonging in the same dataset.
- The admin can filter the user files by their status.

The path prefix filtering is happening on the api-side and the status filtering is happening on the client side. 

## How to test
This can be tested by running the `sda-admin` and add `4f7df025d3c8c6c645a8be3e6d42b5789ffc953e@lifescience-ri.eu` as user in the `BP-staging`. There are files with different statuses and with different inbox path.

You will need the download token which can be fetched by logging in to the BP-staging.