### PR TITLE
Refactor/intercept broker v2

### DIFF
--- a/.github/integration/rabbitmq-federation.yml
+++ b/.github/integration/rabbitmq-federation.yml
@@ -28,7 +28,10 @@ services:
   certfixer:
     command:
       - /bin/sh
-      - /scripts/make_certs.sh
+      - -c
+      - |
+        /scripts/make_certs.sh &&
+        chmod 644 /client_certs/client.key
     container_name: certfixer
     image: alpine:latest
     volumes:
@@ -71,17 +74,16 @@ services:
       - BROKER_USER=guest
       - BROKER_PASSWORD=guest
       - BROKER_VHOST=sda
-      - BROKER_QUEUE=from_cega
-      - BROKER_VERIFYPEER=false
+      - SOURCE_QUEUE=from_cega
       - BROKER_SSL=true
-      - BROKER_CLIENTCERT=/certs/client.crt
-      - BROKER_CLIENTKEY=/certs/client.key
-      - BROKER_CACERT=/certs/ca.crt
+      - BROKER_CLIENT_CERT=/certs/client.crt
+      - BROKER_CLIENT_KEY=/certs/client.key
+      - BROKER_CA_CERT=/certs/ca.crt
       - LOG_LEVEL=debug
     image: ghcr.io/neicnordic/sensitive-data-archive:PR${PR_NUMBER}
     restart: always
     volumes:
-      - certs:/certs
+      - client_certs:/certs
 
   rabbitmq:
     build:

--- a/charts/sda-svc/CHANGELOG.md
+++ b/charts/sda-svc/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Populate broker_v2 config for mapper
 - Populate broker_v2 config for verify
+- Populate broker_v2 config for intercept
 
 ## [4.0.0] - 2026-08-26
 

--- a/charts/sda-svc/templates/intercept-secrets.yaml
+++ b/charts/sda-svc/templates/intercept-secrets.yaml
@@ -9,28 +9,22 @@ metadata:
 type: Opaque
 stringData:
   config.yaml: |-
+    source_queue: "from_cega"
     broker:
     {{- if .Values.global.tls.enabled }}
-      caCert: {{ template "tlsPath" . }}/ca.crt
+      ca_cert: {{ template "tlsPath" . }}/ca.crt
       {{- if .Values.global.broker.verifyPeer }}
-      clientCert: {{ template "tlsPath" . }}/tls.crt
-      clientKey: {{ template "tlsPath" . }}/tls.key
+      client_cert: {{ template "tlsPath" . }}/tls.crt
+      client_key: {{ template "tlsPath" . }}/tls.key
       {{- end }}
     {{- end }}
       exchange: {{ default "sda" .Values.global.broker.exchange }}
       host: {{ required "A valid MQ host is required" .Values.global.broker.host }}
       port: {{ default (ternary 5671 5672 .Values.global.tls.enabled) .Values.global.broker.port }}
-      prefetchCount: {{ default 1 .Values.global.broker.prefetchCount }}
+      prefetch_count: {{ default 1 .Values.global.broker.prefetchCount }}
       password: {{ required "MQ password is required" (include "mqPassInterceptor" .) }}
-      queue: "from_cega"
-    {{- if ne "" ( default "" .Values.global.broker.serverName ) }}
-      serverName: {{.Values.global.broker.serverName }}
-    {{- end }}
       ssl: {{ .Values.global.tls.enabled }}
       user: {{ required "MQ user is required" (include "mqUserInterceptor" .) }}
-    {{- if .Values.global.tls.enabled }}
-      verifyPeer: {{ .Values.global.broker.verifyPeer }}
-    {{- end }}
       vhost: {{ include "brokerVhost" . }}
     log:
       format: {{ .Values.global.log.format }}

--- a/sda/CHANGELOG.md
+++ b/sda/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - verify:
   - Update to use broker/v2 instead of broker (v1)
   - Add unit tests
+- intercept:
+  - Update to use broker/v2 instead of broker (v1)
+  - Refactor and add unit tests
+  - Add configuration options for destination routing keys
 
 ### Fixed
 

