### PR TITLE
fix(integration test): wait on DB state and ack counter in rotatekey test

### DIFF
--- a/.github/integration/tests/sda/70_rotate_key_test.sh
+++ b/.github/integration/tests/sda/70_rotate_key_test.sh
@@ -126,30 +126,29 @@ rotatekey_body=$(
         '$ARGS.named'
 )
 
+# error events for the file and acknowledged messages on the archived queue before the
+# rotation, used to detect that verify has processed the re-verify message without error
+errorEvents=$(psql -U postgres -h postgres -d sda -At -c "select count(*) from sda.file_event_log where file_id='$fileID' and event='error';")
+archivedAcks=$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/archived/ | jq -r '.message_stats.ack // 0')
+
 curl -s -u guest:guest "http://rabbitmq:15672/api/exchanges/sda/sda/publish" \
     -H 'Content-Type: application/json;charset=UTF-8' \
     -d "$rotatekey_body" | jq
 
-# check that rotate key doesn't fail
+# check that rotate key doesn't fail, the key hash in sda.files is only updated once
+# rotatekey has re-encrypted the header, so poll the database instead of the queue depth
 echo "waiting for rotatekey to complete"
+rotatekeyHash=$(psql -U postgres -h postgres -d sda -At -c "select key_hash from sda.encryption_keys where description='this is the rotatekey key';")
 RETRY_TIMES=0
-until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/rotatekey/ | jq -r '.messages_ready')" -eq 0 ]; do
+until [ "$(psql -U postgres -h postgres -d sda -At -c "select key_hash from sda.files where id='$fileID';")" = "$rotatekeyHash" ]; do
     echo "waiting for rotatekey to complete"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
-        echo "::error::Time out while waiting for rotatekey to complete"
+        echo "::error::Time out while waiting for the key hash of the file to be updated"
         exit 1
     fi
     sleep 2
 done
-
-# check DB for updated key hash in sda.files
-rotatekeyHash=$(psql -U postgres -h postgres -d sda -At -c "select key_hash from sda.encryption_keys where description='this is the rotatekey key';")
-if [ "$(psql -U postgres -h postgres -d sda -At -c "select key_hash from sda.files where id='$fileID';" | grep -c "$rotatekeyHash")" -ne 1 ];
-then
-	echo "failed to update the key hash of files"
-	exit 1
-fi
 
 echo "verifying header backup in sda.file_headers_backup"
 backupCount=$(psql -U postgres -h postgres -d sda -At -c "SELECT count(*) FROM sda.file_headers_backup WHERE file_id='$fileID';")
@@ -158,18 +157,27 @@ if [ "$backupCount" -lt 1 ]; then
     exit 1
 fi
 
-# check that files were re-verified
+# check that the file was re-verified, verify writes nothing to the database when a
+# re-verification succeeds and acks the message only once it is done, so wait for the ack
+# counter of the archived queue to grow (it is monotonic, unlike the queue depth which
+# reads 0 both before the message arrives and after it is consumed) and then require that
+# verify has not logged an error event for the file
 echo "waiting for re-verify to complete"
 RETRY_TIMES=0
-until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/archived/ | jq -r '.messages_ready')" -eq 0 ]; do
+until [ "$(curl -su guest:guest http://rabbitmq:15672/api/queues/sda/archived/ | jq -r '.message_stats.ack // 0')" -gt "$archivedAcks" ]; do
     echo "waiting for re-verify to complete"
     RETRY_TIMES=$((RETRY_TIMES + 1))
     if [ "$RETRY_TIMES" -eq 30 ]; then
-        echo "::error::Time out while waiting for verify to complete"
+        echo "::error::Time out while waiting for the re-verification of the file to complete"
         exit 1
     fi
     sleep 2
 done
+
+if [ "$(psql -U postgres -h postgres -d sda -At -c "select count(*) from sda.file_event_log where file_id='$fileID' and event='error';")" -ne "$errorEvents" ]; then
+    echo "::error::verify logged an error event for file $fileID during re-verification"
+    exit 1
+fi
 
 # check that no other erros occured
 sleep 5


### PR DESCRIPTION
## Related issue(s) and PR(s)
No issue. The failure showed up in the `sda s3` integration job on #2575 and on a Dependabot run on main (https://github.com/neicnordic/sensitive-data-archive/actions/runs/34125515487), so it is not caused by any open PR.

## Description
`70_rotate_key_test.sh` waited for the `rotatekey` and `archived` queues to reach `messages_ready == 0` and then asserted on the database. `messages_ready` drops to 0 as soon as the consumer takes the message, while rotatekey only writes the new key hash to `sda.files` after it has backed up and re-encrypted the header. On a slow runner the assertion ran before that write and the test failed with "failed to update the key hash of files".

Changes, all in that one script:

* Wait for rotatekey by polling `sda.files.key_hash` for the file until it equals the rotation key's hash. This replaces both the queue-depth wait and the separate assertion.
* Wait for re-verify by polling the `archived` queue's `message_stats.ack` counter until it grows past the value captured before the rotation message was published. Verify writes nothing to the database when a re-verification succeeds and acks only when it is done, and the counter is monotonic, so a stale management API read cannot end the wait early the way `messages_ready` could.
* After that wait, assert that verify logged no new `error` event for the file in `sda.file_event_log`. Verify records a re-verify checksum mismatch there and not on the error queue, so the existing `error_stream` check never saw it.

Not changed: `65_api_admin_rotate_key_test.sh` and `60_api_admin_test.sh` wait on `messages_ready` in the same way. I left them out to keep this PR to the test that is failing. Happy to do them as a follow-up if you agree with the approach here.

## ADR

- [ ] This PR includes an architecturally significant decision (see `docs/decisions/README.md`)
  - [ ] A decision record has been added or updated in `docs/decisions/`
  - [ ] The decision record is listed in the `docs/decisions/README.md` index table

No new decision.

## How to test
The `sda s3` and `sda sync` integration jobs run this script, but the PR workflow's paths filter does not include `.github/integration/**`, so it does not run on this PR. #2578 adds those paths. Until then the test runs on any PR that touches code, for example #2575 once it has this fix from main. Locally:

```
bash -n .github/integration/tests/sda/70_rotate_key_test.sh
shellcheck .github/integration/tests/sda/70_rotate_key_test.sh
```
