### PR TITLE
docs(adr): ADR-0007 use Conventional Commits for commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,39 @@
+#!/bin/sh
+# commit-msg hook: enforce Conventional Commits, see docs/decisions/0007-use-conventional-commits.md
+#
+# Enable once per clone:   git config core.hooksPath .githooks
+# CI runs this same script on the stored subject of every commit in a pull request.
+
+msg_file="$1"
+types='build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test'
+
+# A merge in progress keeps git's generated message.
+if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+  exit 0
+fi
+
+# Subject is the first line after git's own cleanup: comments (core.commentChar) and blank lines removed.
+subject=$(git stripspace --strip-comments < "$msg_file" | head -n 1 | tr -d '\r')
+
+# Messages git generates for reverts, and autosquash markers, are exempt.
+case "$subject" in
+  'Revert "'* | 'Reapply "'* | "fixup! "* | "squash! "* | "amend! "*) exit 0 ;;
+esac
+
+if printf '%s\n' "$subject" | grep -Eq "^(${types})(\([A-Za-z0-9_,./ -]+\))?!?: [^[:space:]]"; then
+  exit 0
+fi
+
+cat >&2 <<MSG
+Commit message does not follow Conventional Commits:
+
+    ${subject}
+
+Expected:  <type>[optional scope][!]: <description>
+Types:     ${types}
+Examples:  feat(api): add dataset release endpoint
+           fix(s3inbox)!: reject uploads without a checksum
+
+See docs/decisions/0007-use-conventional-commits.md and CONTRIBUTING.md.
+MSG
+exit 1

--- a/.github/workflows/pr_conventional_commits.yml
+++ b/.github/workflows/pr_conventional_commits.yml
@@ -1,0 +1,48 @@
+name: Conventional commits
+
+on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  commit-messages:
+    name: Check commit messages
+    # merge_group has no branch filter; release_v1 has its own queue and keeps its "[release_v1]" prefix.
+    if: github.event_name != 'merge_group' || github.event.merge_group.base_ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check every commit in the pull request
+        env:
+          BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || format('origin/{0}', github.event.pull_request.base.ref) }}
+          HEAD: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+        run: |
+          range="$(git merge-base "$BASE" "$HEAD")..$HEAD"
+          failed=0
+          for sha in $(git rev-list --no-merges --reverse "$range"); do
+            # Stored subject only, with CR/LF removed so it cannot forge a workflow command.
+            subject=$(git log -1 --format=%s "$sha" | tr -d '\r\n')
+            printf '%s\n' "$subject" > "$RUNNER_TEMP/commit-msg"
+            case "$subject" in
+              "fixup! "* | "squash! "* | "amend! "*)
+                echo "::error::${sha:0:8} must be squashed before merge: $subject"
+                failed=1
+                continue
+                ;;
+            esac
+            if ! sh .githooks/commit-msg "$RUNNER_TEMP/commit-msg"; then
+              echo "::error::${sha:0:8} does not follow Conventional Commits: $subject"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,19 +54,58 @@ Each commit should contain changes that are functionally connected and/or relate
 > NOTE:
 > The commands `git add -p` or `git commit -p` can prove useful for selecting chunks of changed files in order to group unrelated things into multiple separate commits.
 
+#### Commit message format
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), see [ADR-0007](docs/decisions/0007-use-conventional-commits.md):
+
+```text
+<type>[optional scope][!]: <description>
+
+<optional body>
+
+<optional footer(s)>
+```
+
+- `type` is one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+- `scope` is optional and names the part of the repository you touch, e.g. `api`, `s3inbox`, `sda-download`, `chart`, `deps`.
+- `!` before the colon marks a breaking change. A `BREAKING CHANGE:` footer can describe it in more detail.
+- `description` is a short summary in the imperative mood ("add", not "added"), with no trailing period.
+
+Examples:
+
+```text
+feat(api): add dataset release endpoint
+fix(s3inbox): honour writer_disabled when selecting writers
+docs(chart)!: 4.0.0 migration guide
+build(deps): bump golang.org/x/crypto
+```
+
+Merge commits and the `Revert "..."` and `Reapply "..."` messages git generates are exempt.
+
+Pull requests are rebase-merged, so every commit message in a PR is preserved on `main`. Reword commits such as `fix review comments` or `Apply suggestions from code review` before the PR is merged, for example with `git rebase -i main`. When you commit a suggestion in the GitHub web UI you can edit the commit message in the dialog before confirming.
+
+#### Checking the format
+
+Enable the repository's `commit-msg` hook once per clone, and `git commit` and `git merge` check the message before the commit is created:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+The same check runs in CI on every commit of a pull request against `main`, including commits created by rebase, cherry-pick or revert, which the hook does not see. A failing check lists the offending commits; reword them and force-push the branch.
+
 #### Helpful commit messages
 
 The commit messages may be seen as meta-comments on the code that are incredibly helpful for anyone who wants to know how this piece of software is working, including colleagues (current and future) and external users.
 
 Some tips about writing helpful commit messages:
 
