### PR TITLE
docs(adr): ADR-0008 use accessionID in code, keep stable_id column

### DIFF
--- a/docs/decisions/0008-use-accessionid-in-application-code.md
+++ b/docs/decisions/0008-use-accessionid-in-application-code.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: "2026-09-07"
+status: accepted
+date: "2026-09-08"
 decision-makers:
   - "@neicnordic/sensitive-data-development-collaboration"
 consulted:

--- a/docs/decisions/0008-use-accessionid-in-application-code.md
+++ b/docs/decisions/0008-use-accessionid-in-application-code.md
@@ -1,0 +1,88 @@
+---
+status: proposed
+date: "2026-09-07"
+decision-makers:
+  - "@neicnordic/sensitive-data-development-collaboration"
+consulted:
+  - "@KarlG-nbis"
+  - "@jbygdell"
+  - "@kjellp"
+  - "@viklund"
+informed: []
+---
+
+# Use `accessionID` in application code and keep `stable_id` as the database column
+
+## Context and Problem Statement
+
+The archive identifier of a file or dataset goes by `stableID`,
+`accessionID` and `stable_id` in different layers of the codebase, and no
+written rule says which name belongs where. [RFC-0001][rfc-0001] explored the
+question and holds the pros and cons, the codebase survey and the discussion
+history, so this record does not repeat them. By September 2026 ordinary
+refactoring had removed every `stableID` identifier from the `sda` module.
+What remained was a handful of identifiers in `sda-download` and `sda-doa`,
+and no written convention. Which name do we commit to, and in which layers?
+
+## Decision Drivers
+
+* One name per layer, written down, so reviews stop relitigating it
+* No database migration for a naming change (cost and risk, @kjellp)
+* Do not pre-empt the v4.0 schema work, where the column may be dropped
+  rather than renamed (@viklund, @jbygdell)
+
+## Considered Options
+
+1. `accessionID` everywhere, including a column rename
+2. `stableID` everywhere
+3. `accessionID` in application code only; the column stays `stable_id`
+4. Leave as-is
+5. Drop `stable_id` and use the `file_references` / `dataset_references`
+   tables
+
+See [RFC-0001][rfc-0001] for the pros and cons of each option.
+
+## Decision Outcome
+
+Chosen option: "`accessionID` in application code only", because the code is
+already there, a column rename would need a coordinated migration at every
+site without changing any behaviour, and whether the column is renamed or
+dropped is a v4.0 question.
+
+| Layer | Name |
+| --- | --- |
+| Go and Java application code | `accessionID` / `accessionId` |
+| API responses and messages | `accessionID` (unchanged) |
+| Database columns, views, functions and SQL strings | `stable_id` (unchanged) |
+
+Option 5 is deferred rather than rejected. We reopen it as a new RFC together
+with the removal of the `local_ega` legacy schema. The open questions in
+RFC-0001 about migration strategy and an entity-qualified naming rule move to
+that RFC.
+
+### Consequences
+
+* Good, because the rule is easy to apply: `accessionID` in code, `stable_id`
+  in SQL
+* Good, because there is no migration, and so no maintenance window or
+  dual-name transition period
+* Neutral, because the surrounding type or table still has to say whether an
+  `accessionID` belongs to a file or a dataset. This record adds no naming
+  rule for that.
+* Bad, because the name still changes between code and SQL, so a conversation
+  about the column still needs the word "column"
+
+### Confirmation
+
+* `grep -rn --include='*.go' -e stableID -e StableID .` returns nothing once
+  the follow-up code PR has landed
+* In `sda-doa`, the entity field is `accessionId` while the
+  `@Column(name = "stable_id")` mapping is unchanged
+
+## More Information
+
+The team decided this at the NeIC SDA-Devs meet-up on 2026-09-07. RFC-0001
+is `promoted` with this file in its `promoted-to`. The RFC body is frozen, so
+any revision of this decision goes in this file.
+
+[rfc-0001]: ../rfcs/0001-standardize-on-accessionid.md

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -114,7 +114,7 @@ superseded-by: "0005-use-new-approach.md"
 | [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md)  | Introduce RFCs as an upstream exploration phase for ADRs       | accepted |
 | [0006](0006-metrics-and-tracing.md)                           | Metrics and Tracing in the sensitive-data-archive applications | accepted |
 | [0007](0007-use-conventional-commits.md)                      | Use Conventional Commits for commit messages                   | accepted |
