### PR TITLE
docs(rfcs): spell out the review loop, sync ADR statuses, lint RFCs

### DIFF
--- a/.github/workflows/adr_lint_markdown.yml
+++ b/.github/workflows/adr_lint_markdown.yml
@@ -5,19 +5,21 @@ on:
   pull_request:
     paths:
       - "docs/decisions/**"
+      - "docs/rfcs/**"
       - ".github/workflows/adr_lint_markdown.yml"
       - ".markdownlint.yml"
 
 jobs:
   markdownlint:
-    name: Decision records
+    name: Decision records and RFCs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Lint decision records
+      - name: Lint decision records and RFCs
         uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           globs: |
             docs/decisions/**/*.md
+            docs/rfcs/**/*.md

--- a/docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md
+++ b/docs/decisions/0005-introduce-rfcs-as-upstream-exploration-phase.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: "2026-04-20"
+status: accepted
+date: "2026-04-24"
 decision-makers:
   - "@neicnordic/sensitive-data-development-collaboration"
 consulted: []

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -110,8 +110,8 @@ superseded-by: "0005-use-new-approach.md"
 |---------------------------------------------------------------|----------------------------------------------------------------|----------|
 | [0000](0000-use-markdown-architectural-decision-records.md)   | Use Markdown Architectural Decision Records                    | accepted |
 | [0002](0002-merge-dependabot-package-managers.md)             | Merge Dependabot package managers                              | accepted |
-| [0003](0003-shared-state-strategy-for-s3inbox-and-caching.md) | Replace s3inbox In-Memory File ID Cache with Database Lookups  | proposed |
-| [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md)  | Introduce RFCs as an upstream exploration phase for ADRs       | proposed |
+| [0003](0003-shared-state-strategy-for-s3inbox-and-caching.md) | Replace s3inbox In-Memory File ID Cache with Database Lookups  | accepted |
+| [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md)  | Introduce RFCs as an upstream exploration phase for ADRs       | accepted |
 | [0006](0006-metrics-and-tracing.md)                           | Metrics and Tracing in the sensitive-data-archive applications | accepted |
 
 Numbers `0001` and `0004` were proposed in PRs

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -39,13 +39,29 @@ you can write *"Chosen option: X, because Y"* in the initial PR.
 2. Fill in the sections. The `## Open Questions` section is the heart of an
    RFC — not a placeholder, it is the deliverable.
 
-3. Set `status: exploring` in the front matter.
+3. Set `status: exploring` in the front matter, and add a row for the RFC to
+   the [index](#index) at the bottom of this README.
 
-4. Open a pull request and label it `rfc`.
+4. Open a pull request and label it `rfc`. Once the PR exists, record its URL
+   in the `discussion` field of the front matter in a follow-up commit, so the
+   file points back at its own thread.
 
-5. The RFC is merged in its current state so the exploration can be versioned.
-   It does **not** have to reach a conclusion before merging. `exploring` is a
-   valid end state for a long time.
+5. The PR thread is where the discussion happens; the file is what the repo
+   keeps. Before the RFC merges, fold what the thread produced into the file:
+   a new option goes under `## Considered Options`, an objection to an option
+   goes into its `Pros and Cons`, and anything still unresolved goes into
+   `## Open Questions`. Push follow-up commits rather than force-pushing, so
+   reviewers can see what changed. Someone reading the file later should not
+   have to open the PR to learn which options and objections exist.
+
+6. The author merges the RFC once a reviewer has approved it and the thread's
+   substance is in the file. Merging publishes an editable exploration; it
+   does not mean the team agrees with the contents, and the RFC does **not**
+   have to reach a conclusion first. `exploring` is a valid end state for a
+   long time. An objection that is still live at merge time goes in as an
+   Open Question with the objector named, and is taken up at the next NeIC
+   SDA-Devs meet-up. Feedback that arrives after the merge goes into the file
+   the same way, through a follow-up PR.
 
 ## Status lifecycle
 
@@ -56,9 +72,11 @@ you can write *"Chosen option: X, because Y"* in the initial PR.
 | `promoted` | One or more ADRs have been created from this RFC. The RFC body is frozen; `promoted-to` lists the resulting ADR filenames. |
 | `withdrawn` | No longer pursued. Kept in place for history. |
 
-RFC numbers are never reused. Once an RFC has any status other than `exploring`,
-its body should not be edited further — only `status`, `date`, `promoted-to`,
-and index entries change.
+RFC numbers are never reused. While an RFC is `exploring` or
+`ready-for-decision`, its body is a living document: edit it in the original
+PR or in follow-up PRs as the exploration progresses. Once it is `promoted` or
+`withdrawn`, the body is frozen — only `status`, `date`, `promoted-to`, and
+index entries change.
 
 ## Promotion — RFC → ADR
 
@@ -122,7 +140,8 @@ still open. The review is a lightweight forcing function, not a deadline.
 | Typical question | *"Should we?"* | *"We did, because."* |
 | Status vocabulary | `exploring`, `ready-for-decision`, `promoted`, `withdrawn` | `proposed`, `accepted`, `rejected`, `deprecated`, `superseded` |
 | Template | MADR 4.0.0 structure, minus `## Decision Outcome` and `### Confirmation`, plus `## Open Questions` | Full MADR 4.0.0 |
-| Expected PR lifetime | Indefinite | Short — merges when the discussion has already happened |
+| Expected PR lifetime | Short — merges once review feedback is in the file | Short — merges when the discussion has already happened |
+| Time to a conclusion | Open-ended; `exploring` can last for months, in the repo rather than in a PR | One meet-up cycle; the PR records a decision the exploration has already converged on |
 
 ADR statuses only apply after a file lives in `docs/decisions/`. An RFC is not
 a `proposed` ADR; it is a separate artifact with its own lifecycle.

--- a/docs/rfcs/template.md
+++ b/docs/rfcs/template.md
@@ -3,6 +3,7 @@
 status: exploring # exploring | ready-for-decision | promoted | withdrawn
 promoted-to: [] # one or more ADR filenames — set when status is `promoted`
 date: "YYYY-MM-DD" # when the RFC was last updated
+discussion: "" # required once the PR exists: leave blank, open the PR, then add its URL in a follow-up commit
 authors: [] # people actively shaping this RFC
 consulted: [] # subject-matter experts consulted (two-way communication)
 informed: [] # kept up to date on the discussion (one-way communication)
@@ -55,8 +56,8 @@ answer — it is fine to describe a tension the team wants to explore.}
 
 <!--
 Intentionally no `## Decision Outcome` section in RFCs. The whole point of an
