### PR TITLE
test(download): probe and test the session cookie with an unseen token

### DIFF
--- a/.github/integration/tests/download/main_test.go
+++ b/.github/integration/tests/download/main_test.go
@@ -78,19 +78,17 @@ func (ts *TestSuite) probeCapabilities() {
 	resp, _, reqErr := ts.doRequest("GET", "/files/"+fileID+"/content", nil, ts.authHeaders())
 	ts.hasStorageFile = reqErr == nil && resp.StatusCode == http.StatusOK
 
-	// Probe session cookie: check if first auth request sets sda_session
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", ts.downloadURL+"/datasets", nil)
-	req.Header.Set("Authorization", "Bearer "+ts.token)
-	cookieResp, cookieErr := http.DefaultClient.Do(req)
-	if cookieErr == nil {
-		for _, c := range cookieResp.Cookies() {
-			if c.Name == "sda_session" {
-				ts.hasSessionCache = true
-
-				break
-			}
+	// Probe session cookie. The service only sets sda_session on a request it
+	// authenticates from scratch, and ts.token is already in its token cache
+	// from getFirstFileID above, so probe with a token it has not seen.
+	if probeToken, tokenErr := ts.generateToken("integration_test@example.org"); tokenErr == nil {
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", ts.downloadURL+"/datasets", nil)
+		req.Header.Set("Authorization", "Bearer "+probeToken)
+		cookieResp, cookieErr := http.DefaultClient.Do(req)
+		if cookieErr == nil {
+			ts.hasSessionCache = sessionCookie(cookieResp) != nil
+			cookieResp.Body.Close()
 		}
-		cookieResp.Body.Close()
 	}
 
 	ts.T().Logf("Environment capabilities: reencrypt=%v, storageFile=%v, sessionCache=%v",
@@ -126,6 +124,10 @@ func (ts *TestSuite) generateToken(sub string) (string, error) {
 		Issuer:    "http://integration.test",
 		ExpiresAt: jwt.NewNumericDate(time.Now().Add(30 * time.Minute)),
 		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		// Unique per call: iat/exp have second precision, so without this two
+		// tokens minted for the same subject in the same second are identical
+		// and hit the service's token cache instead of authenticating afresh.
+		ID: fmt.Sprintf("%d", time.Now().UnixNano()),
 	})
 
 	token.Header["kid"] = "rsa1"
@@ -139,6 +141,17 @@ func (ts *TestSuite) generateToken(sub string) (string, error) {
 	}
 
 	return token.SignedString(keyRaw)
+}
+
+// sessionCookie returns the sda_session cookie from a response, or nil.
+func sessionCookie(resp *http.Response) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == "sda_session" {
+			return c
+		}
+	}
+
+	return nil
 }
 
 func (ts *TestSuite) doRequest(method, path string, body io.Reader, headers map[string]string) (*http.Response, []byte, error) {
@@ -457,40 +470,50 @@ func (ts *TestSuite) Test15_OpaqueTokenNotJWTShaped() {
 // Test17_SessionCookieReuse tests that a session cookie from a previous request
 // can be reused to authenticate without sending the token again
 func (ts *TestSuite) Test17_SessionCookieReuse() {
-	// First request with JWT to get a session cookie
+	if !ts.hasSessionCache {
+		ts.T().Skip("REQUIRES_SESSION_CACHE: visa processing may prevent caching in combined mode")
+		return
+	}
+
+	// The cookie is only set on a request the service authenticates from
+	// scratch, so use a token it has not seen (ts.token is already cached).
+	token, err := ts.generateToken("integration_test@example.org")
+	ts.Require().NoError(err)
+
+	// First request with the fresh JWT: expect a session cookie.
+	// Use a jar-less client so we can inspect cookies manually.
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ts.downloadURL+"/datasets", nil)
 	ts.Require().NoError(err)
-	req.Header.Set("Authorization", "Bearer "+ts.token)
+	req.Header.Set("Authorization", "Bearer "+token)
 
-	// Use a jar-less client so we can inspect cookies manually
 	resp, err := http.DefaultClient.Do(req)
 	ts.Require().NoError(err)
 	defer resp.Body.Close()
 	ts.Require().Equal(http.StatusOK, resp.StatusCode)
 
-	// Extract session cookie from response
-	var sessionCookie *http.Cookie
-	for _, c := range resp.Cookies() {
-		if c.Name == "sda_session" {
-			sessionCookie = c
-			break
-		}
-	}
-	if !ts.hasSessionCache {
-		ts.T().Skip("REQUIRES_SESSION_CACHE: visa processing may prevent caching in combined mode")
-		return
-	}
-	ts.Require().NotNil(sessionCookie, "response should set sda_session cookie")
+	cookie := sessionCookie(resp)
+	ts.Require().NotNil(cookie, "first request with a fresh token should set sda_session cookie")
 
-	// Second request with only the session cookie (no Authorization header)
+	// Second request with the same JWT is served from the token cache: no new cookie
 	req2, err := http.NewRequestWithContext(context.Background(), "GET", ts.downloadURL+"/datasets", nil)
 	ts.Require().NoError(err)
-	req2.AddCookie(sessionCookie)
+	req2.Header.Set("Authorization", "Bearer "+token)
 
 	resp2, err := http.DefaultClient.Do(req2)
 	ts.Require().NoError(err)
 	defer resp2.Body.Close()
-	ts.Equal(http.StatusOK, resp2.StatusCode,
+	ts.Equal(http.StatusOK, resp2.StatusCode)
+	ts.Nil(sessionCookie(resp2), "request served from the token cache should not set a new sda_session cookie")
+
+	// Third request with only the session cookie (no Authorization header)
+	req3, err := http.NewRequestWithContext(context.Background(), "GET", ts.downloadURL+"/datasets", nil)
+	ts.Require().NoError(err)
+	req3.AddCookie(cookie)
+
+	resp3, err := http.DefaultClient.Do(req3)
+	ts.Require().NoError(err)
+	defer resp3.Body.Close()
+	ts.Equal(http.StatusOK, resp3.StatusCode,
 		"session cookie should authenticate without access token")
 }
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2542.

## Description
`Test17_SessionCookieReuse` never ran. `probeCapabilities()` sent `GET /datasets`
with `ts.token` and looked for an `sda_session` cookie, but `getFirstFileID()` had
already authenticated with that token a few lines earlier. The service only sets
the cookie on a request it authenticates from scratch, so the probe hit the token
cache, saw no cookie, and the test skipped on every CI run with a message blaming
combined-mode visa processing. Test17 used `ts.token` for its own first request
too, so it would have failed even with a working probe.

The probe and Test17 now mint a token the service has not seen. `generateToken`
adds a nanosecond `jti`, since `iat`/`exp` have second precision and two tokens
for the same subject minted in the same second were otherwise identical.

Test17 also asserts what the docs in #2541 describe: `Set-Cookie` on the first
request, no new `Set-Cookie` on a second request with the same token, and 200 on
a request carrying only the cookie.

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

## How to test
Run the download v2 integration job and check the log: it should show
`sessionCache=true` and `--- PASS: TestDownloadTestSuite/Test17_SessionCookieReuse`
instead of the `--- SKIP` every earlier run has.

Verified locally against `dev-tools/download-v2-dev` on the PR2541 image: the
file on `main` logs `sessionCache=false` and skips, this one logs
`sessionCache=true` and passes.