-| [0008](0008-use-accessionid-in-application-code.md)           | Use `accessionID` in code, keep `stable_id` in the database    | proposed |
+| [0008](0008-use-accessionid-in-application-code.md)           | Use `accessionID` in code, keep `stable_id` in the database    | accepted |
 
 Numbers `0001` and `0004` were proposed in PRs
 [#2263](https://github.com/neicnordic/sensitive-data-archive/pull/2263) and

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -114,6 +114,7 @@ superseded-by: "0005-use-new-approach.md"
 | [0005](0005-introduce-rfcs-as-upstream-exploration-phase.md)  | Introduce RFCs as an upstream exploration phase for ADRs       | accepted |
 | [0006](0006-metrics-and-tracing.md)                           | Metrics and Tracing in the sensitive-data-archive applications | accepted |
 | [0007](0007-use-conventional-commits.md)                      | Use Conventional Commits for commit messages                   | accepted |
+| [0008](0008-use-accessionid-in-application-code.md)           | Use `accessionID` in code, keep `stable_id` in the database    | proposed |
 
 Numbers `0001` and `0004` were proposed in PRs
 [#2263](https://github.com/neicnordic/sensitive-data-archive/pull/2263) and

--- a/docs/rfcs/0001-standardize-on-accessionid.md
+++ b/docs/rfcs/0001-standardize-on-accessionid.md
@@ -1,5 +1,7 @@
 ---
-status: ready-for-decision
+status: promoted
+promoted-to:
+  - "0008-use-accessionid-in-application-code.md"
 date: "2026-09-07"
 discussion: "https://github.com/neicnordic/sensitive-data-archive/pull/2263"
 authors:

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -150,4 +150,4 @@ a `proposed` ADR; it is a separate artifact with its own lifecycle.
 
 | # | RFC | Status | Promoted to |
 | --- | --- | --- | --- |
-| [0001](0001-standardize-on-accessionid.md) | Standardize on `accessionID` everywhere? | ready-for-decision | — |
+| [0001](0001-standardize-on-accessionid.md) | Standardize on `accessionID` everywhere? | promoted | [ADR-0008](../decisions/0008-use-accessionid-in-application-code.md) |


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR promotes RFC-0001 (#2263, merged 2026-09-07). The code changes come in a separate PR.

## Description

ADR-0008 records what we agreed at the NeIC SDA-Devs meet-up on 2026-09-07: `accessionID` in application code, `stable_id` stays as the database column. Option 5 from the RFC (drop the column in favour of `file_references` / `dataset_references`) is deferred to the v4.0 schema work and comes back as its own RFC together with the `local_ega` removal. Writing that down should stop it from resurfacing in reviews.

I kept the ADR short. It links to RFC-0001 for the pros and cons, the codebase survey and the discussion history instead of repeating them.

Following the promotion procedure in `docs/rfcs/README.md`, the PR also flips RFC-0001 to `promoted`, sets `promoted-to` and updates both index tables. I did not touch the RFC body.

The number is 0008 because 0007 is taken by #2562. The status is `proposed`. Since the decision is already taken, I will flip it to `accepted` in a final commit before merge, the same way as ADR-0005 and ADR-0006.

The follow-up code PR renames the remaining `StableID` identifiers in `sda-download` and the entity field in `sda-doa`, and keeps the `@Column(name = "stable_id")` mapping. That is what the Confirmation section checks.

Did I capture today's decision correctly, in particular that option 5 is deferred rather than rejected?

## ADR

- [x] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [x] A decision record has been added or updated in `docs/decisions/`
  - [x] The decision record is listed in the `docs/decisions/README.md` index table

## How to test

The "Decision records and RFCs" workflow runs markdownlint on both folders. Locally:

```sh
markdownlint-cli2 docs/decisions/*.md docs/rfcs/*.md
```