-RFC is that the team is not yet ready to commit. Add this section at promotion
-time.
+RFC is that the team is not yet ready to commit. At promotion time the section
+is written in the new ADR file, never here; this RFC's body is frozen instead.
 -->
 
 ## Open Questions
@@ -100,5 +101,5 @@ RFC is ready for promotion.}
 
 {Provide additional evidence or context. Link to related RFCs, ADRs, prior art
 from other projects, and any external discussion threads. If the RFC has a
-suspected eventual decision direction, note it here — but do not put a
-commitment in the `## Decision Outcome` section until promotion.}
+suspected eventual decision direction, note it here — but do not add a
+`## Decision Outcome` section; that belongs in the ADR created at promotion.}


### PR DESCRIPTION
Reviewing #2453 surfaced a contradiction in `docs/rfcs/README.md`: step 5 says an RFC merges in its current state and keeps exploring in the repo, while the "How this relates to ADRs" table says an RFC PR lives indefinitely. The table row was a leftover from the first draft of #2401, not a deliberate model. In practice the table's model is the one being followed: all four RFC PRs (#2263, #2320, #2449, #2453) are open with a single commit each while review feedback accumulates in the threads.

This PR keeps step 5's model, which is what ADR-0005 set out to do ("a git artifact in its own right, instead of living only in a GitHub PR thread"), and writes down the pieces that were missing:

* Review feedback is folded into the file before merge: new options under Considered Options, objections under Pros and Cons, the rest under Open Questions. This is the common rule across Rust, Python PEPs, Swift Evolution and Kubernetes KEPs; PEP 1 even makes "Rejected Ideas" a required section.
* A lightweight merge gate: one approval plus the thread's substance in the file. Merging publishes an editable exploration, not team agreement; an objection still live at merge time becomes a named Open Question for the next meet-up.
* The body is editable while `exploring` or `ready-for-decision` and frozen once `promoted` or `withdrawn`. The README used to freeze everything but `exploring`, which contradicted ADR-0005.
* The index row is part of writing the RFC (steps 1–5 never mentioned it; #2449 and #2453 lack one).
* A `discussion` front-matter field links the file to its PR, as Rust (`RFC PR`), PEP (`Discussions-To`), Swift (`Review`) and Oxide RFDs (`discussion`) do.
* The table row now says "Short" for both columns, with a new "Time to a conclusion" row carrying the indefinite part.

Second commit: ADR-0005 is flipped to `accepted`. It merged in #2401 on 2026-04-24 and both Confirmation steps are delivered (#2263/#2320 converted to RFC-0001/0002). Per `docs/decisions/README.md`, `proposed` means "under discussion in a PR". The same commit syncs the index row for ADR-0003, whose file has said `accepted` since 2026-03-13 while the index still said `proposed`.

Third commit: the markdown lint workflow only covered `docs/decisions/**`, so RFC files were never linted. It now runs on `docs/rfcs/**` as well, with the same `.markdownlint.yml`.

Follow-up for the open RFC PRs, not part of this PR: fold the thread into the file and merge per the new step 6. For #2453 that means the objection in the changes-requested review (keep `api`, drop the `sda-admin` CLI) and the third option raised in review (split user and admin APIs) belong in the file before it merges.