--- a/sda/cmd/intercept/config/config.go
+++ b/sda/cmd/intercept/config/config.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"github.com/neicnordic/sensitive-data-archive/internal/config/v2"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+var (
+	sourceQueue         string
+	accessionRoutingKey string
+	cancelRoutingKey    string
+	ingestRoutingKey    string
+	mappingRoutingKey   string
+	releaseRoutingKey   string
+	deprecateRoutingKey string
+)
+
+func init() {
+	config.RegisterFlags(
+		&config.Flag{
+			Name: "source_queue",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "from_cega", "The queue where the verify service consumes messages from")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				sourceQueue = viper.GetString(flagName)
+			},
+		},
+		&config.Flag{
+			Name: "accession_routing_key",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "accession", "The routing key the intercept service forwards \"accession\" type messages to")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				accessionRoutingKey = viper.GetString(flagName)
+			},
+		},
+		&config.Flag{
+			Name: "ingest_routing_key",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "ingest", "The routing key the intercept service forwards \"ingest\" type messages to")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				ingestRoutingKey = viper.GetString(flagName)
+			},
+		},
+		&config.Flag{
+			Name: "cancel_routing_key",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "ingest", "The routing key the intercept service forwards \"cancel\" type messages to")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				cancelRoutingKey = viper.GetString(flagName)
+			},
+		},
+		&config.Flag{
+			Name: "mapping_routing_key",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "mappings", "The routing key the intercept service forwards \"mapping\" type messages to")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				mappingRoutingKey = viper.GetString(flagName)
+			},
+		},
+		&config.Flag{
+			Name: "release_routing_key",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "mappings", "The routing key the intercept service forwards \"release\" type messages to")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				releaseRoutingKey = viper.GetString(flagName)
+			},
+		},
+		&config.Flag{
+			Name: "deprecate_routing_key",
+			RegisterFunc: func(flagSet *pflag.FlagSet, flagName string) {
+				flagSet.String(flagName, "mappings", "The routing key the intercept service forwards \"deprecate\" type messages to")
+			},
+			Required: false,
+			AssignFunc: func(flagName string) {
+				deprecateRoutingKey = viper.GetString(flagName)
+			},
+		},
+	)
+}
+
+func SourceQueue() string {
+	return sourceQueue
+}
+func AccessionRoutingKey() string {
+	return accessionRoutingKey
+}
+func CancelRoutingKey() string {
+	return cancelRoutingKey
+}
+func IngestRoutingKey() string {
+	return ingestRoutingKey
+}
+func MappingRoutingKey() string {
+	return mappingRoutingKey
+}
+func ReleaseRoutingKey() string {
+	return releaseRoutingKey
+}
+func DeprecateRoutingKey() string {
+	return deprecateRoutingKey
+}

--- a/sda/cmd/intercept/intercept.go
+++ b/sda/cmd/intercept/intercept.go
@@ -3,109 +3,147 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
 
-	"github.com/neicnordic/sensitive-data-archive/internal/broker"
-	"github.com/neicnordic/sensitive-data-archive/internal/config"
+	interceptconfig "github.com/neicnordic/sensitive-data-archive/cmd/intercept/config"
+	broker "github.com/neicnordic/sensitive-data-archive/internal/broker/v2"
+	"github.com/neicnordic/sensitive-data-archive/internal/broker/v2/rabbitmq"
+	configv2 "github.com/neicnordic/sensitive-data-archive/internal/config/v2"
 
 	log "github.com/sirupsen/logrus"
 )
 
+type messageType string
+
 const (
-	msgAccession string = "accession"
-	msgCancel    string = "cancel"
-	msgIngest    string = "ingest"
-	msgMapping   string = "mapping"
-	msgRelease   string = "release"
-	msgDeprecate string = "deprecate"
+	messageTypeAccession messageType = "accession"
+	messageTypeCancel    messageType = "cancel"
+	messageTypeIngest    messageType = "ingest"
+	messageTypeMapping   messageType = "mapping"
+	messageTypeRelease   messageType = "release"
+	messageTypeDeprecate messageType = "deprecate"
 )
 
