### PR TITLE
[s3inbox]: log reasons for failed readiness check 

### DIFF
--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -61,7 +61,7 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	err = p.httpsGetCheck(s3url)
+	err = p.httpsGetCheck(r.Context(), s3url)
 	if err != nil {
 		log.Error(err)
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -72,9 +72,9 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 // httpsGetCheck sends a request to the S3 backend and makes sure it is healthy
-func (p *Proxy) httpsGetCheck(uri string) error {
+func (p *Proxy) httpsGetCheck(ctx context.Context, uri string) error {
 	// Use a dedicated context timeout for readiness checks so s3inbox logs the timeout first
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -74,7 +74,7 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, r *http.Request) {
 // httpsGetCheck sends a request to the S3 backend and makes sure it is healthy
 func (p *Proxy) httpsGetCheck(uri string) error {
 	// Use a dedicated context timeout for readiness checks so s3inbox logs the timeout first
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)

--- a/sda/cmd/s3inbox/healthchecks.go
+++ b/sda/cmd/s3inbox/healthchecks.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
+	"time"
 
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
 	log "github.com/sirupsen/logrus"
@@ -69,13 +73,25 @@ func (p *Proxy) CheckHealth(w http.ResponseWriter, r *http.Request) {
 
 // httpsGetCheck sends a request to the S3 backend and makes sure it is healthy
 func (p *Proxy) httpsGetCheck(uri string) error {
-	resp, e := p.client.Get(uri) // #nosec G704 uri originates from configuration
-	if e != nil {
-		return e
+	// Use a dedicated context timeout for readiness checks so s3inbox logs the timeout first
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create health check request: %w", err)
 	}
-	_ = resp.Body.Close() // ignoring error
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("returned status %d", resp.StatusCode)
+
+	resp, e := p.client.Do(req)
+	if e != nil {
+		return fmt.Errorf("S3 backend check failed for %s: %w", uri, e)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+
+		return fmt.Errorf("S3 check to %s returned status %d: %s", uri, resp.StatusCode, strings.TrimSpace(string(bodyBytes)))
 	}
 
 	return nil

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -92,9 +92,16 @@ func (ts *HealthcheckTestSuite) TestHttpsGetCheck() {
 	assert.NoError(ts.T(), p.httpsGetCheck(url))
 
 	// HTTP Non-200 Status Response (Server reachable, but path not found)
-	err := p.httpsGetCheck("http://127.0.0.1:8888/nonexistent")
+	mock404Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>`))
+	}))
+	defer mock404Server.Close()
+
+	err := p.httpsGetCheck(mock404Server.URL + "/nonexistent")
 	assert.Error(ts.T(), err)
-	assert.Contains(ts.T(), err.Error(), "S3 check to http://127.0.0.1:8888/nonexistent returned status 404")
+	assert.Contains(ts.T(), err.Error(), fmt.Sprintf("S3 check to %s/nonexistent returned status 404", mock404Server.URL))
+	assert.Contains(ts.T(), err.Error(), "<Code>NoSuchKey</Code>")
 
 	// HTTP Non-200 response with S3 error body extraction
 	mockS3ErrorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
@@ -85,9 +87,38 @@ func (ts *HealthcheckTestSuite) TearDownTest() {
 func (ts *HealthcheckTestSuite) TestHttpsGetCheck() {
 	p := NewProxy(ts.mockS3Conf, ts.s3ClientToMock, &helper.AlwaysAllow{}, ts.messenger, ts.database, new(tls.Config))
 
+	// Success path (200 OK)
 	url, _ := p.getS3ReadyPath()
 	assert.NoError(ts.T(), p.httpsGetCheck(url))
-	assert.Error(ts.T(), p.httpsGetCheck("http://127.0.0.1:8888/nonexistent"), "404 should fail")
+
+	// HTTP Non-200 Status Response (Server reachable, but path not found)
+	err := p.httpsGetCheck("http://127.0.0.1:8888/nonexistent")
+	assert.Error(ts.T(), err)
+	assert.Contains(ts.T(), err.Error(), "S3 check to http://127.0.0.1:8888/nonexistent returned status 404")
+
+	// HTTP Non-200 response with S3 error body extraction
+	mockS3ErrorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`<Error><Code>AccessDenied</Code><Message>Access Denied.</Message></Error>`))
+	}))
+	defer mockS3ErrorServer.Close()
+
+	err = p.httpsGetCheck(mockS3ErrorServer.URL)
+	assert.Error(ts.T(), err)
+	assert.Contains(ts.T(), err.Error(), fmt.Sprintf("S3 check to %s returned status 403", mockS3ErrorServer.URL))
+	assert.Contains(ts.T(), err.Error(), "<Code>AccessDenied</Code>")
+
+	// Timeout / Context Deadline Exceeded (S3 hangs)
+	mockHangingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(6 * time.Second) // Exceeds the 5s context timeout
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockHangingServer.Close()
+
+	err = p.httpsGetCheck(mockHangingServer.URL)
+	assert.Error(ts.T(), err)
+	assert.Contains(ts.T(), err.Error(), fmt.Sprintf("S3 backend check failed for %s", mockHangingServer.URL))
+	assert.Contains(ts.T(), err.Error(), "context deadline exceeded")
 }
 
 func (ts *HealthcheckTestSuite) TestS3URL() {

--- a/sda/cmd/s3inbox/healthchecks_test.go
+++ b/sda/cmd/s3inbox/healthchecks_test.go
@@ -89,7 +89,7 @@ func (ts *HealthcheckTestSuite) TestHttpsGetCheck() {
 
 	// Success path (200 OK)
 	url, _ := p.getS3ReadyPath()
-	assert.NoError(ts.T(), p.httpsGetCheck(url))
+	assert.NoError(ts.T(), p.httpsGetCheck(context.Background(), url))
 
 	// HTTP Non-200 Status Response (Server reachable, but path not found)
 	mock404Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +98,7 @@ func (ts *HealthcheckTestSuite) TestHttpsGetCheck() {
 	}))
 	defer mock404Server.Close()
 
-	err := p.httpsGetCheck(mock404Server.URL + "/nonexistent")
+	err := p.httpsGetCheck(context.Background(), mock404Server.URL+"/nonexistent")
 	assert.Error(ts.T(), err)
 	assert.Contains(ts.T(), err.Error(), fmt.Sprintf("S3 check to %s/nonexistent returned status 404", mock404Server.URL))
 	assert.Contains(ts.T(), err.Error(), "<Code>NoSuchKey</Code>")
@@ -110,19 +110,19 @@ func (ts *HealthcheckTestSuite) TestHttpsGetCheck() {
 	}))
 	defer mockS3ErrorServer.Close()
 
-	err = p.httpsGetCheck(mockS3ErrorServer.URL)
+	err = p.httpsGetCheck(context.Background(), mockS3ErrorServer.URL)
 	assert.Error(ts.T(), err)
 	assert.Contains(ts.T(), err.Error(), fmt.Sprintf("S3 check to %s returned status 403", mockS3ErrorServer.URL))
 	assert.Contains(ts.T(), err.Error(), "<Code>AccessDenied</Code>")
 
 	// Timeout / Context Deadline Exceeded (S3 hangs)
 	mockHangingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(6 * time.Second) // Exceeds the 5s context timeout
+		time.Sleep(16 * time.Second) // Exceeds the 15s context timeout
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer mockHangingServer.Close()
 
-	err = p.httpsGetCheck(mockHangingServer.URL)
+	err = p.httpsGetCheck(context.Background(), mockHangingServer.URL)
 	assert.Error(ts.T(), err)
 	assert.Contains(ts.T(), err.Error(), fmt.Sprintf("S3 backend check failed for %s", mockHangingServer.URL))
 	assert.Contains(ts.T(), err.Error(), "context deadline exceeded")


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1540 

## Description
This PR enhances the s3inbox readiness probe logging by enriching error details when the S3 backend health check fails or times out.

## How to test
Unit tests pass