### PR TITLE
Add RabbitMQ configuration to disable queue creation at start up

### DIFF
--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -249,6 +249,8 @@ spec:
       {{- if .Values.global.doa.outbox.enabled }}
         - name: OUTBOX_QUEUE
           value: {{ .Values.global.doa.outbox.queue | quote }}
+        - name: OUTBOX_QUEUE_AUTO_CREATE
+          value: "true"
         - name: OUTBOX_TYPE
           value: {{ .Values.global.doa.outbox.type | quote}}
         {{- if eq "s3" .Values.global.doa.outbox.type }}

--- a/charts/sda-svc/templates/doa-deploy.yaml
+++ b/charts/sda-svc/templates/doa-deploy.yaml
@@ -250,7 +250,7 @@ spec:
         - name: OUTBOX_QUEUE
           value: {{ .Values.global.doa.outbox.queue | quote }}
         - name: OUTBOX_QUEUE_AUTO_CREATE
-          value: "true"
+          value: {{ .Values.global.doa.outbox.autoCreateQueue | quote }}
         - name: OUTBOX_TYPE
           value: {{ .Values.global.doa.outbox.type | quote}}
         {{- if eq "s3" .Values.global.doa.outbox.type }}

--- a/charts/sda-svc/values.yaml
+++ b/charts/sda-svc/values.yaml
@@ -272,6 +272,7 @@ global:
       s3Bucket: ""
       s3AccessKey: null
       s3SecretKey: null
+      autoCreateQueue: true
     servicePort: 443
     envFile: env
 

--- a/sda-doa/README.md
+++ b/sda-doa/README.md
@@ -22,7 +22,7 @@ Environment variables used:
 | OUTBOX_ENABLED                         | true                                                                 | Enables/disables the outbox functionality          |
 | OUTBOX_TYPE                            | POSIX                                                                | Outbox type: `POSIX` or `S3`                       |
 | OUTBOX_QUEUE                           | exportRequests                                                       | MQ queue name for files/datasets export requests   |
-| OUTBOX_QUEUE_AUTO_CREATE               | true                                                                 | Automatically create the queue; when false, the queue must be provisioned externally |
+| OUTBOX_QUEUE_AUTO_CREATE               | true                                                                 | Automatically create an exclusive and non-durable queue; when false, the queue must be provisioned externally |
 | OUTBOX_LOCATION                        | /ega/outbox/p11-%s/files/                                            | Outbox location with placeholder for the username  |
 | BROKER_HOST                            | private-mq                                                           | Local RabbitMQ broker hostname                     |
 | BROKER_PORT                            | 5671                                                                 | Local RabbitMQ broker port                         |

--- a/sda-doa/README.md
+++ b/sda-doa/README.md
@@ -22,6 +22,7 @@ Environment variables used:
 | OUTBOX_ENABLED                         | true                                                                 | Enables/disables the outbox functionality          |
 | OUTBOX_TYPE                            | POSIX                                                                | Outbox type: `POSIX` or `S3`                       |
 | OUTBOX_QUEUE                           | exportRequests                                                       | MQ queue name for files/datasets export requests   |
+| OUTBOX_QUEUE_AUTO_CREATE               | true                                                                 | Automatically create the queue; when false, the queue must be provisioned externally |
 | OUTBOX_LOCATION                        | /ega/outbox/p11-%s/files/                                            | Outbox location with placeholder for the username  |
 | BROKER_HOST                            | private-mq                                                           | Local RabbitMQ broker hostname                     |
 | BROKER_PORT                            | 5671                                                                 | Local RabbitMQ broker port                         |

