### PR TITLE
fix(integration test): update bullseye -> trixie

### DIFF
--- a/.github/integration/sda-posix-integration.yml
+++ b/.github/integration/sda-posix-integration.yml
@@ -193,7 +193,7 @@ services:
       - PGSSLKEY=/certs/client.key
       - PGSSLMODE=verify-ca
       - STORAGETYPE=posix
-    image: python:3.11-slim-bullseye
+    image: python:3.13-slim-trixie
     profiles:
       - tests
     volumes:

--- a/.github/integration/sda-sync-integration.yml
+++ b/.github/integration/sda-sync-integration.yml
@@ -363,7 +363,7 @@ services:
       - PGPASSWORD=rootpasswd
       - STORAGETYPE=s3
       - SYNCTEST=true
-    image: python:3.11-slim-bullseye
+    image: python:3.13-slim-trixie
     profiles:
       - tests
     volumes:


### PR DESCRIPTION
## Description
fix(integration test): update python:3.11-slim-bullseye -> python:3.13-slim-trixie, as debian 11(bullseye) LTS ended on 2026-08-31, and other similar tests already using python:3.13-slim-trixie

## How to test
- integration tests pass