### PR TITLE
fix(storage-v2): handle every s3 endpoint being full

### DIFF
--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed downloading files by the `file_dataset.download_path` in the sda-download(v1) 
+- s3 writer: don't panic or upload to an empty bucket name when every endpoint is full
 
 ## [3.1.76] - 2026-07-15
 

--- a/sda/internal/storage/v2/s3/writer/write_file.go
+++ b/sda/internal/storage/v2/s3/writer/write_file.go
@@ -44,6 +44,12 @@ func (writer *Writer) WriteFile(ctx context.Context, filePath string, fileConten
 	}
 	writer.Unlock()
 
+	// No endpoint had a free bucket, so there is nowhere to write. Bail out
+	// before the upload runs against an empty bucket name.
+	if activeBucket == "" {
+		return "", storageerrors.ErrorNoFreeBucket
+	}
+
 	client, err := writer.activeEndpoint.getS3Client(ctx)
 	if err != nil {
 		return "", err

--- a/sda/internal/storage/v2/s3/writer/writer.go
+++ b/sda/internal/storage/v2/s3/writer/writer.go
@@ -69,6 +69,20 @@ func NewWriter(ctx context.Context, backendName string, locationBroker locationb
 		return nil, storageerrors.ErrorNoValidLocations
 	}
 
+	// Every configured endpoint is full. Point the writer at the first one
+	// anyway so activeEndpoint is never nil once NewWriter has succeeded,
+	// which is the invariant WriteFile relies on when it dereferences it.
+	// WriteFile rolls over between the configured endpoints on every call, so
+	// writes resume on their own once a bucket frees up, and until then
+	// WriteFile reports ErrorNoFreeBucket. Failing here instead would stop the
+	// service from starting over a condition that is usually temporary, and
+	// storage.NewWriter reads ErrorNoValidLocations as "s3 has no writer
+	// configured" and would silently fall back to a posix writer.
+	if writer.activeEndpoint == nil {
+		log.Warningf("s3: no endpoint of backend %s has an available bucket, writes fail until one frees up", backendName)
+		writer.activeEndpoint = writer.configuredEndpoints[0]
+	}
+
 	return writer, nil
 }
 func getS3ClientForEndpoint(ctx context.Context, configuredEndpoints []*endpointConfig, endpoint string) (*s3.Client, error) {

--- a/sda/internal/storage/v2/s3/writer/writer_test.go
+++ b/sda/internal/storage/v2/s3/writer/writer_test.go
@@ -364,3 +364,83 @@ func (ts *WriterTestSuite) TestWriteFile_NoMockLocationBroker_FirstBucketFull() 
 	ts.Equal(ts.s3Mock1.buckets["bucket_in_1-2"]["test_file_1.txt"], content)
 	ts.Equal(fmt.Sprintf("%s/bucket_in_1-2", ts.s3Mock1.server.URL), location)
 }