- 1. Separate subject (the first line of the message) from body with a  blank line.
- 2. Limit the subject line to 50 characters.
- 3. Capitalize the subject line.
- 4. Do not end the subject line with a period.
- 5. Use the imperative mood in the subject line.
- 6. Wrap the body at 72 characters.
- 7. Use the body to explain what and why vs. how.
+ 1. Separate subject (the first line of the message) from body with a blank line.
+ 2. Keep the subject line short, 72 characters is a good limit.
+ 3. Do not end the subject line with a period.
+ 4. Use the imperative mood in the subject line.
+ 5. Wrap the body at 72 characters.
+ 6. Use the body to explain what and why vs. how.
 
 For an in-depth explanation of the above points, please see [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,15 +8,15 @@ We thank you in advance 👍 🎉 for taking the time to contribute, whether wit
 
 - If you're unable to find an issue addressing the problem, open a new one by using the following [template to report a bug]. Be sure to include:
 
-    - a *clear* description,
-    - as much relevant information as possible, and
-    - a *code sample* or an (executable) *test case* demonstrating the expected behaviour that is not occurring.
+  - a *clear* description,
+  - as much relevant information as possible, and
+  - a *code sample* or an (executable) *test case* demonstrating the expected behaviour that is not occurring.
 
 - If possible, prefix the issue title with a short identifier for the relevant repository component, e.g. **[ingest]**, **[postgres]** etc.
 
 ## How to work on a new feature/bug
 
-- Create an issue on Github or you can alternatively pick one already created.
+- Create an issue on Github or you can alternatively pick one of the already [open Issues].
 
 - Assign yourself to that issue.
 
@@ -36,12 +36,11 @@ All work takes place in feature branches. Give your branch a short descriptive n
 
 Use comments in your code, choose variable and function names that clearly show what you intend to implement.
 
-Once the feature is done you can request it to be merged back into `main` by making a Pull Request.
+Once the feature is done you can request it to be merged back into `main` by making a Pull Request using the [template to open a new Pull Request].
 
 Before making the pull request, it is a good idea to rebase your branch onto `main` to ensure that eventual conflicts with the `main` branch are solved before the PR is reviewed and that there can be a clean merge.
 > NOTE:
 > In older github repositories the default branch might be called `master` instead of `main`.
-
 
 ### About git and commit messages
 
@@ -109,7 +108,6 @@ Some tips about writing helpful commit messages:
 
 For an in-depth explanation of the above points, please see [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
 
-
 ### How we do code reviews
 
 A code review is initiated when someone has made a Pull Request in the appropriate repo on github.
@@ -133,7 +131,6 @@ Once at least 3 reviews from 3 different partners are positive, the Pull Request
 
 If it takes long for some partner to review code, it is common practice to try to contact them on slack to see what the problem is and if it can be resolved quickly or whether it's ok to merge.
 
-
 ----
 
 Thanks again,
@@ -141,5 +138,5 @@ Thanks again,
 
 [searching under Issues]: https://github.com/neicnordic/sensitive-data-archive/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3Abug
 [template to report a bug]: https://github.com/neicnordic/sensitive-data-archive/issues/new?assignees=&labels=bug&projects=&template=BUG_REPORT.md
-[open Issues]: https://github.com/neicnordic/neic-sda/issues
-[template to open a new Pull Request]: https://github.com/neicnordic/neic-sda/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+[open Issues]: https://github.com/neicnordic/sensitive-data-archive/issues
+[template to open a new Pull Request]: https://github.com/neicnordic/sensitive-data-archive/blob/main/.github/PULL_REQUEST_TEMPLATE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,11 @@ To avoid unnecessary work duplication and waste of time and effort, it's general
 
 ## How we work with Git
 
-All work takes place in feature branches. Give your branch a short descriptive name and prefix the name with the most suitable of:
+All work takes place in feature branches. Give your branch a short descriptive name and prefix it with the [Conventional Commits type](#commit-message-format) that best describes the change, for example:
 
-- `feature/`
+- `feat/`
+- `fix/`
 - `docs/`
-- `bugfix/`
 - `test/`
 - `refactor/`
 

--- a/docs/decisions/0007-use-conventional-commits.md
+++ b/docs/decisions/0007-use-conventional-commits.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+date: "2026-09-02"
+decision-makers:
+  - "@neicnordic/sensitive-data-development-collaboration"
+---
+
+# Use Conventional Commits for commit messages
+
+## Context and Problem Statement
+
+Pull requests are rebase-merged, so every commit message in a PR is preserved individually on `main`, and the commit log is the primary record of what changed and why.
+Most commits already use a `type(scope): description` prefix, but nothing enforces it: over the last thousand commits on `main` about one in nine does not, with subjects like `review: addressing comments` or `Apply suggestions from code review`.
+Which commit message format should the project require, and how should it be enforced without adding a new toolchain?
+
+## Decision Drivers
+
+* A `git log` on `main` that is readable and searchable by type and component.
+* The same check locally and in CI, with no new toolchain in a Go/Java/Python repository.
+* Room for later automation such as changelog generation and semantic version hints from `feat`, `fix` and `!`.
+
+## Considered Options
+
+* Conventional Commits on every commit, enforced by a `commit-msg` hook and a CI check.
+* Conventional Commits on pull request titles only.
+* Keep the current free-form guidance in `CONTRIBUTING.md`.
+
+## Decision Outcome
+
+Chosen option: "Conventional Commits on every commit", because rebase merging discards the PR title, and unenforced guidance has already produced the inconsistent history described above.
+
+* Every commit subject follows `<type>[optional scope][!]: <description>` as defined by [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+* `type` is one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+* `scope` is optional and names the component touched, for example `api`, `s3inbox`, `sda-download`, `chart` or `deps`. `!` marks a breaking change.
+* Merge commits and the `Revert "..."` and `Reapply "..."` messages git generates are exempt. `fixup!`, `squash!` and `amend!` commits may exist locally but must be squashed before a PR is merged.
+* Body and footer conventions in `CONTRIBUTING.md` are unchanged.
+
+### Consequences
+
+* Good, because the history on `main` becomes uniform and machine-readable.
+* Good, because one dependency-free shell script is the single source of truth for both the hook and CI.
+* Bad, because contributors must reword rejected commits, including ones created by the GitHub web UI, before a PR can merge.
+* Bad, because the hook is opt-in per clone; CI is the safety net.
+
+### Confirmation
+
+* `.githooks/commit-msg` rejects non-conforming messages from `git commit` and `git merge` once enabled with `git config core.hooksPath .githooks`. Commits replayed by rebase, cherry-pick or revert are only covered by CI.
+* `.github/workflows/pr_conventional_commits.yml` runs the same script on the stored subject of every non-merge commit of a pull request targeting `main`, and fails on `fixup!`, `squash!` and `amend!` commits.
+* Reviewers still check that type, scope and description match the change.
+
+## Pros and Cons of the Options
+
+### Conventional Commits on every commit
+
+* Good, because it matches how the repository is merged and how most commits are already written.
+* Bad, because it adds a CI failure that contributors will hit until they enable the hook.
+
+### Conventional Commits on pull request titles only
+
+* Good, because it is one check per PR and never requires rewriting history.
+* Bad, because with rebase merges the PR title never reaches `main`, so the history does not improve.
+* Neutral, because it becomes the right choice if the project switches to squash merges.
+
+### Keep the current free-form guidance
+
+* Good, because nothing changes for contributors.
+* Bad, because the existing guidance (50-character, capitalised subjects) is already ignored in practice, and there is nothing for tooling to build on.
+
+## More Information
+
+The team agreed on this before it was written down; this record (2026-09-02) documents the decision and adds the enforcement.
+How to write and check commit messages is described in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#commit-message-format).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -113,6 +113,7 @@ superseded-by: "0005-use-new-approach.md"
 | [0003](0003-shared-state-strategy-for-s3inbox-and-caching.md) | Replace s3inbox In-Memory File ID Cache with Database Lookups  | accepted |
 | [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md)  | Introduce RFCs as an upstream exploration phase for ADRs       | accepted |
 | [0006](0006-metrics-and-tracing.md)                           | Metrics and Tracing in the sensitive-data-archive applications | accepted |
+| [0007](0007-use-conventional-commits.md)                      | Use Conventional Commits for commit messages                   | accepted |
 
 Numbers `0001` and `0004` were proposed in PRs
 [#2263](https://github.com/neicnordic/sensitive-data-archive/pull/2263) and


### PR DESCRIPTION
## Related issue(s) and PR(s)

No issue. The team already agreed on this, so this PR writes it down and adds the checks.

## Description

ADR-0007 records that commit messages follow Conventional Commits. It is marked `accepted` since the decision is already taken.

The PR also adds the enforcement:

- `.githooks/commit-msg` checks the subject line locally. Enable it once per clone with `git config core.hooksPath .githooks`.
- A new workflow runs that same script on every non-merge commit of a PR against `main` and fails on `fixup!` and `squash!` commits. We rebase-merge, so the PR title never reaches `main` and each commit has to be right on its own.
- `CONTRIBUTING.md` describes the format and the hook and drops the old "50 characters, capitalised" rules. The last commit fixes a few markdownlint nits in that file and repoints two links that still went to the old neic-sda repo.

Of the last 200 commits on `main`, 5 would fail the check. It stays advisory until an admin adds "Check commit messages" as a required status check in the `main` ruleset. Should we do that right away, or wait until the hook has been in use for a while?

## ADR

- [x] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [x] A decision record has been added or updated in `docs/decisions/`
  - [x] The decision record is listed in the `docs/decisions/README.md` index table

## How to test

The "Conventional commits" workflow runs on this PR. Locally:

```sh
git config core.hooksPath .githooks
git commit --allow-empty -m "fix review comments"   # rejected
git commit --allow-empty -m "docs: try the hook"    # accepted
```