--- a/sda-doa/src/main/java/no/uio/ifi/localega/doa/mq/ExportRequestsListener.java
+++ b/sda-doa/src/main/java/no/uio/ifi/localega/doa/mq/ExportRequestsListener.java
@@ -17,7 +17,6 @@ import no.uio.ifi.localega.doa.services.MetadataService;
 import no.uio.ifi.localega.doa.services.StreamingService;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.amqp.rabbit.annotation.Queue;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -64,9 +63,7 @@ public class ExportRequestsListener {
     @Value("${s3.bucket}")
     private String s3Bucket;
 
-    @RabbitListener(
-            queuesToDeclare = @Queue(name = "${outbox.queue}", durable = "false", exclusive = "true", autoDelete = "true")
-    )
+    @RabbitListener(queues = "${outbox.queue}")
     public void listen(String message) {
         try {
             jsonSchemaValidationService.validate(message);

--- a/sda-doa/src/main/java/no/uio/ifi/localega/doa/mq/RabbitMQConfiguration.java
+++ b/sda-doa/src/main/java/no/uio/ifi/localega/doa/mq/RabbitMQConfiguration.java
@@ -13,6 +13,9 @@ public class RabbitMQConfiguration {
     @Bean
     @ConditionalOnProperty(name = "outbox.queue-auto-create", havingValue = "true", matchIfMissing = true)
     public Queue exportQueue(@Value("${outbox.queue}") String queueName) {
-        return new Queue(queueName, false, true, true);
+        boolean durable = false;
+        boolean exclusive = true;
+        boolean autoDelete = true;
+        return new Queue(queueName,durable, exclusive, autoDelete);
     }
 }

--- a/sda-doa/src/main/java/no/uio/ifi/localega/doa/mq/RabbitMQConfiguration.java
+++ b/sda-doa/src/main/java/no/uio/ifi/localega/doa/mq/RabbitMQConfiguration.java
@@ -1,0 +1,18 @@
+package no.uio.ifi.localega.doa.mq;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "outbox.enabled", havingValue = "true")
+public class RabbitMQConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(name = "outbox.queue-auto-create", havingValue = "true", matchIfMissing = true)
+    public Queue exportQueue(@Value("${outbox.queue}") String queueName) {
+        return new Queue(queueName, false, true, true);
+    }
+}

--- a/sda-doa/src/main/resources/application.yml
+++ b/sda-doa/src/main/resources/application.yml
@@ -31,6 +31,7 @@ outbox:
   enabled: ${OUTBOX_ENABLED:true}
   type: ${OUTBOX_TYPE:POSIX}
   queue: ${OUTBOX_QUEUE:exportRequests}
+  queue-auto-create: ${OUTBOX_QUEUE_AUTO_CREATE:true}
   location: ${OUTBOX_LOCATION:/ega/outbox/p11-%s/files/}
 
 spring:

--- a/sda-doa/src/test/java/no/uio/ifi/localega/doa/mq/RabbitMQConfigurationTest.java
+++ b/sda-doa/src/test/java/no/uio/ifi/localega/doa/mq/RabbitMQConfigurationTest.java
@@ -1,0 +1,51 @@
+package no.uio.ifi.localega.doa.mq;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Queue;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RabbitMQConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(RabbitMQConfiguration.class);
+
+    @Test
+    void createsQueueWithExistingDefaultsWhenAutoCreationIsNotConfigured() {
+        contextRunner
+                .withPropertyValues(
+                        "outbox.enabled=true",
+                        "outbox.queue=custom-export-requests"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(Queue.class);
+                    Queue queue = context.getBean(Queue.class);
+                    assertThat(queue.getName()).isEqualTo("custom-export-requests");
+                    assertThat(queue.isDurable()).isFalse();
+                    assertThat(queue.isExclusive()).isTrue();
+                    assertThat(queue.isAutoDelete()).isTrue();
+                });
+    }
+
+    @Test
+    void doesNotCreateQueueWhenAutoCreationIsDisabled() {
+        contextRunner
+                .withPropertyValues(
+                        "outbox.enabled=true",
+                        "outbox.queue=custom-export-requests",
+                        "outbox.queue-auto-create=false"
+                )
+                .run(context -> assertThat(context).doesNotHaveBean(Queue.class));
+    }
+
+    @Test
+    void doesNotCreateQueueWhenOutboxIsDisabled() {
+        contextRunner
+                .withPropertyValues(
+                        "outbox.enabled=false",
+                        "outbox.queue=custom-export-requests"
+                )
+                .run(context -> assertThat(context).doesNotHaveBean(Queue.class));
+    }
+}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes [ #2564].


## Description
Make the RabbitMQ configurable via environment vars including the option to disable queue creation at startup

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

## How to test