+
+// fillAllEndpoints fills every configured endpoint to its limits: it puts
+// max_buckets (3) prefixed buckets on both mock endpoints and makes the
+// broker report each of them at more than max_objects (10 and 5), so
+// findActiveBucket returns ErrorNoFreeBucket for both endpoints. The
+// expectations are deliberately not `.Once()` — the same locations are
+// looked up both while constructing the writer and while writing.
+func (ts *WriterTestSuite) fillAllEndpoints(broker *mockLocationBroker) {
+	ts.s3Mock1.buckets = map[string]map[string]string{}
+	ts.s3Mock2.buckets = map[string]map[string]string{}
+
+	for i := 1; i <= 3; i++ {
+		bucket1 := fmt.Sprintf("bucket_in_1-%d", i)
+		bucket2 := fmt.Sprintf("bucket_in_2-%d", i)
+		ts.s3Mock1.buckets[bucket1] = make(map[string]string)
+		ts.s3Mock2.buckets[bucket2] = make(map[string]string)
+		broker.On("GetObjectCount", fmt.Sprintf("%s/%s", ts.s3Mock1.server.URL, bucket1)).Return(11, nil)
+		broker.On("GetObjectCount", fmt.Sprintf("%s/%s", ts.s3Mock2.server.URL, bucket2)).Return(11, nil)
+	}
+}
+
+// TestNewWriter_AllEndpointsFull_KeepsWriterUsable covers the first half of
+// #2546. When every endpoint reports ErrorNoFreeBucket the endpoints are
+// still appended to configuredEndpoints so WriteFile can roll over to them
+// once space frees up, but activeEndpoint was only assigned on the success
+// path. The `len(configuredEndpoints) == 0` guard then passed and NewWriter
+// returned a writer with a nil activeEndpoint, which the next WriteFile
+// dereferenced. NewWriter must keep the writer usable — a full backend is a
+// temporary condition and must not stop the service from starting — while
+// leaving activeEndpoint set so nothing dereferences nil.
+func (ts *WriterTestSuite) TestNewWriter_AllEndpointsFull_KeepsWriterUsable() {
+	broker := &mockLocationBroker{}
+	broker.On("RegisterSizeAndCountFinderFunc").Return().Once()
+	ts.fillAllEndpoints(broker)
+
+	writer, err := NewWriter(context.TODO(), "test", broker)
+	ts.NoError(err, "a full backend is temporary and must not stop the service from starting")
+	ts.Require().NotNil(writer)
+
+	ts.NotNil(writer.activeEndpoint, "activeEndpoint must be set even when every endpoint is full, WriteFile dereferences it")
+	ts.Len(writer.configuredEndpoints, 2, "full endpoints must stay configured so WriteFile can roll over once space frees up")
+}
+
+// TestWriteFile_AllEndpointsFull_FromStart is the write-time consequence of
+// the nil activeEndpoint above: the writer is built while every endpoint is
+// already full, and the first write panicked in getS3Client. It must return
+// ErrorNoFreeBucket instead.
+func (ts *WriterTestSuite) TestWriteFile_AllEndpointsFull_FromStart() {
+	broker := &mockLocationBroker{}
+	broker.On("RegisterSizeAndCountFinderFunc").Return().Once()
+	ts.fillAllEndpoints(broker)
+
+	writer, err := NewWriter(context.TODO(), "test", broker)
+	ts.Require().NoError(err)
+
+	var location string
+	ts.Require().NotPanics(func() {
+		location, err = writer.WriteFile(context.TODO(), "test_file_1.txt", bytes.NewReader([]byte("test file 1")))
+	})
+
+	ts.ErrorIs(err, storageerrors.ErrorNoFreeBucket)
+	ts.Empty(location)
+}
+
+// TestWriteFile_AllEndpointsBecomeFull covers the second half of #2546: the
+// writer started with a free bucket, but by the time it writes every
+// endpoint is full. The rollover loop `continue`s past each endpoint on
+// ErrorNoFreeBucket and ends with activeBucket still empty, and nothing
+// checked it, so the upload ran with Bucket: aws.String("").
+func (ts *WriterTestSuite) TestWriteFile_AllEndpointsBecomeFull() {
+	ts.Require().NotNil(ts.writer.activeEndpoint, "writer starts out with an active endpoint")
+	ts.fillAllEndpoints(ts.locationBrokerMock)
+
+	location, err := ts.writer.WriteFile(context.TODO(), "test_file_1.txt", bytes.NewReader([]byte("test file 1")))
+
+	ts.ErrorIs(err, storageerrors.ErrorNoFreeBucket)
+	ts.Empty(location)
+	ts.NotContains(ts.s3Mock1.buckets, "", "nothing may be uploaded to an empty bucket name")
+	ts.NotContains(ts.s3Mock2.buckets, "", "nothing may be uploaded to an empty bucket name")
+}


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #2546.

Both bugs are pre-existing. The first was surfaced by the review bot on #2545, the second spotted by @KarlG-nbis while reviewing it. #2545 touches `loadConfig` in the same files, so this needs a small rebase once that merges. That rebase also matters here: after #2545 `loadConfig` returns only writer-enabled entries, so the fallback described below cannot land on a `writer_disabled` endpoint.