+type intercept struct {
+	broker  broker.Broker
+	routing map[messageType]string
+}
+
 func main() {
-	forever := make(chan bool)
-	conf, err := config.NewConfig("intercept")
-	if err != nil {
+	if err := run(); err != nil {
 		log.Fatal(err)
 	}
-	mq, err := broker.NewMQ(conf.Broker)
-	if err != nil {
-		log.Fatal(err)
+}
+
+func run() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := configv2.Load(); err != nil {
+		return fmt.Errorf("failed to load config: %v", err)
 	}
 
-	defer mq.Channel.Close()
-	defer mq.Connection.Close()
+	app := &intercept{
+		routing: map[messageType]string{
+			messageTypeAccession: interceptconfig.AccessionRoutingKey(),
+			messageTypeCancel:    interceptconfig.CancelRoutingKey(),
+			messageTypeIngest:    interceptconfig.IngestRoutingKey(),
+			messageTypeMapping:   interceptconfig.MappingRoutingKey(),
+			messageTypeRelease:   interceptconfig.ReleaseRoutingKey(),
+			messageTypeDeprecate: interceptconfig.DeprecateRoutingKey(),
+		},
+	}
 
-	go func() {
-		connError := mq.ConnectionWatcher()
-		log.Error(connError)
-		forever <- false
-	}()
+	var err error
+	app.broker, err = rabbitmq.NewRabbitMQBroker(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create new rabbit mq broker: %w", err)
+	}
 
-	go func() {
-		connError := mq.ChannelWatcher()
-		log.Error(connError)
-		forever <- false
-	}()
-
-	log.Info("Starting intercept service")
-
-	go func() {
-		messages, err := mq.GetMessages(conf.Broker.Queue)
-		if err != nil {
-			log.Fatal(err)
+	defer func() {
+		if app.broker == nil {
+			return
 		}
-		for delivered := range messages {
-			log.Debugf("Received a message: %s", delivered.Body)
-
-			msgType, err := typeFromMessage(delivered.Body)
-			if err != nil {
-				log.Errorf("Failed to get type for message (%v), reason: %v", msgType, err.Error())
-				if err := delivered.Ack(false); err != nil {
-					log.Errorf("Failed acking canceled work, reason: (%v)", err)
-				}
-				// Restart on new message
-				continue
-			}
-
-			routing := map[string]string{
-				msgAccession: "accession",
-				msgCancel:    "ingest",
-				msgIngest:    "ingest",
-				msgMapping:   "mappings",
-				msgRelease:   "mappings",
-				msgDeprecate: "mappings",
-			}
-
-			routingKey := routing[msgType]
-
-			if routingKey == "" {
-				log.Debugf("msg type: %s", msgType)
-				if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, "undeliverable", delivered.Body); err != nil {
-					log.Errorf("failed to publish message, reason: (%v)", err)
-				}
-				if err := delivered.Ack(false); err != nil {
-					log.Errorf("failed to ack message for reason: %v", err)
-				}
-
-				continue
-			}
-
-			log.Infof("Routing message (correlation-id: %s, routingkey: %s)", delivered.CorrelationId, routingKey)
-			if err := mq.SendMessage(delivered.CorrelationId, conf.Broker.Exchange, routingKey, delivered.Body); err != nil {
-				log.Errorf("failed to publish message, reason: (%v)", err)
-			}
-			if err := delivered.Ack(false); err != nil {
-				log.Errorf("failed to ack message for reason: %v", err)
-			}
+		if err := app.broker.Close(); err != nil {
+			slog.Error("could not close broker", "error", err)
 		}
 	}()
 
-	<-forever
+	consumeErr := make(chan error, 1)
+	go func() {
+		consumeErr <- app.broker.Subscribe(ctx, interceptconfig.SourceQueue(), app.handleMessage)
+	}()
+
+	slog.Info("intercept service started")
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	select {
+	case sig := <-sigc:
+		slog.Info("received signal, shutting down gracefully", "signal", sig)
+
+		return nil
+	case err := <-consumeErr:
+		if !errors.Is(err, context.Canceled) {
+			slog.Error("consumer failure", "error", err, "source-queue", interceptconfig.SourceQueue())
+
+			return err
+		}
+
+		return nil
+	}
+}
+
+func (app *intercept) handleMessage(ctx context.Context, message *broker.Message) ([]func(), error) {
+	msgType, err := typeFromMessage(message.Body)
+	if err != nil {
+		slog.Error("Failed to get type from message",
+			slog.String("message-key", message.Key),
+			slog.Any("error", err),
+		)
+		// Restart on new message
+		return nil, nil
+	}
+
+	routingKey := app.routing[msgType]
+
+	if routingKey == "" {
+		slog.Warn("unknown routing key for message type, routing to undeliverable",
+			slog.String("message-key", message.Key),
+			slog.String("message-type", string(msgType)),
+		)
+
+		routingKey = "undeliverable"
+	}
+
+	slog.Info(
+		"Routing message",
+		slog.String("message-key", message.Key),
+		slog.String("message-type", string(msgType)),
+		slog.String("routing-key", routingKey),
+	)
+	if err := app.broker.Publish(ctx, routingKey, *message); err != nil {
+		slog.Error("failed to publish message",
+			slog.Any("error", err),
+		)
+
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 // typeFromMessage returns the type value given a JSON structure for the message
 // supplied in body
-func typeFromMessage(body []byte) (string, error) {
+func typeFromMessage(body []byte) (messageType, error) {
 	message := make(map[string]any)
 	err := json.Unmarshal(body, &message)
 	if err != nil {
@@ -113,7 +151,7 @@ func typeFromMessage(body []byte) (string, error) {
 	}
 
 	msgTypeFetch, ok := message["type"]
-	if !ok {
+	if !ok || msgTypeFetch == "" {
 		return "", errors.New("malformed message, type is missing")
 	}
 
@@ -122,5 +160,5 @@ func typeFromMessage(body []byte) (string, error) {
 		return "", errors.New("could not cast type attribute to string")
 	}
 
-	return msgType, nil
+	return messageType(msgType), nil
 }

--- a/sda/cmd/intercept/intercept_test.go
+++ b/sda/cmd/intercept/intercept_test.go
@@ -1,127 +1,237 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
-	"github.com/spf13/viper"
+	broker "github.com/neicnordic/sensitive-data-archive/internal/broker/v2"
+	"github.com/neicnordic/sensitive-data-archive/internal/schema"
+	"github.com/neicnordic/sensitive-data-archive/mocks"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/mock"
 )
 
-type TestSuite struct {
-	suite.Suite
-}
+func TestHandleMessage(t *testing.T) {
+	type testCase struct {
+		name          string
+		message       any
+		routing       map[messageType]string
+		newMock       func(testCase) *mocks.MockBroker
+		expectedError error
+	}
 
-func TestConfigTestSuite(t *testing.T) {
-	suite.Run(t, new(TestSuite))
-}
+	for _, tc := range []testCase{
+		{
+			name: "accession",
+			message: &schema.IngestionAccession{
+				Type:               "accession",
+				User:               "123",
+				FilePath:           "321",
+				AccessionID:        "",
+				DecryptedChecksums: nil,
+			},
+			newMock: func(tc testCase) *mocks.MockBroker {
+				mb := &mocks.MockBroker{}
 
-func (ts *TestSuite) SetupTest() {
-	viper.Set("log.level", "debug")
-}
+				expectedMsgBody, _ := json.Marshal(tc.message)
 
-type accession struct {
-	Type               string      `json:"type"`
-	User               string      `json:"user"`
-	FilePath           string      `json:"filepath"`
-	AccessionID        string      `json:"accession_id"`
-	DecryptedChecksums []Checksums `json:"decrypted_checksums"`
-}
+				mb.On("Publish", "accession_rk", mock.MatchedBy(func(msg broker.Message) bool {
+					return bytes.Equal(msg.Body, expectedMsgBody) && msg.Key == "accession_test_case"
+				})).Return(nil).Once()
 
-type Checksums struct {
-	Type  string `json:"type"`
-	Value string `json:"value"`
-}
+				return mb
+			},
+			routing: map[messageType]string{
+				"accession": "accession_rk",
+			},
+			expectedError: nil,
+		}, {
+			name: "ingestion",
+			message: &schema.IngestionTrigger{
+				Type:     "ingest",
+				User:     "123",
+				FilePath: "321",
+			},
+			newMock: func(tc testCase) *mocks.MockBroker {
+				mb := &mocks.MockBroker{}
 
-type ingest struct {
-	Type     string `json:"type"`
-	User     string `json:"user"`
-	FilePath string `json:"filepath"`
-}
+				expectedMsgBody, _ := json.Marshal(tc.message)
 
-type mapping struct {
-	Type        string   `json:"type"`
-	DatasetID   string   `json:"dataset_id"`
-	AcessionIDs []string `json:"accession_ids"`
-}
+				mb.On("Publish", "ingest_rk", mock.MatchedBy(func(msg broker.Message) bool {
+					return bytes.Equal(msg.Body, expectedMsgBody) && msg.Key == "ingestion_test_case"
+				})).Return(nil).Once()
 
-type missing struct {
-	User     string `json:"user"`
-	FilePath string `json:"filepath"`
-}
+				return mb
+			},
+			routing: map[messageType]string{
+				"ingest": "ingest_rk",
+			},
+			expectedError: nil,
+		}, {
+			name: "cancel",
+			message: &schema.IngestionTrigger{
+				Type:     "cancel",
+				User:     "123",
+				FilePath: "321",
+			},
+			newMock: func(tc testCase) *mocks.MockBroker {
+				mb := &mocks.MockBroker{}
 
-func (ts *TestSuite) TestMessageSelection_Accession() {
-	msg := accession{
-		Type:        "accession",
-		User:        "foo",
-		FilePath:    "/tmp/foo",
-		AccessionID: "EGAF12345678901",
-		DecryptedChecksums: []Checksums{
-			{"md5", "7Ac236b1a8dce2dac89e7cf45d2b48BD"},
+				expectedMsgBody, _ := json.Marshal(tc.message)
+
+				mb.On("Publish", "cancel_rk", mock.MatchedBy(func(msg broker.Message) bool {
+					return bytes.Equal(msg.Body, expectedMsgBody) && msg.Key == "cancel_test_case"
+				})).Return(nil).Once()
+
+				return mb
+			},
+			routing: map[messageType]string{
+				"cancel": "cancel_rk",
+			},
+			expectedError: nil,
+		}, {
+			name: "type_no_rk",
+			message: &schema.IngestionTrigger{
+				Type: "no_rk",
+			},
+			newMock: func(tc testCase) *mocks.MockBroker {
+				mb := &mocks.MockBroker{}
+
+				expectedMsgBody, _ := json.Marshal(tc.message)
+
+				mb.On("Publish", "undeliverable", mock.MatchedBy(func(msg broker.Message) bool {
+					return bytes.Equal(msg.Body, expectedMsgBody) && msg.Key == "type_no_rk_test_case"
+				})).Return(nil).Once()
+
+				return mb
+			},
+			routing: map[messageType]string{
+				"cancel": "cancel_rk",
+			},
+			expectedError: nil,
+		}, {
+			name: "inc_msg_no_type",
+			message: &struct {
+				NoType string `json:"no_type"`
+			}{
+				NoType: "no_type",
+			},
+			newMock: func(tc testCase) *mocks.MockBroker {
+				return &mocks.MockBroker{}
+			},
+			routing:       map[messageType]string{},
+			expectedError: nil,
 		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockBroker := tc.newMock(tc)
+
+			app := intercept{
+				broker:  mockBroker,
+				routing: tc.routing,
+			}
+
+			msgBody, _ := json.Marshal(tc.message)
+			callBacks, err := app.handleMessage(context.Background(), &broker.Message{
+				Key:     tc.name + "_test_case",
+				Headers: nil,
+				Body:    msgBody,
+			})
+			for _, cb := range callBacks {
+				cb()
+			}
+
+			assert.Equal(t, tc.expectedError, err, "error does not match expected")
+			mockBroker.AssertExpectations(t)
+		})
 	}
-	message, _ := json.Marshal(&msg)
-
-	msgType, err := typeFromMessage(message)
-
-	assert.Nil(ts.T(), err, "Unexpected error from typeFromMessage")
-	assert.Equal(ts.T(), msgType, msgAccession, "message type from message does not match expected")
 }
-
-func (ts *TestSuite) TestMessageSelection_Cancel() {
-	msg := ingest{
-		Type:     "cancel",
-		User:     "foo",
-		FilePath: "/tmp/foo",
-	}
-	message, _ := json.Marshal(&msg)
-
-	msgType, err := typeFromMessage(message)
-
-	assert.Nil(ts.T(), err, "Unexpected error from typeFromMessage")
-	assert.Equal(ts.T(), msgType, msgCancel, "message type from message does not match expected")
-}
-
-func (ts *TestSuite) TestMessageSelection_Ingest() {
-	msg := ingest{
-		Type:     "ingest",
-		User:     "foo",
-		FilePath: "/tmp/foo",
-	}
-	message, _ := json.Marshal(&msg)
-
-	msgType, err := typeFromMessage(message)
-
-	assert.Nil(ts.T(), err, "Unexpected error from typeFromMessage")
-	assert.Equal(ts.T(), msgIngest, msgType, "message type from message does not match expected")
-}
-
-func (ts *TestSuite) TestMessageSelection_Mapping() {
-	msg := mapping{
-		Type:      "mapping",
-		DatasetID: "EGAD12345678900",
-		AcessionIDs: []string{
-			"EGAF12345678901",
+func TestTypeFromMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		message             any
+		expectedMessageType messageType
+		expectedError       error
+	}{
+		{
+			name: "accession",
+			message: &schema.IngestionAccession{
+				Type: "accession",
+			},
+			expectedMessageType: messageTypeAccession,
+			expectedError:       nil,
+		}, {
+			name: "cancel",
+			message: &schema.IngestionTrigger{
+				Type: "cancel",
+			},
+			expectedMessageType: messageTypeCancel,
+			expectedError:       nil,
+		}, {
+			name: "ingest",
+			message: &schema.IngestionTrigger{
+				Type: "ingest",
+			},
+			expectedMessageType: messageTypeIngest,
+			expectedError:       nil,
+		}, {
+			name: "mapping",
+			message: &schema.DatasetMapping{
+				Type: "mapping",
+			},
+			expectedMessageType: messageTypeMapping,
+			expectedError:       nil,
+		}, {
+			name: "deprecate",
+			message: &schema.DatasetMapping{
+				Type: "deprecate",
+			},
+			expectedMessageType: messageTypeDeprecate,
+			expectedError:       nil,
+		}, {
+			name: "release",
+			message: &schema.DatasetMapping{
+				Type: "release",
+			},
+			expectedMessageType: messageTypeRelease,
+			expectedError:       nil,
+		}, {
+			name: "no_type",
+			message: &struct {
+				NoType string `json:"no_type"`
+			}{
+				NoType: "other_type",
+			},
+			expectedMessageType: "",
+			expectedError:       errors.New("malformed message, type is missing"),
+		}, {
+			name: "empty_type",
+			message: &struct {
+				Type string `json:"type"`
+			}{},
+			expectedMessageType: "",
+			expectedError:       errors.New("malformed message, type is missing"),
+		}, {
+			name: "wrong_type_type",
+			message: &struct {
+				Type int `json:"type"`
+			}{
+				Type: 1,
+			},
+			expectedMessageType: "",
+			expectedError:       errors.New("could not cast type attribute to string"),
 		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			message, _ := json.Marshal(tc.message)
+
+			msgType, err := typeFromMessage(message)
+
+			assert.Equal(t, tc.expectedError, err, "error does not match expected")
+			assert.Equal(t, tc.expectedMessageType, msgType, "message type from message does not match expected")
+		})
 	}
-	message, _ := json.Marshal(&msg)
-
-	msgType, err := typeFromMessage(message)
-
-	assert.Nil(ts.T(), err, "Unexpected error from typeFromMessage")
-	assert.Equal(ts.T(), msgMapping, msgType, "message type from message does not match expected")
-}
-
-func (ts *TestSuite) TestMessageSelection_Notype() {
-	msg := missing{
-		User:     "foo",
-		FilePath: "/tmp/foo",
-	}
-	message, _ := json.Marshal(&msg)
-
-	msgType, err := typeFromMessage(message)
-
-	assert.Error(ts.T(), err, "Unexpected lack of error from typeFromMessage")
-	assert.Equal(ts.T(), "", msgType, "message type from message does not match expected")
 }


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #2570 


## Description
### sda
- intercept:
  - Update to use broker/v2 instead of broker (v1)
  - Refactor and add unit tests
  - Add configuration options for destination routing keys


### sda-svc
- Populate broker_v2 config for intercept

## How to test
- unit & integration tests pass