### PR TITLE
refactor(config): extract inbox project code into its own config/v2 package

### DIFF
--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Remove redundant unit tests which are covered by other tests, and remove unit tests which should be covered by integration tests.
   - Use log/slog for logging instead of logrus.
 - Update remaining mocks to implement github.com/stretchr/testify/mock.Mock.
+- inbox project code:
+  - Moved `storage.inbox.projectCode` and `storage.inbox.projectCodeDelimiter` out of `internal/config` into `internal/v2/inboxproject`, registered through `config/v2` so both appear in `--help`. Key names, validation and the stock default are unchanged.
+  - `helper.ResolveInboxPath` takes the project code and delimiter as strings rather than a config struct, so `internal/helper` holds no config type and `internal/config` no longer imports it.
+  - Only ingest, mapper and api validate the section now. finalize, verify and intercept never read it and no longer fail at startup on a malformed one.
 
 ### Fixed
 

--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed downloading files by the `file_dataset.download_path` in the sda-download(v1) 
 - s3 writer: don't panic or upload to an empty bucket name when every endpoint is full
+- api: resolve the inbox path through the configured project-code layout again when deleting and downloading inbox files. The `gin` -> `net/http` rewrite in 3.1.75 reverted both call sites to the stock `UnanonymizeFilepath`, so on a deployment with `storage.inbox.projectCode` set they addressed a directory that does not exist: the download returned 500, and on an s3 inbox the delete reported success while leaving the file in place.
 
 ## [3.1.76] - 2026-07-15
 

--- a/sda/cmd/api/api.go
+++ b/sda/cmd/api/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2"
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/locationbroker"
 	"github.com/neicnordic/sensitive-data-archive/internal/userauth"
+	"github.com/neicnordic/sensitive-data-archive/internal/v2/inboxproject"
 	"google.golang.org/grpc"
 )
 
@@ -42,6 +43,7 @@ type API struct {
 	server      *http.Server
 	inboxReader storage.Reader
 	inboxWriter storage.Writer
+	inbox       inboxproject.Config
 	db          database.Database
 	mq          broker.Broker
 }
@@ -59,6 +61,11 @@ func run() error {
 
 	if err := config.Load(); err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
+	}
+
+	inbox, err := inboxproject.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load inbox project config: %v", err)
 	}
 
 	db, err := postgres.NewPostgresSQLDatabase()
@@ -136,7 +143,7 @@ func run() error {
 	}
 	defer conn.Close()
 
-	app := API{grpcClient: conn, auth: auth, enforcer: e, inboxReader: inboxReader, inboxWriter: inboxWriter, db: db, mq: mq}
+	app := API{grpcClient: conn, auth: auth, enforcer: e, inboxReader: inboxReader, inboxWriter: inboxWriter, inbox: inbox, db: db, mq: mq}
 
 	serverErr := make(chan error, 1)
 	addr := apiconfig.APIAddr()

--- a/sda/cmd/api/api_test.go
+++ b/sda/cmd/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/neicnordic/sensitive-data-archive/internal/jsonadapter"
 	"github.com/neicnordic/sensitive-data-archive/internal/userauth"