## Description

Two missing checks in the s3 writer, both on the path where no endpoint has a free bucket.

**`NewWriter` returned a writer with a nil `activeEndpoint`.** A full endpoint is still appended to `configuredEndpoints`, deliberately, so `WriteFile` can roll over to it once space frees up — but `activeEndpoint` was only assigned on the success path. With every endpoint full the `len(configuredEndpoints) == 0` guard still passed, and the next `WriteFile` panicked on the nil receiver:

```
.../s3/writer.(*endpointConfig).getS3Client(0x0?, ...)        config.go:119
.../s3/writer.(*endpointConfig).findActiveBucket(0x0, ...)    config.go:189
.../s3/writer.(*Writer).WriteFile(...)                        write_file.go:17
```

**`WriteFile` uploaded to bucket `""`.** The rollover loop `continue`s past each endpoint on `ErrorNoFreeBucket`, so it can end with `activeBucket` still empty, and nothing checked it before `UploadObject`:

```
failed to upload object: test_file_1.txt, bucket: , endpoint: http://127.0.0.1:40199, ...
```

That half is a plain missing check; it now returns `storageerrors.ErrorNoFreeBucket` after the loop.

**The `NewWriter` half deliberately does not do what the issue asks, so please read this bit rather than the checkbox.** #2546 says `NewWriter` should report that no writable location is available. I have instead kept the writer alive: `activeEndpoint` points at the first configured endpoint, a warning is logged, and writes fail with `ErrorNoFreeBucket` until a bucket frees up, at which point they resume on their own. Two reasons. Hard-failing would stop the service from starting over a condition that is usually temporary, which in a deployment means a crash loop rather than a clear error. And `storage.NewWriter` in `internal/storage/v2/writer.go` treats `ErrorNoValidLocations` as "this implementation has no writer configured", so on a backend with both an s3 and a posix entry the service would silently start writing to the posix path instead of refusing to write. The upside is that "activeEndpoint is never nil once `NewWriter` has succeeded" becomes an invariant `WriteFile` can rely on. I will reword that checkbox when closing the issue, but tell me if you would rather have the hard failure — it is a small change to one commit.

One operational consequence worth naming: `ingest` treats an archive write failure as retryable (`cmd/ingest/ingest.go:403-407`), so a message hitting `ErrorNoFreeBucket` is requeued immediately, with no backoff, no error event and no error-queue routing, and each redelivery re-runs the decrypt and the full `ListBuckets`/`GetObjectCount`/`GetSize` scan. That route is not new — the old empty-bucket upload failed into the same path, and the startup case was a crash loop, so this is a net improvement — but a backend that stays full will now spin. I would rather fix that in ingest than here; say the word and I will open an issue for it.

The posix writer hard-fails in the same situation (`posix/writer/writer.go:72`), so the two writers are now inconsistent, and `ErrorNoValidLocations` is doing double duty as "not configured" and "full". Out of scope here; if you agree with the reasoning above, arguably it is posix that should change, with a distinct "configured but full" sentinel so both backends behave the same. Happy to open a separate issue.

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

## How to test

```
cd sda && go test ./internal/storage/v2/...
```

Three tests in `internal/storage/v2/s3/writer/writer_test.go` cover the state where every bucket on every endpoint is at `max_objects` and `max_buckets` is used up: one on `NewWriter`, one writing with a writer built in that state, one writing with a writer that started out with a free bucket.

To see them fail, restore either source file on its own, e.g.

```
git show origin/main:sda/internal/storage/v2/s3/writer/writer.go \
  > sda/internal/storage/v2/s3/writer/writer.go
```

which fails `TestNewWriter_AllEndpointsFull_KeepsWriterUsable` and `TestWriteFile_AllEndpointsFull_FromStart` (the latter with the panic above), while doing the same to `write_file.go` fails `TestWriteFile_AllEndpointsFull_FromStart` and `TestWriteFile_AllEndpointsBecomeFull`.
