### PR TITLE
Run tests against stable k8s version

### DIFF
--- a/.github/workflows/pr_build_and_test_images.yml
+++ b/.github/workflows/pr_build_and_test_images.yml
@@ -302,14 +302,11 @@ jobs:
     strategy:
       matrix:
         deployment: ["federated", "isolated"]
-        version: ["1.32", "1.33"]
+        version: ["1.36"]
         tls: ["true", "false"]
         storage: ["posix", "s3"]
         exclude:
-          - version: "1.32"
-            tls: "false"
-            storage: "posix"
-          - version: "1.33"
+          - version: "1.36"
             tls: "false"
             storage: "posix"
     steps:

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ k3d-version-check:
 		echo "kubectl is missing";\
 	fi
 k3d-create-cluster:
-	@k3d cluster create --agents 2 --image rancher/k3s:v1.34.2-k3s1 \
+	@k3d cluster create --agents 2 --image rancher/k3s:v1.36.3-k3s1 \
 	--port "80:80@loadbalancer" \
 	--port "443:443@loadbalancer"
 k3d-delete-cluster:


### PR DESCRIPTION
Both 1.23 and 1.33 are EOL.
