### PR TITLE
Fix destination on  /dataset/release/{datasetid}

### DIFF
--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed downloading files by the `file_dataset.download_path` in the sda-download(v1) 
 - s3 writer: don't panic or upload to an empty bucket name when every endpoint is full
+- api: fix publishing to correct destination on POST /dataset/release/{datasetid}
 
 ## [3.1.76] - 2026-07-15
 

--- a/sda/cmd/api/handlers.go
+++ b/sda/cmd/api/handlers.go
@@ -806,8 +806,8 @@ func (api *API) releaseDataset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	releaseMessage := broker.Message{Key: "", Headers: nil, Body: marshaledMsg}
-	if err := api.mq.Publish(context.Background(), "accession", releaseMessage); err != nil {
-		slog.Debug("failed to publish accession message", "err", err)
+	if err := api.mq.Publish(context.Background(), "mappings", releaseMessage); err != nil {
+		slog.Debug("failed to publish dataset release message", "err", err)
 		writeJSON(w, http.StatusInternalServerError, err.Error())
 
 		return


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #2482 .


## Description
api: fix publishing to correct destination on POST /dataset/release/{datasetid}

## How to test
- Do a dataset/release API call and confirm the message ends up in correct queue