+	"github.com/neicnordic/sensitive-data-archive/internal/v2/inboxproject"
 	"github.com/neicnordic/sensitive-data-archive/mocks"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -344,6 +345,98 @@ func TestDeleteFile(t *testing.T) {
 			r.SetPathValue("fileid", tc.fileID)
 			api.rbac(api.deleteFile)(w, r)
 			assert.Equal(t, tc.wantCode, w.Code)
+		})
+	}
+}
+
+// setup runs configv2.Load, the only place in the unit suites where the real flag registration is
+// exercised. Importing inboxproject is what registers the inbox keys, so if that ever stops
+// happening the flags vanish from --help and no config file can switch the layout on. Nothing
+// else fails when they are missing, since an unregistered key just reads as the stock default.
+func TestInboxProjectFlagsAreRegistered(t *testing.T) {
+	// AllKeys includes keys bound from pflags, which is what registration produces; IsSet does not
+	// consider a flag's default, so an unset string flag would read as absent either way.
+	registered := map[string]bool{}
+	for _, key := range viper.AllKeys() {
+		registered[key] = true
+	}
+	for _, key := range []string{"storage.inbox.projectcode", "storage.inbox.projectcodedelimiter"} {
+		assert.True(t, registered[key], "%s should be bound after config load, got keys: %v", key, viper.AllKeys())
+	}
+}
+
+// submissionUser carries an "@" on purpose: the stock branch normalizes it to "_" while the
+// project-code branch keeps it raw, so the two expectations in each table differ by the username
+// itself and not only by the prefix.
+const submissionUser = "dummy@elixir-europe.org"
+
+func TestDeleteFile_resolvesInboxProjectPath(t *testing.T) {
+	// A deployment with a project code stores the inbox directory as "<code><delimiter><rawuser>",
+	// so the stored anonymized path must be resolved against that layout before the inbox write.
+	// Resolving it as the stock normalized username instead targets a directory that does not
+	// exist and the delete silently misses.
+	for _, tc := range []struct {
+		name     string
+		inbox    inboxproject.Config
+		wantPath string
+	}{
+		{"stock", inboxproject.Config{}, "dummy_elixir-europe.org/files/x.c4gh"},
+		{"project code", inboxproject.Config{Code: "p11", Delimiter: "-"}, "p11-dummy@elixir-europe.org/files/x.c4gh"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDB := &mocks.MockDatabase{}
+			mockDB.On("GetUploadedSubmissionFilePathAndLocation", submissionUser, fileID).
+				Return("files/x.c4gh", "inbox-location", nil).Once()
+			mockDB.On("UpdateFileEventLog", fileID, "disabled", "api", "{}", "{}").Return(nil).Once()
+
+			mockWriter := &mocks.MockWriter{}
+			mockWriter.On("RemoveFile", "inbox-location", tc.wantPath).Return(nil).Once()
+
+			apiImpl := &API{db: mockDB, inboxWriter: mockWriter, inbox: tc.inbox}
+
+			r, w := newRequest(t, http.MethodDelete, "/file", nil, "")
+			r.SetPathValue("username", submissionUser)
+			r.SetPathValue("fileid", fileID)
+			apiImpl.deleteFile(w, r)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			mockDB.AssertExpectations(t)
+			mockWriter.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDownloadFile_resolvesInboxProjectPath(t *testing.T) {
+	// Same layout contract on the read side. The reader is failed deliberately: the assertion is
+	// the path it was handed, not the crypt4gh stream that would follow.
+	for _, tc := range []struct {
+		name     string
+		inbox    inboxproject.Config
+		wantPath string
+	}{
+		{"stock", inboxproject.Config{}, "dummy_elixir-europe.org/files/x.c4gh"},
+		{"project code", inboxproject.Config{Code: "p11", Delimiter: "-"}, "p11-dummy@elixir-europe.org/files/x.c4gh"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDB := &mocks.MockDatabase{}
+			mockDB.On("GetUploadedSubmissionFilePathAndLocation", submissionUser, fileID).
+				Return("files/x.c4gh", "inbox-location", nil).Once()
+
+			mockReader := &mocks.MockReader{}
+			mockReader.On("NewFileReader", "inbox-location", tc.wantPath).
+				Return(nil, errors.New("read failed")).Once()
+
+			apiImpl := &API{db: mockDB, inboxReader: mockReader, inbox: tc.inbox}
+
+			r, w := newRequest(t, http.MethodGet, "/users/file", nil, "")
+			r.Header.Set("C4GH-Public-Key", base64.StdEncoding.EncodeToString([]byte(publicKey)))
+			r.SetPathValue("username", submissionUser)
+			r.SetPathValue("fileid", fileID)
+			apiImpl.downloadFile(w, r)
+
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+			mockDB.AssertExpectations(t)
+			mockReader.AssertExpectations(t)
 		})
 	}
 }

--- a/sda/cmd/api/handlers.go
+++ b/sda/cmd/api/handlers.go
@@ -417,7 +417,7 @@ func (api *API) deleteFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filePath = helper.UnanonymizeFilepath(filePath, username)
+	filePath = helper.ResolveInboxPath(filePath, username, api.inbox.Code, api.inbox.Delimiter)
 	for count := 1; count <= 5; count++ {
 		err = api.inboxWriter.RemoveFile(r.Context(), location, filePath)
 		if err == nil {
@@ -490,10 +490,11 @@ func (api *API) downloadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, err := api.inboxReader.NewFileReader(r.Context(), location, helper.UnanonymizeFilepath(filePath, submissionUser))
+	inboxPath := helper.ResolveInboxPath(filePath, submissionUser, api.inbox.Code, api.inbox.Delimiter)
+	file, err := api.inboxReader.NewFileReader(r.Context(), location, inboxPath)
 	if err != nil {
 		// #nosec G706 -- slog safely escapes structured attributes natively
-		slog.Error("inbox file not found or failed to read", "file_path", filePath, "err", err)
+		slog.Error("inbox file not found or failed to read", "file_path", inboxPath, "err", err)
 		writeJSON(w, http.StatusInternalServerError, "failed to read inbox file")
 
 		return

--- a/sda/cmd/ingest/ingest.go
+++ b/sda/cmd/ingest/ingest.go
@@ -34,18 +34,19 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2"
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/locationbroker"
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/storageerrors"
+	"github.com/neicnordic/sensitive-data-archive/internal/v2/inboxproject"
 	log "github.com/sirupsen/logrus"
 )
 
 type Ingest struct {
-	ArchiveWriter      storage.Writer
-	BackupWriter       storage.Writer
-	ArchiveReader      storage.Reader
-	ArchiveKeyList     []*[32]byte
-	db                 database.Database
-	InboxReader        storage.Reader
-	InboxProjectConfig helper.InboxProjectConfig
-	Broker             brokerv2.Broker
+	ArchiveWriter  storage.Writer
+	BackupWriter   storage.Writer
+	ArchiveReader  storage.Reader
+	ArchiveKeyList []*[32]byte
+	db             database.Database
+	InboxReader    storage.Reader
+	Inbox          inboxproject.Config
+	Broker         brokerv2.Broker
 }
 
 type decryptResult struct {
@@ -71,7 +72,7 @@ func run() error {
 	if err = configv2.Load(); err != nil {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
-	app.InboxProjectConfig, err = config.LoadInboxProjectConfig()
+	app.Inbox, err = inboxproject.Load()
 	if err != nil {
 		return fmt.Errorf("failed to load inbox project config: %v", err)
 	}
@@ -322,7 +323,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 
 		// message.Key is the broker correlation-id, not the submission path; use the trigger's
 		// filePath and resolve it to the physical inbox path before locating it.
-		submissionLocation, err = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
+		submissionLocation, err = app.InboxReader.FindFile(ctx, helper.ResolveInboxPath(filePath, user, app.Inbox.Code, app.Inbox.Delimiter))
 		if err != nil {
 			slog.Error("failed to find submission location for file", "error", err, "file-id", fileID)
 
@@ -359,7 +360,7 @@ func (app *Ingest) ingestFile(ctx context.Context, fileID, filePath, user, archi
 		return []func(){app.errorQueue(message, reason), app.setErrorEvent(reason, message)}, nil
 	}
 
-	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.InboxProjectConfig))
+	sourceReader, err := app.InboxReader.NewFileReader(ctx, submissionLocation, helper.ResolveInboxPath(filePath, user, app.Inbox.Code, app.Inbox.Delimiter))
 	if err != nil {
 		switch {
 		case errors.Is(err, storageerrors.ErrorFileNotFoundInLocation):

--- a/sda/cmd/ingest/ingest_test.go
+++ b/sda/cmd/ingest/ingest_test.go
@@ -16,8 +16,8 @@ import (
 	ingestconf "github.com/neicnordic/sensitive-data-archive/cmd/ingest/config"
 	broker "github.com/neicnordic/sensitive-data-archive/internal/broker/v2"
 	"github.com/neicnordic/sensitive-data-archive/internal/database"
-	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/storageerrors"
+	"github.com/neicnordic/sensitive-data-archive/internal/v2/inboxproject"
 	"github.com/neicnordic/sensitive-data-archive/mocks"
 	"github.com/stretchr/testify/mock"
 
@@ -74,6 +74,7 @@ func (ts *TestSuite) SetupTest() {
 	ts.ingest.BackupWriter = ts.mockBackupWriter
 	ts.ingest.db = ts.mockDB
 	ts.ingest.Broker = ts.mockBroker
+	ts.ingest.Inbox = inboxproject.Config{}
 }
 
 func (ts *TestSuite) encryptBytes(in []byte) ([]byte, []byte) {
@@ -143,7 +144,7 @@ func (ts *TestSuite) TestCancelFile_NotArchived() {
 func (ts *TestSuite) TestIngestFile_BaseCase() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	encryptedContent, encryptedChecksum := ts.encryptBytes([]byte("test file content"))
 
@@ -152,7 +153,7 @@ func (ts *TestSuite) TestIngestFile_BaseCase() {
 	ts.mockDB.On("BeginTransaction").Return(nil)
 	ts.mockDB.On("Commit").Return(nil)
 	ts.mockDB.On("Rollback").Return(nil)
-	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return(encryptedContent, nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", "test-ingest/files/TestIngestMessage.c4gh").Return(encryptedContent, nil)
 	ts.mockDB.On("UpdateFileEventLog", fileID, "submitted", "ingest", mock.Anything, mock.Anything).Return(nil)
 	ts.mockDB.On("SetKeyHash", mock.Anything, fileID).Return(nil)
 	ts.mockDB.On("StoreHeader", mock.Anything, fileID).Return(nil)
@@ -178,6 +179,49 @@ func (ts *TestSuite) TestIngestFile_BaseCase() {
 	ts.mockBroker.AssertNumberOfCalls(ts.T(), "Publish", 1)
 }
 
+// A deployment with a project code stores the inbox directory as "<code><delimiter><rawuser>", so
+// the anonymized path on the trigger must be resolved against that layout before the inbox read.
+// Resolving it as the stock normalized username instead reads from a directory that does not exist
+// and the file is never ingested.
+func (ts *TestSuite) TestIngestFile_ProjectCode_ResolvesInboxPath() {
+	fileID := uuid.NewString()
+	// The "@" matters: the stock branch would normalize it to "_", the project-code branch keeps
+	// the username raw, so the expected path below differs by more than the prefix.
+	userName := "dummy@elixir-europe.org"
+	filePath := "files/TestIngestMessage.c4gh"
+	ts.ingest.Inbox = inboxproject.Config{Code: "p11", Delimiter: "-"}
+
+	encryptedContent, encryptedChecksum := ts.encryptBytes([]byte("test file content"))
+
+	ts.mockDB.On("GetFileStatus", fileID).Return("uploaded", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("submission_unit_test_location", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Commit").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", "p11-dummy@elixir-europe.org/files/TestIngestMessage.c4gh").Return(encryptedContent, nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "submitted", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockDB.On("SetKeyHash", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("StoreHeader", mock.Anything, fileID).Return(nil)
+	ts.mockArchiveWriter.On("WriteFile", fileID).Return("archive_unit_test_location", nil)
+	ts.mockArchiveReader.On("GetFileSize", "archive_unit_test_location", fileID).Return(int64(1), nil)
+	ts.mockDB.On("SetArchived", "archive_unit_test_location", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "archived", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockBroker.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
+	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
+	ts.mockInboxReader.AssertExpectations(ts.T())
+	ts.mockDB.AssertCalled(ts.T(), "SetArchived", "archive_unit_test_location", database.FileInfo{
+		Size:             1,
+		Path:             fileID,
+		UploadedChecksum: fmt.Sprintf("%x", encryptedChecksum),
+	}, fileID)
+}
+
 // Non-s3inbox flow (e.g. FEGA-Norway via TSD): nothing pre-registers the file, so ingest's
 // catch-all (status "") is the first registration point. It must register AND archive in one
 // pass; an early return after RegisterFile would park the file at "registered" and verify would
@@ -185,7 +229,7 @@ func (ts *TestSuite) TestIngestFile_BaseCase() {
 func (ts *TestSuite) TestIngestFile_NotRegistered_FallsThroughToArchive() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	encryptedContent, encryptedChecksum := ts.encryptBytes([]byte("test file content"))
 
@@ -194,9 +238,9 @@ func (ts *TestSuite) TestIngestFile_NotRegistered_FallsThroughToArchive() {
 	ts.mockDB.On("BeginTransaction").Return(nil)
 	ts.mockDB.On("Commit").Return(nil)
 	ts.mockDB.On("Rollback").Return(nil)
-	ts.mockInboxReader.On("FindFile", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return("submission_unit_test_location", nil)
+	ts.mockInboxReader.On("FindFile", "test-ingest/files/TestIngestMessage.c4gh").Return("submission_unit_test_location", nil)
 	ts.mockDB.On("RegisterFile", &fileID, "submission_unit_test_location", filePath, userName).Return(fileID, nil)
-	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return(encryptedContent, nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", "test-ingest/files/TestIngestMessage.c4gh").Return(encryptedContent, nil)
 	ts.mockDB.On("UpdateFileEventLog", fileID, "submitted", "ingest", mock.Anything, mock.Anything).Return(nil)
 	ts.mockDB.On("SetKeyHash", mock.Anything, fileID).Return(nil)
 	ts.mockDB.On("StoreHeader", mock.Anything, fileID).Return(nil)
@@ -225,16 +269,64 @@ func (ts *TestSuite) TestIngestFile_NotRegistered_FallsThroughToArchive() {
 	ts.mockBroker.AssertNumberOfCalls(ts.T(), "Publish", 1)
 }
 
+// The catch-all crossed with a project code: the combination FEGA-Norway actually runs, since it
+// uploads through TSD rather than s3inbox and namespaces every inbox directory by project. The
+// path handed to FindFile is the one the file is stored under, so resolving it as the stock
+// normalized username leaves the file unfindable and the ingest never starts.
+func (ts *TestSuite) TestIngestFile_NotRegistered_ProjectCode_ResolvesInboxPath() {
+	fileID := uuid.NewString()
+	// The "@" matters: the stock branch would normalize it to "_", the project-code branch keeps
+	// the username raw, so the expected path below differs by more than the prefix.
+	userName := "dummy@elixir-europe.org"
+	filePath := "files/TestIngestMessage.c4gh"
+	ts.ingest.Inbox = inboxproject.Config{Code: "p11", Delimiter: "-"}
+
+	encryptedContent, encryptedChecksum := ts.encryptBytes([]byte("test file content"))
+
+	ts.mockDB.On("GetFileStatus", fileID).Return("", nil)
+	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
+	ts.mockDB.On("BeginTransaction").Return(nil)
+	ts.mockDB.On("Commit").Return(nil)
+	ts.mockDB.On("Rollback").Return(nil)
+	ts.mockInboxReader.On("FindFile", "p11-dummy@elixir-europe.org/files/TestIngestMessage.c4gh").Return("submission_unit_test_location", nil)
+	ts.mockDB.On("RegisterFile", &fileID, "submission_unit_test_location", filePath, userName).Return(fileID, nil)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", "p11-dummy@elixir-europe.org/files/TestIngestMessage.c4gh").Return(encryptedContent, nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "submitted", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockDB.On("SetKeyHash", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("StoreHeader", mock.Anything, fileID).Return(nil)
+	ts.mockArchiveWriter.On("WriteFile", fileID).Return("archive_unit_test_location", nil)
+	ts.mockArchiveReader.On("GetFileSize", "archive_unit_test_location", fileID).Return(int64(1), nil)
+	ts.mockDB.On("SetArchived", "archive_unit_test_location", mock.Anything, fileID).Return(nil)
+	ts.mockDB.On("UpdateFileEventLog", fileID, "archived", "ingest", mock.Anything, mock.Anything).Return(nil)
+	ts.mockBroker.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	message := createMessage("ingest", filePath, userName, fileID)
+	callbacks, err := ts.ingest.handleMessage(context.Background(), message)
+	for _, cb := range callbacks {
+		cb()
+	}
+	assert.NoError(ts.T(), err, "unexpected error when ingesting file")
+	// The anonymized path, not the resolved one, is what gets registered: the mapper resolves it
+	// again on cleanup.
+	ts.mockDB.AssertCalled(ts.T(), "RegisterFile", &fileID, "submission_unit_test_location", filePath, userName)
+	ts.mockInboxReader.AssertExpectations(ts.T())
+	ts.mockDB.AssertCalled(ts.T(), "SetArchived", "archive_unit_test_location", database.FileInfo{
+		Size:             1,
+		Path:             fileID,
+		UploadedChecksum: fmt.Sprintf("%x", encryptedChecksum),
+	}, fileID)
+}
+
 func (ts *TestSuite) TestIngestFile_NotRegistered_NotFoundInInbox() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	ts.mockDB.On("GetFileStatus", fileID).Return("", nil)
 	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
 	ts.mockDB.On("BeginTransaction").Return(nil)
 	ts.mockDB.On("Rollback").Return(nil)
-	ts.mockInboxReader.On("FindFile", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return("", storageerrors.ErrorFileNotFoundInLocation)
+	ts.mockInboxReader.On("FindFile", "test-ingest/files/TestIngestMessage.c4gh").Return("", storageerrors.ErrorFileNotFoundInLocation)
 	ts.mockBroker.On("Publish", "error", mock.Anything).Return(nil)
 
 	message := createMessage("ingest", filePath, userName, fileID)
@@ -250,7 +342,7 @@ func (ts *TestSuite) TestIngestFile_NotRegistered_NotFoundInInbox() {
 func (ts *TestSuite) TestIngestFile_NoSubmissionLocation() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	ts.mockDB.On("GetFileStatus", fileID).Return("uploaded", nil)
 	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
@@ -273,7 +365,7 @@ func (ts *TestSuite) TestIngestFile_NoSubmissionLocation() {
 func (ts *TestSuite) TestIngestFile_AlreadyIngested() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	ts.mockDB.On("GetFileStatus", fileID).Return("verified", nil)
 	ts.mockDB.On("GetSubmissionLocation", fileID).Return("", nil)
@@ -293,13 +385,13 @@ func (ts *TestSuite) TestIngestFile_AlreadyIngested() {
 func (ts *TestSuite) TestIngestFile_MissingFile() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	ts.mockDB.On("GetFileStatus", fileID).Return("uploaded", nil)
 	ts.mockDB.On("GetSubmissionLocation", fileID).Return("submission_unit_test_location", nil)
 	ts.mockDB.On("BeginTransaction").Return(nil)
 	ts.mockDB.On("Rollback").Return(nil)
-	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", helper.ResolveInboxPath(filePath, userName, helper.InboxProjectConfig{})).Return(nil, storageerrors.ErrorFileNotFoundInLocation)
+	ts.mockInboxReader.On("NewFileReader", "submission_unit_test_location", "test-ingest/files/TestIngestMessage.c4gh").Return(nil, storageerrors.ErrorFileNotFoundInLocation)
 	ts.mockDB.On("UpdateFileEventLog", fileID, "error", "ingest", mock.Anything, mock.Anything).Return(nil)
 	ts.mockBroker.On("Publish", "error", mock.Anything).Return(nil)
 
@@ -317,7 +409,7 @@ func (ts *TestSuite) TestIngestFile_MissingFile() {
 func (ts *TestSuite) TestIngestFile_DatabaseError() {
 	fileID := uuid.NewString()
 	userName := "test-ingest"
-	filePath := fmt.Sprintf("/%v/TestIngestMessage.c4gh", userName)
+	filePath := "files/TestIngestMessage.c4gh"
 
 	ts.mockDB.On("GetFileStatus", fileID).Return("", errors.New("some error"))
 

--- a/sda/cmd/mapper/mapper.go
+++ b/sda/cmd/mapper/mapper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/neicnordic/sensitive-data-archive/internal/schema"
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2"
 	"github.com/neicnordic/sensitive-data-archive/internal/storage/v2/locationbroker"
+	"github.com/neicnordic/sensitive-data-archive/internal/v2/inboxproject"
 	amqp "github.com/rabbitmq/amqp091-go"
 	log "github.com/sirupsen/logrus"
 )
@@ -27,7 +28,7 @@ import (
 var db database.Database
 var inboxWriter storage.Writer
 var mqBroker *broker.AMQPBroker
-var inboxConfig helper.InboxProjectConfig
+var inboxConfig inboxproject.Config
 
 func main() {
 	if err := run(); err != nil {
@@ -47,7 +48,13 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to load config, due to: %v", err)
 	}
-	inboxConfig = conf.Inbox
+
+	// After NewConfig, never before: the inbox keys can arrive with the legacy config file, which
+	// only NewConfig reads, and loading them earlier silently yields the stock layout instead.
+	inboxConfig, err = inboxproject.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load inbox project config: %v", err)
+	}
 
 	db, err = postgres.NewPostgresSQLDatabase()
 	if err != nil {
@@ -274,7 +281,7 @@ func handleMessage(ctx context.Context, delivered amqp.Delivery) {
 	}
 
 	for _, fileMappingData := range filesToCleanFromInbox {
-		resolvedSubmissionPath := helper.ResolveInboxPath(fileMappingData.SubmissionFilePath, fileMappingData.User, inboxConfig)
+		resolvedSubmissionPath := helper.ResolveInboxPath(fileMappingData.SubmissionFilePath, fileMappingData.User, inboxConfig.Code, inboxConfig.Delimiter)
 		if err := inboxWriter.RemoveFile(ctx, fileMappingData.SubmissionLocation, resolvedSubmissionPath); err != nil {
 			log.Errorf("removal of file id: %s at location: %s, path: %s failed, reason: %v", fileMappingData.FileID, fileMappingData.SubmissionLocation, resolvedSubmissionPath, err)
 		}

--- a/sda/internal/config/config.go
+++ b/sda/internal/config/config.go
@@ -7,11 +7,9 @@ import (
 	"os"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/neicnordic/crypt4gh/keys"
 	"github.com/neicnordic/sensitive-data-archive/internal/broker"
-	"github.com/neicnordic/sensitive-data-archive/internal/helper"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -42,7 +40,6 @@ type Config struct {
 	ReEncrypt    ReEncConfig
 	Auth         AuthConf
 	RotateKey    RotateKeyConf
-	Inbox        helper.InboxProjectConfig
 }
 
 type Grpc struct {
@@ -379,10 +376,6 @@ func NewConfig(app string) (*Config, error) {
 			return nil, err
 		}
 		c.configSchemas()
-		c.Inbox, err = LoadInboxProjectConfig()
-		if err != nil {
-			return nil, err
-		}
 
 		c.API.Grpc, err = configReEncryptClient()
 		if err != nil {
@@ -458,10 +451,6 @@ func NewConfig(app string) (*Config, error) {
 		}
 
 		c.configSchemas()
-		c.Inbox, err = LoadInboxProjectConfig()
-		if err != nil {
-			return nil, err
-		}
 	case "notify":
 		c.configSMTP()
 
@@ -777,41 +766,6 @@ func (c *Config) configReEncryptServer() (err error) {
 	}
 
 	return nil
-}
-
-// LoadInboxProjectConfig reads the per-user inbox directory layout from the shared viper instance.
-// An absent section yields the zero value, which is stock SDA behavior, so deployments that omit it
-// are unaffected. This is the single source of the storage.inbox.* keys, read both by NewConfig
-// (mapper, api) and directly by the ingest service, which loads through config/v2 but populates
-// the same viper instance. Setting only one of the two keys is an error. Code and delimiter join
-// with the username into ONE inbox directory name, so the delimiter is restricted to "-", "_" or
-// "." and the code must not contain path separators, whitespace or control characters: anything
-// else would corrupt or split the layout.
-func LoadInboxProjectConfig() (helper.InboxProjectConfig, error) {
-	cfg := helper.InboxProjectConfig{
-		Code:      viper.GetString("storage.inbox.projectCode"),
-		Delimiter: viper.GetString("storage.inbox.projectCodeDelimiter"),
-	}
-	switch {
-	case cfg.Code == "" && cfg.Delimiter == "":
-		return cfg, nil
-	case cfg.Code == "" || cfg.Delimiter == "":
-		return helper.InboxProjectConfig{}, errors.New("storage.inbox.projectCode and storage.inbox.projectCodeDelimiter must be set together")
-	}
-
-	switch cfg.Delimiter {
-	case "-", "_", ".":
-	default:
-		return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCodeDelimiter %q is not a delimiter character (use \"-\", \"_\" or \".\")", cfg.Delimiter)
-	}
-
-	for _, r := range cfg.Code {
-		if r == '/' || r == '\\' || unicode.IsSpace(r) || unicode.IsControl(r) {
-			return helper.InboxProjectConfig{}, fmt.Errorf("storage.inbox.projectCode %q must not contain path separators or whitespace", cfg.Code)
-		}
-	}
-
-	return cfg, nil
 }
 
 // configSchemas configures the schemas to load depending on

--- a/sda/internal/config/config_test.go
+++ b/sda/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -612,100 +611,4 @@ func (ts *ConfigTestSuite) TestConfigAuth_OIDC() {
 	viper.Set("oidc.redirectUrl", "http://auth/oidc/login")
 	_, err = NewConfig("auth")
 	assert.NoError(ts.T(), err, "unexpected failure")
-}
-
-func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_readsNestedStorageInboxKeys() {
-	// Each service loads its config.yaml into the shared global viper (mapper/api via NewConfig,
-	// ingest via config/v2). LoadInboxProjectConfig then reads it. Prove the nested storage.inbox.*
-	// block flattens to the dotted keys it reads: the seam the projectCode resolver depends on.
-	viper.Reset()
-	viper.SetConfigType("yaml")
-	cfg := "storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n"
-	assert.NoError(ts.T(), viper.ReadConfig(bytes.NewBufferString(cfg)))
-
-	got, err := LoadInboxProjectConfig()
-	assert.NoError(ts.T(), err)
-	assert.Equal(ts.T(), "p11", got.Code)
-	assert.Equal(ts.T(), "-", got.Delimiter)
-}
-
-func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_absentSectionIsStock() {
-	// With no storage.inbox section LoadInboxProjectConfig yields the zero value, which
-	// ResolveInboxPath treats as stock SDA behavior, so deployments that omit it (e.g. the Swedish
-	// node) are unaffected.
-	viper.Reset()
-	got, err := LoadInboxProjectConfig()
-	assert.NoError(ts.T(), err)
-	assert.Equal(ts.T(), "", got.Code)
-	assert.Equal(ts.T(), "", got.Delimiter)
-}
-
-func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_halfConfigured_errors() {
-	// A project code without a delimiter would silently glue code and username together
-	// ("p11username"); a delimiter without a code would be silently ignored. Both are
-	// misconfigurations that must fail at startup, not produce garbage paths at runtime.
-	viper.Reset()
-	viper.Set("storage.inbox.projectCode", "p11")
-	_, err := LoadInboxProjectConfig()
-	assert.ErrorContains(ts.T(), err, "must be set together")
-
-	viper.Reset()
-	viper.Set("storage.inbox.projectCodeDelimiter", "-")
-	_, err = LoadInboxProjectConfig()
-	assert.ErrorContains(ts.T(), err, "must be set together")
-}
-
-func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_projectCodeMustBeSingleSegment() {
-	// The code prefixes ONE per-user directory name. Path separators would silently split it into
-	// multiple segments ("p11/" -> "p11/-user/..."), and whitespace or control characters produce
-	// directory names no deployment intends. Free text otherwise: codes are deployment-specific.
-	load := func(code string) error {
-		viper.Reset()
-		viper.Set("storage.inbox.projectCode", code)
-		viper.Set("storage.inbox.projectCodeDelimiter", "-")
-		_, err := LoadInboxProjectConfig()
-
-		return err
-	}
-
-	for _, bad := range []string{"p11/", "/p11", "p\\11", "p 11", "p\t11", "p\n11"} {
-		assert.ErrorContains(ts.T(), load(bad), "must not contain",
-			"project code %q should be rejected", bad)
-	}
-	for _, good := range []string{"p11", "fega-no", "P11.x"} {
-		assert.NoError(ts.T(), load(good), "project code %q should be accepted", good)
-	}
-}
-
-func (ts *ConfigTestSuite) TestNewConfig_inboxProjectMisconfig_failsStartup() {
-	// The loader's validation must propagate out of NewConfig: a half-configured inbox project
-	// section stops the service at startup instead of producing garbage paths at runtime.
-	viper.Set("storage.inbox.projectCode", "p11")
-	defer viper.Reset()
-
-	_, err := NewConfig("mapper")
-	assert.ErrorContains(ts.T(), err, "must be set together")
-}
-
-func (ts *ConfigTestSuite) TestLoadInboxProjectConfig_delimiterMustBeSeparatorCharacter() {
-	// The delimiter joins code and username into ONE inbox directory name ("p11-user"), so only the
-	// whitelisted separators "-", "_" and "." are accepted. Letters and digits would blur the
-	// code/username boundary, "/" would split the directory across two path segments, and
-	// whitespace or control characters would produce miserable directory names.
-	load := func(delimiter string) error {
-		viper.Reset()
-		viper.Set("storage.inbox.projectCode", "p11")
-		viper.Set("storage.inbox.projectCodeDelimiter", delimiter)
-		_, err := LoadInboxProjectConfig()
-
-		return err
-	}
-
-	for _, bad := range []string{"x", "Q", "1", "/", "\\", " ", "\t", "\n", "+", "★", "--", "p11"} {
-		assert.ErrorContains(ts.T(), load(bad), "not a delimiter character",
-			"delimiter %q should be rejected", bad)
-	}
-	for _, good := range []string{"-", "_", "."} {
-		assert.NoError(ts.T(), load(good), "delimiter %q should be accepted", good)
-	}
 }

--- a/sda/internal/helper/helper.go
+++ b/sda/internal/helper/helper.go
@@ -465,38 +465,25 @@ func UnanonymizeFilepath(fp string, username string) string {
 	return filepath.Join(strings.Replace(username, "@", "_", 1), fp)
 }
 
-// InboxProjectConfig describes how a deployment names its per-user inbox directories, so an
-// anonymized submission path (the user prefix stripped) can be resolved back to the physical
-// inbox-relative path. An empty Code selects stock SDA behavior.
-type InboxProjectConfig struct {
-	// Code optionally prefixes the per-user inbox directory (e.g. "p11"). Empty keeps the
-	// stock layout where the directory is the normalized username (see UnanonymizeFilepath).
-	Code string
-	// Delimiter separates Code from the username (e.g. "-"). Unused when
-	// Code is empty.
-	Delimiter string
-}
-
 // ResolveInboxPath reconstructs the physical inbox-relative path for an anonymized submission
 // filePath.
 //
-// With no Code it is the stock round-trip, deferring to UnanonymizeFilepath unchanged (normalize
-// the username, first "@" -> "_", and prepend "<user>/"), so existing deployments are unaffected,
-// edge inputs included.
+// With an empty projectCode it defers to UnanonymizeFilepath (first "@" -> "_", then prepend
+// "<user>/"), so existing deployments keep the stock layout.
 //
-// With a Code it rebuilds "<Code><delimiter><username>/<filePath>" using the RAW username. In
-// this branch an already-resolved path (e.g. on reprocessing) is returned as-is, with any leading
-// separator normalized away. Whether to normalize is derived from the project code rather than
-// configured separately: a project code denotes a TSD-style inbox namespaced by project (e.g.
-// FEGA-Norway's "p11-dummy@elixir-europe.org/files/..."), which stores the username verbatim. No
-// current deployment needs a project code together with normalization; add an explicit toggle if
-// one does.
-func ResolveInboxPath(filePath, username string, cfg InboxProjectConfig) string {
-	if cfg.Code == "" {
+// With a projectCode it rebuilds "<projectCode><delimiter><username>/<filePath>" using the RAW
+// username. In this branch an already-resolved path (e.g. on reprocessing) is returned as-is, with
+// any leading separator normalized away. Whether to normalize is derived from the project code
+// rather than configured separately: a project code denotes a TSD-style inbox namespaced by
+// project (e.g. FEGA-Norway's "p11-dummy@elixir-europe.org/files/..."), which stores the username
+// verbatim. No current deployment needs a project code together with normalization; add an
+// explicit toggle if one does.
+func ResolveInboxPath(filePath, username, projectCode, delimiter string) string {
+	if projectCode == "" {
 		return UnanonymizeFilepath(filePath, username)
 	}
 
-	userDir := cfg.Code + cfg.Delimiter + username
+	userDir := projectCode + delimiter + username
 	// Tolerate leading separators from older proxy formats (e.g. "/p11-user/files/..."); without
 	// stripping them the prefix check below misses and userDir gets prepended a second time.
 	relPath := strings.TrimLeft(filePath, "/")

--- a/sda/internal/helper/helper_test.go
+++ b/sda/internal/helper/helper_test.go
@@ -193,57 +193,51 @@ func (ts *HelperTest) TestResolveInboxPath_stockDefault_prependsNormalizedUser()
 	// With no project code ResolveInboxPath defers to the stock UnanonymizeFilepath: the first
 	// "@" becomes "_" and the username directory is prepended unless the path already starts with
 	// it. These assertions keep existing deployments pinned.
-	stockDefault := InboxProjectConfig{}
 	user := "test.user@demo.org"
 	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
-		ResolveInboxPath("files/x.raw.enc", user, stockDefault))
+		ResolveInboxPath("files/x.raw.enc", user, "", ""))
 	// Already-prefixed path is returned unchanged.
 	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
-		ResolveInboxPath("test.user_demo.org/files/x.raw.enc", user, stockDefault))
+		ResolveInboxPath("test.user_demo.org/files/x.raw.enc", user, "", ""))
 }
 
 func (ts *HelperTest) TestResolveInboxPath_stockDefault_leadingSeparator() {
 	// Stock branch (no project code): a leading "/" on the anonymized path is harmless. The userDir
 	// prefix is still applied, refuting the assumption that filepath.Join treats a leading "/" as
 	// absolute and drops the prefix.
-	stockDefault := InboxProjectConfig{}
 	user := "test.user@demo.org"
 	assert.Equal(ts.T(), "test.user_demo.org/files/x.raw.enc",
-		ResolveInboxPath("/files/x.raw.enc", user, stockDefault))
+		ResolveInboxPath("/files/x.raw.enc", user, "", ""))
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_reconstructsRawUserDir() {
 	// FEGA-Norway: anonymized "/files/x" is rebuilt under the project-code-prefixed RAW username
 	// (the "@" is not normalized to "_" when a project code is configured).
-	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
-	got := ResolveInboxPath("/files/x.raw.enc", "dummy@elixir-europe.org", cfg)
+	got := ResolveInboxPath("/files/x.raw.enc", "dummy@elixir-europe.org", "p11", "-")
 	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc", got)
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_alreadyPrefixed_unchanged() {
 	// An already-resolved path (e.g. on reprocessing) is returned as-is, not double-prefixed.
-	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	fp := "p11-dummy@elixir-europe.org/files/x.raw.enc"
-	assert.Equal(ts.T(), fp, ResolveInboxPath(fp, "dummy@elixir-europe.org", cfg))
+	assert.Equal(ts.T(), fp, ResolveInboxPath(fp, "dummy@elixir-europe.org", "p11", "-"))
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_leadingSeparator_notDoubled() {
 	// Older proxy formats can send an already-resolved path with a leading "/". The leading
 	// separator must be normalized away, not cause the user directory to be prepended a second time
 	// ("/p11-user/files/x" -> "p11-user/p11-user/files/x").
-	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc",
-		ResolveInboxPath("/p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", cfg))
+		ResolveInboxPath("/p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", "p11", "-"))
 	// All leading separators are stripped, so repeated slashes cannot sneak past the
 	// already-resolved check either.
 	assert.Equal(ts.T(), "p11-dummy@elixir-europe.org/files/x.raw.enc",
-		ResolveInboxPath("//p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", cfg))
+		ResolveInboxPath("//p11-dummy@elixir-europe.org/files/x.raw.enc", "dummy@elixir-europe.org", "p11", "-"))
 }
 
 func (ts *HelperTest) TestResolveInboxPath_projectCode_segmentBoundary() {
 	// The already-resolved check holds on a path-segment boundary: "p11-user2/..." belongs to a
 	// different user and must not be treated as already under the "p11-user" directory.
-	cfg := InboxProjectConfig{Code: "p11", Delimiter: "-"}
 	assert.Equal(ts.T(), "p11-user/p11-user2/files/x.raw.enc",
-		ResolveInboxPath("p11-user2/files/x.raw.enc", "user", cfg))
+		ResolveInboxPath("p11-user2/files/x.raw.enc", "user", "p11", "-"))
 }

--- a/sda/internal/v2/inboxproject/inboxproject.go
+++ b/sda/internal/v2/inboxproject/inboxproject.go
@@ -1,0 +1,109 @@
+// Package inboxproject configures how a deployment names its per-user inbox directories.
+//
+// Deployments that namespace each inbox directory by project code (e.g. FEGA-Norway's
+// "p11-dummy@elixir-europe.org/files/...") set storage.inbox.projectCode and
+// storage.inbox.projectCodeDelimiter. Importing this package registers both flags with config/v2,
+// so configv2.Load fills them; Load then validates them into a Config for helper.ResolveInboxPath.
+// An absent section is stock SDA behavior.
+package inboxproject
+
+import (
+	"errors"
+	"fmt"
+	"unicode"
+
+	"github.com/neicnordic/sensitive-data-archive/internal/config/v2"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	codeKey      = "storage.inbox.projectCode"
+	delimiterKey = "storage.inbox.projectCodeDelimiter"
+)
+
+// assigned records that config/v2 has registered and loaded these keys. The values themselves are
+// read in Load rather than captured here: mapper populates viper in two phases, configv2.Load
+// followed by the legacy config.NewConfig, and only the latter honours the CONFIGFILE env var. A
+// value captured at assign time would miss a config file that the legacy loader reads afterwards.
+var assigned bool
+
+var flags = []*config.Flag{
+	{
+		Name: codeKey,
+		RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+			flagSet.String(flagName, "", `Project code prefixing every per-user inbox directory, e.g. "p11". Empty selects the stock layout, where the directory is the normalized username`)
+		},
+		Required: false,
+		AssignFunc: func(_ string) {
+			assigned = true
+		},
+	},
+	{
+		Name: delimiterKey,
+		RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+			flagSet.String(flagName, "", `Character joining the project code to the username in an inbox directory name, one of "-", "_" or "."`)
+		},
+		Required: false,
+		AssignFunc: func(_ string) {
+			assigned = true
+		},
+	},
+}
+
+func init() {
+	config.RegisterFlags(flags...)
+}
+
+// Config describes how a deployment names its per-user inbox directories, so an anonymized
+// submission path (the user prefix stripped) can be resolved back to the physical inbox-relative
+// path. An empty Code selects stock SDA behavior.
+type Config struct {
+	// Code optionally prefixes the per-user inbox directory (e.g. "p11"). Empty keeps the
+	// stock layout, where the directory is the normalized username.
+	Code string
+	// Delimiter separates Code from the username (e.g. "-"). Unused when Code is empty.
+	Delimiter string
+}
+
+// Load reads the inbox layout keys from viper and returns them validated. It must be called after
+// configv2.Load and after any later config load, since it reads whatever viper holds at the moment
+// it is called.
+//
+// The error when configv2.Load has not run is the one missing-configuration case this can detect.
+// It proves the flags are registered and bound; it does not prove every config source has been
+// read. A caller that loads more config afterwards still gets the zero Config here, and the zero
+// Config is a valid stock layout, so it comes back with no error.
+//
+// An absent section yields the zero Config, which is stock SDA behavior, so deployments that omit
+// it are unaffected. Code and delimiter join with the username into ONE inbox directory name, which
+// is why the two must be set together and why neither may carry a character that would corrupt or
+// split that name.
+func Load() (Config, error) {
+	if !assigned {
+		return Config{}, errors.New("inboxproject.Load called before config/v2 assigned the inbox flags")
+	}
+
+	cfg := Config{Code: viper.GetString(codeKey), Delimiter: viper.GetString(delimiterKey)}
+
+	switch {
+	case cfg.Code == "" && cfg.Delimiter == "":
+		return cfg, nil
+	case cfg.Code == "" || cfg.Delimiter == "":
+		return Config{}, fmt.Errorf("%s and %s must be set together", codeKey, delimiterKey)
+	}
+
+	switch cfg.Delimiter {
+	case "-", "_", ".":
+	default:
+		return Config{}, fmt.Errorf("%s %q is not a delimiter character (use \"-\", \"_\" or \".\")", delimiterKey, cfg.Delimiter)
+	}
+
+	for _, r := range cfg.Code {
+		if r == '/' || r == '\\' || unicode.IsSpace(r) || unicode.IsControl(r) {
+			return Config{}, fmt.Errorf("%s %q must not contain path separators or whitespace", codeKey, cfg.Code)
+		}
+	}
+
+	return cfg, nil
+}

--- a/sda/internal/v2/inboxproject/inboxproject_test.go
+++ b/sda/internal/v2/inboxproject/inboxproject_test.go
@@ -1,0 +1,149 @@
+package inboxproject
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assign runs the registered AssignFuncs, which is what configv2.Load does. Calling configv2.Load
+// itself is not an option here: it runs cobra Execute, which parses os.Args and so picks up the
+// test binary's own flags.
+func assign(t *testing.T) {
+	t.Helper()
+	prev := assigned
+	t.Cleanup(func() { assigned = prev })
+
+	for _, flag := range flags {
+		flag.AssignFunc(flag.Name)
+	}
+}
+
+// configure seeds viper from a storage.inbox section, the way a service's config.yaml does, then
+// assigns and loads. It covers the whole chain the resolver depends on: nested YAML -> dotted flag
+// key -> validated Config.
+func configure(t *testing.T, storageInbox string) (Config, error) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	require.NoError(t, viper.ReadConfig(bytes.NewBufferString(storageInbox)))
+	assign(t)
+
+	return Load()
+}
+
+func TestLoad_readsNestedStorageInboxKeys(t *testing.T) {
+	got, err := configure(t, "storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n")
+	assert.NoError(t, err)
+	assert.Equal(t, Config{Code: "p11", Delimiter: "-"}, got)
+}
+
+func TestLoad_absentSectionIsStock(t *testing.T) {
+	// With no storage.inbox section Load yields the zero Config, which helper.ResolveInboxPath
+	// treats as stock SDA behavior, so deployments that omit it (e.g. the Swedish node) are
+	// unaffected.
+	got, err := configure(t, "")
+	assert.NoError(t, err)
+	assert.Equal(t, Config{}, got)
+}
+
+func TestLoad_beforeAssignment_errors(t *testing.T) {
+	// An unassigned Config is indistinguishable from a deliberate stock layout, so loading before
+	// configv2.Load must fail rather than hand back a project-code deployment's inbox paths
+	// silently reverted to the stock layout.
+	prev := assigned
+	t.Cleanup(func() { assigned = prev })
+	assigned = false
+
+	_, err := Load()
+	assert.ErrorContains(t, err, "called before config/v2")
+}
+
+// mapper reads its config file through the legacy loader, which runs AFTER configv2.Load. Keys that
+// only arrive with that second read must still reach Load, so the values cannot be captured when
+// the flags are assigned. Regression guard: capturing at assign time silently drops FEGA-Norway's
+// project code and reverts mapper to the stock inbox layout.
+func TestLoad_readsValuesArrivingAfterAssignment(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	assign(t)
+
+	viper.SetConfigType("yaml")
+	require.NoError(t, viper.ReadConfig(bytes.NewBufferString(
+		"storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: \"-\"\n")))
+
+	got, err := Load()
+	assert.NoError(t, err)
+	assert.Equal(t, Config{Code: "p11", Delimiter: "-"}, got)
+}
+
+func TestLoad_halfConfigured_errors(t *testing.T) {
+	// A project code without a delimiter would silently glue code and username together
+	// ("p11username"); a delimiter without a code would be silently ignored. Both are
+	// misconfigurations that must fail at startup, not produce garbage paths at runtime.
+	_, err := configure(t, "storage:\n  inbox:\n    projectCode: p11\n")
+	assert.ErrorContains(t, err, "must be set together")
+
+	_, err = configure(t, "storage:\n  inbox:\n    projectCodeDelimiter: \"-\"\n")
+	assert.ErrorContains(t, err, "must be set together")
+}
+
+func TestLoad_projectCodeMustBeSingleSegment(t *testing.T) {
+	// The code prefixes ONE per-user directory name. Path separators would silently split it into
+	// multiple segments ("p11/" -> "p11/-user/..."), and whitespace or control characters produce
+	// directory names no deployment intends. Free text otherwise: codes are deployment-specific.
+	load := func(code string) error {
+		_, err := configure(t, fmt.Sprintf("storage:\n  inbox:\n    projectCode: %q\n    projectCodeDelimiter: \"-\"\n", code))
+
+		return err
+	}
+
+	for _, bad := range []string{"p11/", "/p11", "p\\11", "p 11", "p\t11", "p\n11", "p\x0011", "p\x1b11"} {
+		assert.ErrorContains(t, load(bad), "must not contain",
+			"project code %q should be rejected", bad)
+	}
+	for _, good := range []string{"p11", "fega-no", "P11.x"} {
+		assert.NoError(t, load(good), "project code %q should be accepted", good)
+	}
+}
+
+func TestLoad_delimiterMustBeSeparatorCharacter(t *testing.T) {
+	// The delimiter joins code and username into ONE inbox directory name ("p11-user"), so only the
+	// allowlisted separators "-", "_" and "." are accepted. Letters and digits would blur the
+	// code/username boundary, "/" would split the directory across two path segments, and
+	// whitespace or control characters would produce miserable directory names.
+	load := func(delimiter string) error {
+		_, err := configure(t, fmt.Sprintf("storage:\n  inbox:\n    projectCode: p11\n    projectCodeDelimiter: %q\n", delimiter))
+
+		return err
+	}
+
+	for _, bad := range []string{"x", "Q", "1", "/", "\\", " ", "\t", "\n", "+", "★", "--", "p11"} {
+		assert.ErrorContains(t, load(bad), "not a delimiter character",
+			"delimiter %q should be rejected", bad)
+	}
+	for _, good := range []string{"-", "_", "."} {
+		assert.NoError(t, load(good), "delimiter %q should be accepted", good)
+	}
+}
+
+func TestRegisteredFlags_defaultToStock(t *testing.T) {
+	// The registered defaults are what a deployment with no storage.inbox section gets, so they
+	// must be empty: any other default would change the inbox layout for every existing node.
+	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	for _, flag := range flags {
+		flag.RegisterFunc(flagSet, flag.Name)
+	}
+
+	for _, name := range []string{codeKey, delimiterKey} {
+		registered := flagSet.Lookup(name)
+		require.NotNil(t, registered, "flag %q should be registered", name)
+		assert.Equal(t, "", registered.DefValue)
+	}
+}


### PR DESCRIPTION
Closes #2477.

## The refactor

`InboxProjectConfig` was squatting in `internal/helper`, which forced `internal/config` to import `helper` and mixed up where the config lives with where the path function lives. `internal/v2/inboxproject` now owns the type, registers `storage.inbox.projectCode` and `storage.inbox.projectCodeDelimiter` with `config/v2` in `init()`, and validates them in `Load()`. `helper.ResolveInboxPath` stays put and takes the code and delimiter as two strings, so `helper` has no config dependency left. ingest, mapper and api call `inboxproject.Load()` and pass the strings down.

Against the acceptance criteria: both flags now appear in `--help` on ingest, mapper and api, and not on services that do not import the package. Validation moved across unchanged. A deployment that sets neither key still gets the stock inbox layout, since an empty project code makes `ResolveInboxPath` delegate to `UnanonymizeFilepath` exactly as before.

Two deviations from @KarlG-nbis's sketch on #2466, both deliberate. The keys keep their shipped camelCase spelling rather than becoming `project_code` / `project_code_delimiter`, because renaming them breaks every config written against v3.1.73. And the package is `inboxproject` rather than `inbox_project_config`, underscores not being idiomatic for Go package names. Worth saying out loud: the `internal/v2/` grouping comes from the issue, but every other v2 package here is `internal/<domain>/v2`, so if you would rather this lived somewhere else, say the word and I will move it.

## The `Load()` shape, and why it reads viper when called

`AssignFunc` records that `config/v2` ran; the values themselves are read inside `Load()`. That is not the obvious shape, and it exists because mapper populates viper in two phases.

mapper calls `configv2.Load()` and then `config.NewConfig("mapper")`. The two loaders resolve the config file from different env vars, `CONFIG_FILE` for the former and `CONFIGFILE` for the latter, and `configv2.Load()` swallows a missing file. So on a deployment that supplies its config through `CONFIGFILE` alone, a value captured at assign time is empty, `Load()` returns the zero `Config` with a nil error, and the zero `Config` is a valid stock layout. Mapper then resolves stock paths and its post-mapping inbox cleanup misses every file, logging at `Errorf` and continuing. The helm chart sets both env vars so chart deployments were never exposed, and CI never sets a project code, which is why the eager version passed everything locally.

Reading at call time restores the old semantics for mapper and changes nothing for ingest and api, which are `config/v2`-only. There is a unit guard for it, and `Load()` still refuses to run before `configv2.Load()`, though that guard proves only that the flags are bound.

## The api fix

Second commit, and it stands on its own. `deleteFile` and `downloadFile` were wired to `ResolveInboxPath` in v3.1.73 and #2482 put `UnanonymizeFilepath` back while replacing gin with net/http. Nothing in that PR discusses the inbox layout, so this looks like collateral rather than a decision, but it is in v3.1.75 and v3.1.76 today.

It only bites a deployment that runs `api` with a project code configured, which as far as I can tell is nobody right now. When it does bite, `downloadFile` returns a 500. `deleteFile` is worse on s3: `DeleteObject` on a missing key succeeds, so the handler leaves its retry loop, marks the file `disabled` and answers 200 while the encrypted file stays in the inbox. posix at least fails loudly. The `downloadFile` error log also named the unresolved path rather than the one the reader was given, which is now fixed.

Heads up that #2523 rewrites the same `downloadFile` line and keeps `UnanonymizeFilepath`, so whichever order these land in, that one needs a look. #2544 touches `config.LoadInboxProjectConfig` and `helper.InboxProjectConfig`, both of which this PR removes.

## Tests

New tests cover `Load()` end to end from a nested `storage.inbox` block, the values-arrive-late case above, the registration seam, and the project-code path through ingest's catch-all branch, which is the shape a non-s3inbox deployment actually takes. Both api handlers get stock and project-code rows in one table. Each of these was checked by breaking the code and confirming the test fails, and each uses a username containing `@` so the two layouts differ by the username itself and not only by a prefix. The five `cmd/ingest` expectations that computed their own expected value by calling `ResolveInboxPath` are now literals, since the old form passed even when the function returned nonsense.

Two gaps I have not closed. The `Load()` to struct-field wiring can be deleted in any of the three services without a unit test noticing, which wants integration coverage that does not exist for this feature yet. And mapper's resolve call has no unit test at all, because `handleMessage` drives package globals and a concrete `*broker.AMQPBroker`; that seems better left to #2544 than fought here.

`go build ./...`, `go vet ./...` and `golangci-lint` are clean, and the affected packages pass under `-race`.
